### PR TITLE
[ATTENTION] tests for Postgres client with potential issues

### DIFF
--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/client/impl/PostgresClient.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/client/impl/PostgresClient.java
@@ -205,7 +205,7 @@ public class PostgresClient {
                         postgresEndpoint.getWordEmbedding().getValues(),
                         postgresEndpoint.getTopK());
 
-                for (Map row : rows) {
+                for (Map<String, Object> row : rows) {
 
                   PostgresWordEmbeddings val = new PostgresWordEmbeddings();
                   val.setId(row.get("id").toString());

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/client/impl/PostgresClient.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/client/impl/PostgresClient.java
@@ -288,7 +288,7 @@ public class PostgresClient {
                       }
                     }
                   } catch (Exception e) {
-                    logger.error("failed meta query", e);
+                    logger.warn("ignored query error", e);
                   }
                 }
 

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/repositories/PostgresClientMetadataRepository.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/repositories/PostgresClientMetadataRepository.java
@@ -38,6 +38,7 @@ public class PostgresClientMetadataRepository {
             metadataTable));
   }
 
+  @Transactional
   public List<String> batchInsertMetadata(String metadataTableName, List<String> metadataList) {
     List<String> uuidList = new ArrayList<>();
 

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/repositories/PostgresClientRepository.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/index/repositories/PostgresClientRepository.java
@@ -77,6 +77,7 @@ public class PostgresClientRepository {
     }
   }
 
+  @Transactional
   public List<String> batchUpsertEmbeddings(
       String tableName,
       List<WordEmbeddings> wordEmbeddingsList,
@@ -186,6 +187,7 @@ public class PostgresClientRepository {
     }
   }
 
+  @Transactional(readOnly = true)
   public List<Map<String, Object>> getAllChunks(PostgresEndpoint endpoint) {
     return jdbcTemplate.queryForList(
         String.format(

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/context/client/impl/PostgreSQLHistoryContextClientTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/context/client/impl/PostgreSQLHistoryContextClientTest.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Testcontainers(disabledWithoutDocker = true)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@DirtiesContext
 class PostgreSQLHistoryContextClientTest {
 
   private static final Logger LOGGER =
@@ -41,7 +43,7 @@ class PostgreSQLHistoryContextClientTest {
   @Autowired private PostgreSQLHistoryContextClient service;
 
   @Test
-  void cycle() {
+  void allMethods() {
     // hikari has own copy of properties so set these here
     hikariConfig.setJdbcUrl(instance.getJdbcUrl());
     hikariConfig.setUsername(instance.getUsername());

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/context/client/impl/PostgreSQLHistoryContextClientTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/context/client/impl/PostgreSQLHistoryContextClientTest.java
@@ -2,6 +2,8 @@ package com.edgechain.lib.context.client.impl;
 
 import com.edgechain.lib.context.domain.HistoryContext;
 import com.edgechain.lib.rxjava.transformer.observable.EdgeChain;
+import com.edgechain.testutil.PostgresTestContainer;
+import com.edgechain.testutil.PostgresTestContainer.DB;
 import com.zaxxer.hikari.HikariConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,9 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,9 +25,7 @@ class PostgreSQLHistoryContextClientTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PostgreSQLHistoryContextClientTest.class);
 
-  private static PostgresTestContainer instance = new PostgresTestContainer();
-
-  @Autowired private HikariConfig hikariConfig;
+  private static PostgresTestContainer instance = new PostgresTestContainer(DB.PLAIN);
 
   @BeforeAll
   static void baseSetupAll() {
@@ -40,18 +37,7 @@ class PostgreSQLHistoryContextClientTest {
     instance.stop();
   }
 
-  @DynamicPropertySource
-  static void baseSetProps(DynamicPropertyRegistry reg) {
-    String testUrl = instance.getJdbcUrl();
-
-    LOGGER.info("TEST with Docker PostgreSQL url={}", testUrl);
-
-    // inject typical settings based on Docker instance
-    reg.add("spring.datasource.url", () -> testUrl);
-    reg.add("spring.datasource.username", () -> instance.getUsername());
-    reg.add("spring.datasource.password", () -> instance.getPassword());
-  }
-
+  @Autowired private HikariConfig hikariConfig;
   @Autowired private PostgreSQLHistoryContextClient service;
 
   @Test
@@ -101,25 +87,4 @@ class PostgreSQLHistoryContextClientTest {
     public String val;
   }
 
-  public static class PostgresTestContainer extends PostgreSQLContainer<PostgresTestContainer> {
-
-    private static final String DOCKER_IMAGE =
-        PostgreSQLContainer.IMAGE + ":" + PostgreSQLContainer.DEFAULT_TAG;
-
-    public PostgresTestContainer() {
-      super(DOCKER_IMAGE);
-    }
-
-    @Override
-    public void start() {
-      LOGGER.info("starting container");
-      super.start();
-    }
-
-    @Override
-    public void stop() {
-      LOGGER.info("stopping container");
-      super.stop();
-    }
-  }
 }

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/context/client/impl/PostgreSQLHistoryContextClientTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/context/client/impl/PostgreSQLHistoryContextClientTest.java
@@ -3,7 +3,7 @@ package com.edgechain.lib.context.client.impl;
 import com.edgechain.lib.context.domain.HistoryContext;
 import com.edgechain.lib.rxjava.transformer.observable.EdgeChain;
 import com.edgechain.testutil.PostgresTestContainer;
-import com.edgechain.testutil.PostgresTestContainer.DB;
+import com.edgechain.testutil.PostgresTestContainer.PostgresImage;
 import com.zaxxer.hikari.HikariConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,7 +27,7 @@ class PostgreSQLHistoryContextClientTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PostgreSQLHistoryContextClientTest.class);
 
-  private static PostgresTestContainer instance = new PostgresTestContainer(DB.PLAIN);
+  private static PostgresTestContainer instance = new PostgresTestContainer(PostgresImage.PLAIN);
 
   @BeforeAll
   static void baseSetupAll() {

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
@@ -7,7 +7,7 @@ import com.edgechain.lib.index.enums.PostgresDistanceMetric;
 import com.edgechain.lib.response.StringResponse;
 import com.edgechain.lib.rxjava.transformer.observable.EdgeChain;
 import com.edgechain.testutil.PostgresTestContainer;
-import com.edgechain.testutil.PostgresTestContainer.DB;
+import com.edgechain.testutil.PostgresTestContainer.PostgresImage;
 import com.zaxxer.hikari.HikariConfig;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,7 +36,7 @@ class PostgresClientTest {
 
   private static final float FLOAT_ERROR_MARGIN = 0.0001f;
 
-  private static PostgresTestContainer instance = new PostgresTestContainer(DB.VECTOR);
+  private static PostgresTestContainer instance = new PostgresTestContainer(PostgresImage.VECTOR);
 
   @BeforeAll
   static void setupAll() {

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 @Testcontainers(disabledWithoutDocker = true)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@DirtiesContext
 class PostgresClientTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PostgresClientTest.class);
@@ -53,16 +55,13 @@ class PostgresClientTest {
   @Autowired
   private PostgresClient service;
 
-  @BeforeEach
-  void setupEach() {
+  @Test
+  void allMethods() {
     // hikari has own copy of properties so set these here
     hikariConfig.setJdbcUrl(instance.getJdbcUrl());
     hikariConfig.setUsername(instance.getUsername());
     hikariConfig.setPassword(instance.getPassword());
-  }
 
-  @Test
-  void allMethods() {
     createTable();
     createMetadataTable();
     deleteAll(); // check delete before we get foreign keys

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
@@ -1,0 +1,321 @@
+package com.edgechain.lib.index.client.impl;
+
+import com.edgechain.lib.embeddings.WordEmbeddings;
+import com.edgechain.lib.endpoint.impl.PostgresEndpoint;
+import com.edgechain.lib.index.domain.PostgresWordEmbeddings;
+import com.edgechain.lib.index.enums.PostgresDistanceMetric;
+import com.edgechain.lib.response.StringResponse;
+import com.edgechain.lib.rxjava.transformer.observable.EdgeChain;
+import com.edgechain.testutil.PostgresTestContainer;
+import com.edgechain.testutil.PostgresTestContainer.DB;
+import com.zaxxer.hikari.HikariConfig;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class PostgresClientTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PostgresClientTest.class);
+
+  private static PostgresTestContainer instance = new PostgresTestContainer(DB.VECTOR);
+
+  @BeforeAll
+  static void setupAll() {
+    instance.start();
+  }
+
+  @AfterAll
+  static void teardownAll() {
+    instance.stop();
+  }
+
+  @Autowired
+  private HikariConfig hikariConfig;
+
+  @Autowired
+  private PostgresClient service;
+
+  @BeforeEach
+  void setupEach() {
+    // hikari has own copy of properties so set these here
+    hikariConfig.setJdbcUrl(instance.getJdbcUrl());
+    hikariConfig.setUsername(instance.getUsername());
+    hikariConfig.setPassword(instance.getPassword());
+  }
+
+  @Test
+  void test() {
+    createTable();
+    createMetadataTable();
+    deleteAll(); // check delete before we get foreign keys
+
+    String uuid1 = upsert();
+    batchUpsert();
+    query_noMeta();
+
+    String uuid2 = insertMetadata();
+    batchInsertMetadata();
+    insertIntoJoinTable(uuid1, uuid2);
+    query_meta();
+    
+    getChunks();
+    getSimilarChunks();
+  }
+
+  private void createTable() {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getLists()).thenReturn(1);
+    when(mockPe.getDimensions()).thenReturn(2);
+
+    final Data data = new Data();
+    EdgeChain<StringResponse> result = service.createTable(mockPe);
+    result.toSingle().blockingSubscribe(s -> data.val = s.getResponse(), e -> data.error = e);
+    if (data.error != null) {
+      fail("createTable failed", data.error);
+    }
+    LOGGER.info("createTable response: '{}'", data.val);
+  }
+
+  private void createMetadataTable() {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getMetadataTableNames()).thenReturn(List.of("dogmeta", "catmeta"));
+
+    final Data data = new Data();
+    EdgeChain<StringResponse> result = service.createMetadataTable(mockPe);
+    result.toSingle().blockingSubscribe(s -> data.val = s.getResponse(), e -> data.error = e);
+    if (data.error != null) {
+      fail("createMetadataTable failed", data.error);
+    }
+    LOGGER.info("createMetadataTable response: '{}'", data.val);
+  }
+
+  private String upsert() {
+    WordEmbeddings we = new WordEmbeddings();
+    we.setId("WE1");
+    we.setScore("101");
+    we.setValues(List.of(0.25f, 0.5f));
+
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getWordEmbedding()).thenReturn(we);
+    when(mockPe.getFilename()).thenReturn("readme.pdf");
+    when(mockPe.getNamespace()).thenReturn("testns");
+
+    final Data data = new Data();
+    EdgeChain<StringResponse> result = service.upsert(mockPe);
+    result.toSingle().blockingSubscribe(s -> data.val = s.getResponse(), e -> data.error = e);
+    if (data.error != null) {
+      fail("upsert failed", data.error);
+    }
+    LOGGER.info("upsert response: '{}'", data.val);
+    return data.val;
+  }
+
+  private String insertMetadata() {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getMetadataTableNames()).thenReturn(List.of("dogmeta", "catmeta"));
+    when(mockPe.getMetadata()).thenReturn("''duck''");
+    when(mockPe.getDocumentDate()).thenReturn("November 11, 2015");
+
+    final Data data = new Data();
+    EdgeChain<StringResponse> result = service.insertMetadata(mockPe);
+    result.toSingle().blockingSubscribe(s -> data.val = s.getResponse(), e -> data.error = e);
+    if (data.error != null) {
+      fail("insertMetadata failed", data.error);
+    }
+    LOGGER.info("insertMetadata response: '{}'", data.val);
+    return data.val;
+  }
+
+  private void batchUpsert() {
+    WordEmbeddings we1 = new WordEmbeddings();
+    we1.setId("WE1");
+    we1.setScore("101");
+    we1.setValues(List.of(0.25f, 0.5f));
+
+    WordEmbeddings we2 = new WordEmbeddings();
+    we2.setId("WE2");
+    we2.setScore("202");
+    we2.setValues(List.of(0.75f, 0.9f));
+
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getWordEmbeddingsList()).thenReturn(List.of(we1, we2));
+    when(mockPe.getFilename()).thenReturn("readme.pdf");
+    when(mockPe.getNamespace()).thenReturn("testns");
+
+    final Data data = new Data();
+    EdgeChain<List<StringResponse>> result = service.batchUpsert(mockPe);
+    result.toSingle().blockingSubscribe(
+        s -> data.val = s.stream().map(r -> r.getResponse()).collect(Collectors.joining(",")),
+        e -> data.error = e);
+    if (data.error != null) {
+      fail("batchUpsert failed", data.error);
+    }
+    LOGGER.info("batchUpsert response: '{}'", data.val);
+  }
+
+  private void batchInsertMetadata() {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getMetadataTableNames()).thenReturn(List.of("dogmeta", "catmeta"));
+    when(mockPe.getMetadataList()).thenReturn(List.of("cow", "horse"));
+
+    final Data data = new Data();
+    EdgeChain<List<StringResponse>> result = service.batchInsertMetadata(mockPe);
+    result.toSingle().blockingSubscribe(
+        s -> data.val = s.stream().map(r -> r.getResponse()).collect(Collectors.joining(",")),
+        e -> data.error = e);
+    if (data.error != null) {
+      fail("batchInsertMetadata failed", data.error);
+    }
+    LOGGER.info("batchInsertMetadata response: '{}'", data.val);
+  }
+
+  private void insertIntoJoinTable(String uuid1, String uuid2) {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getMetadataTableNames()).thenReturn(List.of("dogmeta", "catmeta"));
+    when(mockPe.getId()).thenReturn(uuid1);
+    when(mockPe.getMetadataId()).thenReturn(uuid2);
+
+    final Data data = new Data();
+
+    EdgeChain<StringResponse> result = service.insertIntoJoinTable(mockPe);
+    result.toSingle().blockingSubscribe(s -> data.val = s.getResponse(), e -> data.error = e);
+    if (data.error != null) {
+      fail("insertIntoJoinTable failed", data.error);
+    }
+    LOGGER.info("insertIntoJoinTable response: '{}'", data.val);
+  }
+
+  private void deleteAll() {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getNamespace()).thenReturn("testns");
+
+    final Data data = new Data();
+    EdgeChain<StringResponse> result = service.deleteAll(mockPe);
+    result.toSingle().blockingSubscribe(s -> data.val = s.getResponse(), e -> data.error = e);
+    if (data.error != null) {
+      fail("deleteAll failed", data.error);
+    }
+    LOGGER.info("deleteAll response: '{}'", data.val);
+  }
+
+  private void query_noMeta() {
+    WordEmbeddings we1 = new WordEmbeddings();
+    we1.setId("WEQUERY");
+    we1.setScore("104");
+    we1.setValues(List.of(0.25f, 0.5f));
+
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getNamespace()).thenReturn("testns");
+    when(mockPe.getProbes()).thenReturn(5);
+    when(mockPe.getMetric()).thenReturn(PostgresDistanceMetric.IP);
+    when(mockPe.getWordEmbedding()).thenReturn(we1);
+    when(mockPe.getTopK()).thenReturn(1000);
+    when(mockPe.getMetadataTableNames()).thenReturn(null);
+
+    final Data data = new Data();
+    EdgeChain<List<PostgresWordEmbeddings>> result = service.query(mockPe);
+    result.toSingle().blockingSubscribe(
+        s -> data.val = s.stream().map(r -> r.getRawText()).collect(Collectors.joining(",")),
+        e -> data.error = e);
+    if (data.error != null) {
+      fail("query (no meta) failed", data.error);
+    }
+    LOGGER.info("query (no meta) response: '{}'", data.val);
+
+    // WE1 from single upsert, and WE2 from batch upsert
+    assertTrue(data.val.contains("WE1") && data.val.contains("WE2"));
+  }
+  
+  private void query_meta() {
+    WordEmbeddings we1 = new WordEmbeddings();
+    we1.setId("WEQUERY");
+    we1.setScore("104");
+    we1.setValues(List.of(0.25f, 0.5f));
+
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getNamespace()).thenReturn("testns");
+    when(mockPe.getProbes()).thenReturn(5);
+    when(mockPe.getMetric()).thenReturn(PostgresDistanceMetric.IP);
+    when(mockPe.getWordEmbedding()).thenReturn(we1);
+    when(mockPe.getTopK()).thenReturn(1000);
+    when(mockPe.getMetadataTableNames()).thenReturn(List.of("dogmeta", "catmeta"));
+
+    final Data data = new Data();
+    EdgeChain<List<PostgresWordEmbeddings>> result = service.query(mockPe);
+    result.toSingle().blockingSubscribe(
+        s -> data.val = s.stream().map(r -> r.getRawText()).collect(Collectors.joining(",")),
+        e -> data.error = e);
+    if (data.error != null) {
+      fail("query (meta) failed", data.error);
+    }
+    LOGGER.info("query (meta) response: '{}'", data.val);
+
+    // WE1 from single joined upsert
+    assertTrue(data.val.contains("WE1"));
+  }  
+
+  private void getChunks() {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getTableName()).thenReturn("testtable");
+    when(mockPe.getFilename()).thenReturn("readme.pdf");
+
+    final Data data = new Data();
+    EdgeChain<List<PostgresWordEmbeddings>> result = service.getAllChunks(mockPe);
+    result.toSingle().blockingSubscribe(
+        s -> data.val = s.stream().map(r -> r.getRawText()).collect(Collectors.joining(",")),
+        e -> data.error = e);
+    if (data.error != null) {
+      fail("getChunks failed", data.error);
+    }
+    LOGGER.info("getChunks response: '{}'", data.val);
+
+    // WE1 from single upsert, and WE2 from batch upsert
+    assertTrue(data.val.contains("WE1") && data.val.contains("WE2"));
+  }
+
+  private void getSimilarChunks() {
+    PostgresEndpoint mockPe = mock(PostgresEndpoint.class);
+    when(mockPe.getMetadataTableNames()).thenReturn(List.of("dogmeta", "catmeta"));
+    when(mockPe.getEmbeddingChunk()).thenReturn("WE");
+
+    final Data data = new Data();
+    EdgeChain<List<PostgresWordEmbeddings>> result = service.getSimilarMetadataChunk(mockPe);
+    result.toSingle().blockingSubscribe(
+        s -> data.val = s.stream().map(r -> r.getMetadataId()).collect(Collectors.joining(",")),
+        e -> data.error = e);
+    if (data.error != null) {
+      fail("getSimilarMetadataChunk failed", data.error);
+    }
+    LOGGER.info("getSimilarMetadataChunk response: '{}'", data.val);
+  }
+  
+  
+  private static class Data {
+    public Throwable error;
+    public String val;
+  }
+
+}

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/index/client/impl/PostgresClientTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -295,7 +294,7 @@ class PostgresClientTest {
     when(mockPe.getMetadataTableNames()).thenReturn(List.of("dogmeta", "catmeta"));
 
     final Data data = new Data();
-    EdgeChain<List<PostgresWordEmbeddings>> result = service.query(mockPe);
+    EdgeChain<List<PostgresWordEmbeddings>> result = service.queryWithMetadata(mockPe);
     result.toSingle().blockingSubscribe(
         s -> data.val = s.stream().map(r -> r.getRawText()).collect(Collectors.joining(",")),
         e -> data.error = e);

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/testutil/PostgresTestContainer.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/testutil/PostgresTestContainer.java
@@ -1,0 +1,40 @@
+package com.edgechain.testutil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class PostgresTestContainer extends PostgreSQLContainer<PostgresTestContainer> {
+  
+  public enum DB {
+    PLAIN,
+    VECTOR
+  };
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(PostgresTestContainer.class);
+  
+//  private static final String DOCKER_IMAGE = PostgreSQLContainer.IMAGE + ":" + PostgreSQLContainer.DEFAULT_TAG;
+  
+  private static final DockerImageName IMAGE = DockerImageName.parse("postgres").withTag("14.5");
+  
+  private static final DockerImageName VECTOR_IMAGE = DockerImageName.parse("ankane/pgvector").asCompatibleSubstituteFor("postgres");
+
+  public PostgresTestContainer(DB db) {
+    super(db == DB.VECTOR ? VECTOR_IMAGE : IMAGE);
+  }
+
+  @Override
+  public void start() {
+    LOGGER.info("starting container");
+    super.start();
+    LOGGER.info("TEST with Docker PostgreSQL url={}", getJdbcUrl());
+  }
+
+  @Override
+  public void stop() {
+    LOGGER.info("stopping container");
+    super.stop();
+  }
+}

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/testutil/PostgresTestContainer.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/testutil/PostgresTestContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class PostgresTestContainer extends PostgreSQLContainer<PostgresTestContainer> {
   
-  public enum DB {
+  public enum PostgresImage {
     PLAIN,
     VECTOR
   };
@@ -21,8 +21,8 @@ public class PostgresTestContainer extends PostgreSQLContainer<PostgresTestConta
   
   private static final DockerImageName VECTOR_IMAGE = DockerImageName.parse("ankane/pgvector").asCompatibleSubstituteFor("postgres");
 
-  public PostgresTestContainer(DB db) {
-    super(db == DB.VECTOR ? VECTOR_IMAGE : IMAGE);
+  public PostgresTestContainer(PostgresImage img) {
+    super(img == PostgresImage.VECTOR ? VECTOR_IMAGE : IMAGE);
   }
 
   @Override

--- a/FlySpring/edgechain-app/src/test/resources/logback-test.xml
+++ b/FlySpring/edgechain-app/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+    
+    <logger name="com.edgechain" level="debug" />
+</configuration>


### PR DESCRIPTION
## Code Quality and tests

- minor code quality improvement
- use single ObjectMapper instance for performance and read with thread-safe .readerFor(...).
- uses regular PostgreSQL image for some tests or a vector-aware PostgreSQL test container if needed
- some potential issues noted below

### Difference in behaviour with multiple meta tables

Where there are multiple meta tables:
- createMetadataTable: use first only
- insertMetadata: use first only
- batchInsertMetadata: use first only
- getSimilarMetadataChunk: use first only
- **queryWithMetadata**: USES ALL and reports/ignores exception for second and subsequent meta tables

### deleteAll and meta data

Where you add a row to table with no meta join:
- deleteAll will work

Where you add a row to table and then join to meta data:
- deleteAll will fail with a foreign key exception
- meta table join rows are not deleted first

### insertMetadata vs batch...

- insertMetadata sanitises the metadata (removes all ')
- batchInsertMetadata does not sanitise content from the metadata list - might break SQL?
