### PR TITLE
[REVERT] Revert delete wikiprovider

### DIFF
--- a/edgechain-app/src/main/java/com/edgechain/lib/wiki/provider/WikiProvider.java
+++ b/edgechain-app/src/main/java/com/edgechain/lib/wiki/provider/WikiProvider.java
@@ -1,0 +1,15 @@
+package com.edgechain.lib.wiki.provider;
+
+import com.edgechain.lib.rxjava.provider.ChainProvider;
+import com.edgechain.lib.rxjava.request.ChainRequest;
+import com.edgechain.lib.rxjava.response.ChainResponse;
+import com.edgechain.lib.rxjava.transformer.observable.EdgeChain;
+import com.edgechain.lib.wiki.service.WikiService;
+
+public class WikiProvider extends ChainProvider {
+
+    @Override
+    public EdgeChain<ChainResponse> request(ChainRequest request) {
+        return new WikiService().getPageContent(request.getInput());
+    }
+}


### PR DESCRIPTION
The concerned file: `edgechain-app/src/main/java/com/edgechain/lib/wiki/provider/WikiProvider.java` was deleted by mistake in the last commit (ie., commit #86 ). 

This PR undoes the deletion 