### PR TITLE
Spring Boot update

### DIFF
--- a/FlySpring/autoroute/dependency-reduced-pom.xml
+++ b/FlySpring/autoroute/dependency-reduced-pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.2</version>
+      <version>5.9.3</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>4.8.1</version>
+      <version>5.3.1</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/FlySpring/edgechain-app/pom.xml
+++ b/FlySpring/edgechain-app/pom.xml
@@ -273,20 +273,19 @@
 			<scope>runtime</scope>
 		</dependency>
 
-    <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
     
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
 			<version>${auth0-jwt.version}</version>
-      <scope>test</scope>
+			<scope>test</scope>
 		</dependency>
-    
-  </dependencies>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/FlySpring/edgechain-app/pom.xml
+++ b/FlySpring/edgechain-app/pom.xml
@@ -272,12 +272,20 @@
 			<scope>runtime</scope>
 		</dependency>
 
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <scope>test</scope>
+    </dependency>
+    
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>3.19.2</version>
+      <scope>test</scope>
+		</dependency>
+    
+  </dependencies>
 
 	<build>
 		<plugins>

--- a/FlySpring/edgechain-app/pom.xml
+++ b/FlySpring/edgechain-app/pom.xml
@@ -16,6 +16,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
+		<auth0-jwt.version>4.4.0</auth0-jwt.version>
 		<djl.version>0.23.0</djl.version>
 		<exp4j.version>0.4.8</exp4j.version>
 		<hibernate-validator>6.0.23.Final</hibernate-validator>
@@ -281,7 +282,7 @@
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>3.19.2</version>
+			<version>${auth0-jwt.version}</version>
       <scope>test</scope>
 		</dependency>
     

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/configuration/WebConfiguration.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/configuration/WebConfiguration.java
@@ -37,11 +37,11 @@ public class WebConfiguration {
   @Bean
   AuthFilter authFilter() {
     AuthFilter filter = new AuthFilter();
-    filter.setRequestPost(new MethodAuthentication(List.of(""), ""));
-    filter.setRequestGet(new MethodAuthentication(List.of(""), ""));
-    filter.setRequestDelete(new MethodAuthentication(List.of(""), ""));
-    filter.setRequestPatch(new MethodAuthentication(List.of(""), ""));
-    filter.setRequestPut(new MethodAuthentication(List.of(""), ""));
+    filter.setRequestPost(new MethodAuthentication(List.of("**"), ""));
+    filter.setRequestGet(new MethodAuthentication(List.of("**"), ""));
+    filter.setRequestDelete(new MethodAuthentication(List.of("**"), ""));
+    filter.setRequestPatch(new MethodAuthentication(List.of("**"), ""));
+    filter.setRequestPut(new MethodAuthentication(List.of("**"), ""));
 
     return filter;
   }

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/JwtFilter.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/JwtFilter.java
@@ -13,7 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Objects;
-
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -60,6 +60,9 @@ public class JwtFilter extends OncePerRequestFilter {
       try {
         claimsJws = jwtHelper.parseToken(token);
       } catch (final Exception e) {
+        // use Spring Security logger here instead of SLF4J
+        logger.info("JWT not accepted: %s".formatted(e.getMessage()));
+        
         ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getWriter().print(JsonUtils.convertToString(errorResponse));
@@ -70,6 +73,9 @@ public class JwtFilter extends OncePerRequestFilter {
       String email = (String) claimsJws.getBody().get("email");
       String role = (String) claimsJws.getBody().get("role");
 
+      // use Spring Security logger here instead of SLF4J
+      logger.info("JWT accepted email=%s role=%s".formatted(email, role));
+      
       User user = new User();
       user.setEmail(email);
       user.setAccessToken(token);

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/JwtFilter.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/JwtFilter.java
@@ -74,7 +74,7 @@ public class JwtFilter extends OncePerRequestFilter {
       String role = (String) claimsJws.getBody().get("role");
 
       // use Spring Security logger here instead of SLF4J
-      logger.info("JWT accepted email=%s role=%s".formatted(email, role));
+      logger.info("JWT email=%s role=%s".formatted(email, role));
       
       User user = new User();
       user.setEmail(email);

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/JwtHelper.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/JwtHelper.java
@@ -2,6 +2,7 @@ package com.edgechain.lib.supabase.security;
 
 import io.jsonwebtoken.*;
 import java.security.Key;
+import java.util.Objects;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -14,10 +15,10 @@ public class JwtHelper {
 
   public Jws<Claims> parseToken(String accessToken) {
     try {
-      Key hmacKey =
-          new SecretKeySpec(
-              env.getProperty("jwt.secret").getBytes(), SignatureAlgorithm.HS256.getJcaName());
-
+      final String secret = env.getProperty("jwt.secret");
+      Objects.requireNonNull(secret, "JWT secret not set");
+      final byte[] bytes = secret.getBytes();
+      final Key hmacKey = new SecretKeySpec(bytes, SignatureAlgorithm.HS256.getJcaName());
       return Jwts.parser().setSigningKey(hmacKey).parseClaimsJws(accessToken);
 
     } catch (MalformedJwtException e) {
@@ -33,27 +34,13 @@ public class JwtHelper {
     }
   }
 
-  // validate
   public boolean validate(String accessToken) {
     try {
-      Key hmacKey =
-          new SecretKeySpec(
-              env.getProperty("jwt.secret").getBytes(), SignatureAlgorithm.HS256.getJcaName());
-
-      //            String encoded =
-      // Base64.getEncoder().encodeToString(this.supabaseEnv.getJwtSecret().getBytes());
-      Jwts.parser().setSigningKey(hmacKey).parseClaimsJws(accessToken);
+      parseToken(accessToken);
       return true;
-    } catch (MalformedJwtException e) {
-      throw new JwtException("Token Malformed");
-    } catch (UnsupportedJwtException e) {
-      throw new JwtException("Token Unsupported");
-    } catch (ExpiredJwtException e) {
-      throw new JwtException("Token Expired");
-    } catch (IllegalArgumentException e) {
-      throw new JwtException("Token Empty");
-    } catch (SignatureException e) {
-      throw new JwtException("Token Signature Failed");
+    }catch(JwtException e) {
+      return false;
     }
   }
+  
 }

--- a/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/WebSecurity.java
+++ b/FlySpring/edgechain-app/src/main/java/com/edgechain/lib/supabase/security/WebSecurity.java
@@ -70,30 +70,34 @@ public class WebSecurity {
         .requestMatchers("" + WebConfiguration.CONTEXT_PATH + "/**")
         .permitAll();
     
-    reg = reg
-        .requestMatchers(HttpMethod.POST, authFilter.getRequestPost().getRequests())
-        .hasAnyAuthority(authFilter.getRequestPost().getAuthorities());
-    
-    reg = reg
-        .requestMatchers(HttpMethod.GET, authFilter.getRequestGet().getRequests())
-        .hasAnyAuthority(authFilter.getRequestGet().getAuthorities());
-        
-    reg = reg
-        .requestMatchers(HttpMethod.DELETE, authFilter.getRequestDelete().getRequests())
-        .hasAnyAuthority(authFilter.getRequestDelete().getAuthorities());
-        
-    reg = reg
-        .requestMatchers(HttpMethod.PUT, authFilter.getRequestPut().getRequests())
-        .hasAnyAuthority(authFilter.getRequestPut().getAuthorities());
-        
-    reg = reg
-        .requestMatchers(HttpMethod.PATCH, authFilter.getRequestPatch().getRequests())
-        .hasAnyAuthority(authFilter.getRequestPatch().getAuthorities());
+    reg = applyAuth(
+        reg.requestMatchers(HttpMethod.POST, authFilter.getRequestPost().getRequests()), 
+        authFilter.getRequestPost().getAuthorities());
+    reg = applyAuth(
+        reg.requestMatchers(HttpMethod.GET, authFilter.getRequestGet().getRequests()), 
+        authFilter.getRequestGet().getAuthorities());
+    reg = applyAuth(
+        reg.requestMatchers(HttpMethod.DELETE, authFilter.getRequestDelete().getRequests()), 
+        authFilter.getRequestDelete().getAuthorities());
+    reg = applyAuth(
+        reg.requestMatchers(HttpMethod.PUT, authFilter.getRequestPut().getRequests()), 
+        authFilter.getRequestPut().getAuthorities());
+    reg = applyAuth(
+        reg.requestMatchers(HttpMethod.PATCH, authFilter.getRequestPatch().getRequests()), 
+        authFilter.getRequestPatch().getAuthorities());
         
     reg = reg
         .anyRequest()
         .permitAll();
     return reg;
+  }
+  
+  private AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry applyAuth(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizedUrl url, String[] auths) {
+    if (auths == null || auths.length == 0 || (auths.length == 1 && auths[0].isEmpty())) {
+      return url.permitAll();
+    }else {
+      return url.hasAnyAuthority(auths);
+    }
   }
 
   @Bean

--- a/FlySpring/edgechain-app/src/main/resources/application-test.properties
+++ b/FlySpring/edgechain-app/src/main/resources/application-test.properties
@@ -1,0 +1,5 @@
+# this profile will be used only when @ActiveProfiles("test")
+
+# uncomment these log level lines to follow what Spring is doing for ROLES
+# logging.level.org.springframework.security=TRACE
+# logging.level.org.springframework.security.web.FilterChainProxy=INFO

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityConfigFixTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityConfigFixTest.java
@@ -1,21 +1,22 @@
 package com.edgechain.lib.supabase.security;
 
-import com.edgechain.lib.configuration.WebConfiguration;
 import com.edgechain.lib.configuration.domain.AuthFilter;
 import com.edgechain.lib.configuration.domain.MethodAuthentication;
-import com.edgechain.lib.configuration.domain.SecurityUUID;
+import com.edgechain.testutil.TestJwtCreator;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -28,75 +29,93 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(name = "contextWithBadPattersAuthFilter")
 class WebSecurityConfigFixTest {
 
-  // ====== TEST CONTEXT-BASED SECURITY (uuid must be in header) ======
-  
-  private static final String FULL_CONTEXT_PATH = WebConfiguration.CONTEXT_PATH + "/";
+  // ====== TEST JWT-BASED SECURITY WITH NO ROLES (bearer token must be in header) ======
+
+  private static final String FULL_NONCONTEXT_PATH = "/v0/endpoint/";
+
+  @BeforeAll
+  static void setupAll() {
+    System.setProperty("jwt.secret", "edge-chain-unit-test-jwt-secret");
+  }
 
   @TestConfiguration
   public static class AuthFilterTestConfig {
     @Bean
     AuthFilter authFilter() {
+      // provide an AuthFilter with an empty string in the patterns list.
+      // the security class should fix this to **
       AuthFilter auth = new AuthFilter();
-      auth.setRequestGet(new MethodAuthentication(List.of(""), "ROLE_ADMIN1", "ROLE_AI1"));
-      auth.setRequestDelete(new MethodAuthentication(List.of(""), "ROLE_ADMIN2", "ROLE_AI2"));
-      auth.setRequestPatch(new MethodAuthentication(List.of(""), "ROLE_ADMIN3", "ROLE_AI3"));
-      auth.setRequestPost(new MethodAuthentication(List.of(""), "ROLE_ADMIN4", "ROLE_AI4"));
-      auth.setRequestPut(new MethodAuthentication(List.of(""), "ROLE_ADMIN5", "ROLE_AI5"));
+      auth.setRequestGet(new MethodAuthentication(List.of(""), ""));
+      auth.setRequestDelete(new MethodAuthentication(List.of(""), ""));
+      auth.setRequestPatch(new MethodAuthentication(List.of(""), ""));
+      auth.setRequestPost(new MethodAuthentication(List.of(""), ""));
+      auth.setRequestPut(new MethodAuthentication(List.of(""), ""));
       return auth;
     }
   }
-  
+
   @Autowired
   private MockMvc mvc;
 
   @Autowired
-  private SecurityUUID securityUUID;
+  private JwtHelper jwtHelper;
 
   @Test
-  void getContextEndpoint() throws Exception {
+  void validateJwt() {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
+    assertTrue(jwtHelper.validate(jwt));
+  }
+
+  @Test
+  void getEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
-        get(FULL_CONTEXT_PATH)
+        get(FULL_NONCONTEXT_PATH)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void postContextEndpoint() throws Exception {
+  void postEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
-        post(FULL_CONTEXT_PATH)
+        post(FULL_NONCONTEXT_PATH)
             .content("{}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void deleteContextEndpoint() throws Exception {
+  void deleteEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
-        delete(FULL_CONTEXT_PATH)
+        delete(FULL_NONCONTEXT_PATH)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void patchContextEndpoint() throws Exception {
+  void patchEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
-        patch(FULL_CONTEXT_PATH)
+        patch(FULL_NONCONTEXT_PATH)
             .content("{}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void putContextEndpoint() throws Exception {
+  void putEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
-        put(FULL_CONTEXT_PATH)
+        put(FULL_NONCONTEXT_PATH)
             .content("{}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityConfigFixTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityConfigFixTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ContextConfiguration(name = "contextWithBadPattersAuthFilter")
+@ContextConfiguration(name = "contextWithEmptyPatternsAuthFilter")
 class WebSecurityConfigFixTest {
 
   // ====== TEST JWT-BASED SECURITY WITH NO ROLES (bearer token must be in header) ======

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityConfigFixTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityConfigFixTest.java
@@ -1,14 +1,20 @@
 package com.edgechain.lib.supabase.security;
 
 import com.edgechain.lib.configuration.WebConfiguration;
+import com.edgechain.lib.configuration.domain.AuthFilter;
+import com.edgechain.lib.configuration.domain.MethodAuthentication;
 import com.edgechain.lib.configuration.domain.SecurityUUID;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -19,12 +25,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-class WebSecurityContextPathTest {
+@ContextConfiguration(name = "contextWithBadPattersAuthFilter")
+class WebSecurityConfigFixTest {
 
   // ====== TEST CONTEXT-BASED SECURITY (uuid must be in header) ======
   
   private static final String FULL_CONTEXT_PATH = WebConfiguration.CONTEXT_PATH + "/";
 
+  @TestConfiguration
+  public static class AuthFilterTestConfig {
+    @Bean
+    AuthFilter authFilter() {
+      AuthFilter auth = new AuthFilter();
+      auth.setRequestGet(new MethodAuthentication(List.of(""), "ROLE_ADMIN1", "ROLE_AI1"));
+      auth.setRequestDelete(new MethodAuthentication(List.of(""), "ROLE_ADMIN2", "ROLE_AI2"));
+      auth.setRequestPatch(new MethodAuthentication(List.of(""), "ROLE_ADMIN3", "ROLE_AI3"));
+      auth.setRequestPost(new MethodAuthentication(List.of(""), "ROLE_ADMIN4", "ROLE_AI4"));
+      auth.setRequestPut(new MethodAuthentication(List.of(""), "ROLE_ADMIN5", "ROLE_AI5"));
+      return auth;
+    }
+  }
+  
   @Autowired
   private MockMvc mvc;
 

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityContextPathTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityContextPathTest.java
@@ -1,0 +1,87 @@
+package com.edgechain.lib.supabase.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.edgechain.lib.configuration.WebConfiguration;
+import com.edgechain.lib.configuration.domain.SecurityUUID;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class WebSecurityContextPathTest {
+
+  private static final String FULL_CONTEXT_PATH = WebConfiguration.CONTEXT_PATH + "/";
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private SecurityUUID securityUUID;
+  
+  // ====== TEST CONTEXT-BASED SECURITY (uuid must be in header) ======
+
+  @Test
+  void getContextEndpoint() throws Exception {
+    mvc.perform(
+        get(FULL_CONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void postContextEndpoint() throws Exception {
+    mvc.perform(
+        post(FULL_CONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteContextEndpoint() throws Exception {
+    mvc.perform(
+        delete(FULL_CONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void patchContextEndpoint() throws Exception {
+    mvc.perform(
+        patch(FULL_CONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void putContextEndpoint() throws Exception {
+    mvc.perform(
+        put(FULL_CONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+}

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtNoRoleTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtNoRoleTest.java
@@ -1,10 +1,6 @@
 package com.edgechain.lib.supabase.security;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.edgechain.lib.configuration.WebConfiguration;
-import com.edgechain.lib.configuration.domain.SecurityUUID;
-import java.util.Date;
+import com.edgechain.testutil.TestJwtCreator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,90 +22,77 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class WebSecurityJwtNoRoleTest {
 
-  private static final String FULL_NONCONTEXT_PATH = "/v0/endpoint/";
+  // ====== TEST JWT-BASED SECURITY WITH NO ROLES (bearer token must be in header) ======
 
-  private static String testJwt;
-  private static String jwtHeaderVal;
+  private static final String FULL_NONCONTEXT_PATH = "/v0/endpoint/";
 
   @BeforeAll
   static void setupAll() {
     System.setProperty("jwt.secret", "edge-chain-unit-test-jwt-secret");
-    testJwt = generateJwt();
-    jwtHeaderVal = "Bearer " + testJwt;
-  }
-
-  private static String generateJwt() {
-    Algorithm algo = Algorithm.HMAC256(System.getProperty("jwt.secret").getBytes());
-    Date d = new Date();
-    return JWT.create()
-        .withSubject("example JWT for testing")
-        .withClaim("email", "admin@machine.local")
-        .withClaim("role", "ROLE_ANONYMOUS")
-        .withIssuer("edgechain-tester")
-        .withIssuedAt(d)
-        .withExpiresAt(new Date(d.getTime() + 25000))
-        .sign(algo);
   }
 
   @Autowired
   private MockMvc mvc;
-  
+
   @Autowired
   private JwtHelper jwtHelper;
 
-  // ====== TEST JWT-BASED SECURITY (bearer token must be in header) ======
-  
   @Test
   void validateJwt() {
-    assertTrue(jwtHelper.validate(testJwt));
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
+    assertTrue(jwtHelper.validate(jwt));
   }
 
   @Test
-  void getNonContextEndpoint() throws Exception {
-    
+  void getEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
         get(FULL_NONCONTEXT_PATH)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", jwtHeaderVal))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void postNonContextEndpoint() throws Exception {
+  void postEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
         post(FULL_NONCONTEXT_PATH)
             .content("{}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", jwtHeaderVal))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void deleteNonContextEndpoint() throws Exception {
+  void deleteEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
         delete(FULL_NONCONTEXT_PATH)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", jwtHeaderVal))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void patchNonContextEndpoint() throws Exception {
+  void patchEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
         patch(FULL_NONCONTEXT_PATH)
             .content("{}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", jwtHeaderVal))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 
   @Test
-  void putNonContextEndpoint() throws Exception {
+  void putEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_IGNORED");
     mvc.perform(
         put(FULL_NONCONTEXT_PATH)
             .content("{}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", jwtHeaderVal))
+            .header("Authorization", "Bearer " + jwt))
         .andExpect(status().isNotFound());
   }
 

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtNoRoleTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtNoRoleTest.java
@@ -24,9 +24,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-class WebSecurityTest {
+class WebSecurityJwtNoRoleTest {
 
-  private static final String FULL_CONTEXT_PATH = WebConfiguration.CONTEXT_PATH + "/";
   private static final String FULL_NONCONTEXT_PATH = "/v0/endpoint/";
 
   private static String testJwt;
@@ -54,62 +53,9 @@ class WebSecurityTest {
 
   @Autowired
   private MockMvc mvc;
-
-  @Autowired
-  private SecurityUUID securityUUID;
   
   @Autowired
   private JwtHelper jwtHelper;
-
-  // ====== TEST CONTEXT-BASED SECURITY (uuid must be in header) ======
-
-  @Test
-  void getContextEndpoint() throws Exception {
-    mvc.perform(
-        get(FULL_CONTEXT_PATH)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
-        .andExpect(status().isNotFound());
-  }
-
-  @Test
-  void postContextEndpoint() throws Exception {
-    mvc.perform(
-        post(FULL_CONTEXT_PATH)
-            .content("{}")
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
-        .andExpect(status().isNotFound());
-  }
-
-  @Test
-  void deleteContextEndpoint() throws Exception {
-    mvc.perform(
-        delete(FULL_CONTEXT_PATH)
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
-        .andExpect(status().isNotFound());
-  }
-
-  @Test
-  void patchContextEndpoint() throws Exception {
-    mvc.perform(
-        patch(FULL_CONTEXT_PATH)
-            .content("{}")
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
-        .andExpect(status().isNotFound());
-  }
-
-  @Test
-  void putContextEndpoint() throws Exception {
-    mvc.perform(
-        put(FULL_CONTEXT_PATH)
-            .content("{}")
-            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .header("Authorization", securityUUID.getAuthKey()))
-        .andExpect(status().isNotFound());
-  }
 
   // ====== TEST JWT-BASED SECURITY (bearer token must be in header) ======
   

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtWithRoleTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtWithRoleTest.java
@@ -39,6 +39,7 @@ class WebSecurityJwtWithRoleTest {
   public static class AuthFilterTestConfig {
     @Bean
     AuthFilter authFilter() {
+      // provide an AuthFilter with roles to check we test the correct role for each method
       AuthFilter auth = new AuthFilter();
       auth.setRequestGet(new MethodAuthentication(List.of("**"), "ROLE_ADMIN1", "ROLE_AI1"));
       auth.setRequestDelete(new MethodAuthentication(List.of("**"), "ROLE_ADMIN2", "ROLE_AI2"));

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtWithRoleTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityJwtWithRoleTest.java
@@ -1,0 +1,175 @@
+package com.edgechain.lib.supabase.security;
+
+import com.edgechain.lib.configuration.domain.AuthFilter;
+import com.edgechain.lib.configuration.domain.MethodAuthentication;
+import com.edgechain.testutil.TestJwtCreator;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ContextConfiguration(name = "contextWithTestRolesAuthFilter")
+class WebSecurityJwtWithRoleTest {
+
+  // ====== TEST JWT-BASED SECURITY WITH ROLES (bearer token must be in header) ======
+
+  private static final String FULL_NONCONTEXT_PATH = "/v0/endpoint/";
+
+  @TestConfiguration
+  public static class AuthFilterTestConfig {
+    @Bean
+    AuthFilter authFilter() {
+      AuthFilter auth = new AuthFilter();
+      auth.setRequestGet(new MethodAuthentication(List.of("**"), "ROLE_ADMIN1", "ROLE_AI1"));
+      auth.setRequestDelete(new MethodAuthentication(List.of("**"), "ROLE_ADMIN2", "ROLE_AI2"));
+      auth.setRequestPatch(new MethodAuthentication(List.of("**"), "ROLE_ADMIN3", "ROLE_AI3"));
+      auth.setRequestPost(new MethodAuthentication(List.of("**"), "ROLE_ADMIN4", "ROLE_AI4"));
+      auth.setRequestPut(new MethodAuthentication(List.of("**"), "ROLE_ADMIN5", "ROLE_AI5"));
+      return auth;
+    }
+  }
+
+  @BeforeAll
+  static void setupAll() {
+    System.setProperty("jwt.secret", "edge-chain-unit-test-jwt-secret");
+  }
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private JwtHelper jwtHelper;
+
+  @Test
+  void validateJwt() {
+    String jwt = TestJwtCreator.generate("ROLE_TEST");
+    assertTrue(jwtHelper.validate(jwt));
+  }
+
+  @Test
+  void getEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_ADMIN1");
+    mvc.perform(
+        get(FULL_NONCONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getEndpoint_notAuth() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_NO_ACCESS");
+    mvc.perform(
+        get(FULL_NONCONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void postEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_ADMIN4");
+    mvc.perform(
+        post(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void postEndpoint_notAuth() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_NO_ACCESS");
+    mvc.perform(
+        post(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void deleteEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_ADMIN2");
+    mvc.perform(
+        delete(FULL_NONCONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteEndpoint_notAuth() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_NO_ACCESS");
+    mvc.perform(
+        delete(FULL_NONCONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void patchEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_ADMIN3");
+    mvc.perform(
+        patch(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void patchEndpoint_notAuth() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_NO_ACCESS");
+    mvc.perform(
+        patch(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void putEndpoint() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_ADMIN5");
+    mvc.perform(
+        put(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void putEndpoint_notAuth() throws Exception {
+    String jwt = TestJwtCreator.generate("ROLE_NO_ACCESS");
+    mvc.perform(
+        put(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", "Bearer " + jwt))
+        .andExpect(status().isForbidden());
+  }
+
+}

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityTest.java
@@ -1,0 +1,80 @@
+package com.edgechain.lib.supabase.security;
+
+import com.edgechain.lib.configuration.WebConfiguration;
+import com.edgechain.lib.configuration.domain.SecurityUUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class WebSecurityTest {
+
+  private static final String FULL_CONTEXT_PATH = WebConfiguration.CONTEXT_PATH + "/";
+
+  @Autowired
+  private MockMvc mvc;
+
+  @Autowired
+  private SecurityUUID securityUUID;
+
+  @Test
+  void getContextEndpoint() throws Exception {
+    mvc.perform(
+        get(FULL_CONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void postContextEndpoint() throws Exception {
+    mvc.perform(
+        post(FULL_CONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteContextEndpoint() throws Exception {
+    mvc.perform(
+        delete(FULL_CONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void patchContextEndpoint() throws Exception {
+    mvc.perform(
+        patch(FULL_CONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void putContextEndpoint() throws Exception {
+    mvc.perform(
+        put(FULL_CONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+}

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityTest.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/lib/supabase/security/WebSecurityTest.java
@@ -1,7 +1,11 @@
 package com.edgechain.lib.supabase.security;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import com.edgechain.lib.configuration.WebConfiguration;
 import com.edgechain.lib.configuration.domain.SecurityUUID;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -10,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -22,12 +27,41 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class WebSecurityTest {
 
   private static final String FULL_CONTEXT_PATH = WebConfiguration.CONTEXT_PATH + "/";
+  private static final String FULL_NONCONTEXT_PATH = "/v0/endpoint/";
+
+  private static String testJwt;
+  private static String jwtHeaderVal;
+
+  @BeforeAll
+  static void setupAll() {
+    System.setProperty("jwt.secret", "edge-chain-unit-test-jwt-secret");
+    testJwt = generateJwt();
+    jwtHeaderVal = "Bearer " + testJwt;
+  }
+
+  private static String generateJwt() {
+    Algorithm algo = Algorithm.HMAC256(System.getProperty("jwt.secret").getBytes());
+    Date d = new Date();
+    return JWT.create()
+        .withSubject("example JWT for testing")
+        .withClaim("email", "admin@machine.local")
+        .withClaim("role", "ROLE_ANONYMOUS")
+        .withIssuer("edgechain-tester")
+        .withIssuedAt(d)
+        .withExpiresAt(new Date(d.getTime() + 25000))
+        .sign(algo);
+  }
 
   @Autowired
   private MockMvc mvc;
 
   @Autowired
   private SecurityUUID securityUUID;
+  
+  @Autowired
+  private JwtHelper jwtHelper;
+
+  // ====== TEST CONTEXT-BASED SECURITY (uuid must be in header) ======
 
   @Test
   void getContextEndpoint() throws Exception {
@@ -74,6 +108,62 @@ class WebSecurityTest {
             .content("{}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .header("Authorization", securityUUID.getAuthKey()))
+        .andExpect(status().isNotFound());
+  }
+
+  // ====== TEST JWT-BASED SECURITY (bearer token must be in header) ======
+  
+  @Test
+  void validateJwt() {
+    assertTrue(jwtHelper.validate(testJwt));
+  }
+
+  @Test
+  void getNonContextEndpoint() throws Exception {
+    
+    mvc.perform(
+        get(FULL_NONCONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", jwtHeaderVal))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void postNonContextEndpoint() throws Exception {
+    mvc.perform(
+        post(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", jwtHeaderVal))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteNonContextEndpoint() throws Exception {
+    mvc.perform(
+        delete(FULL_NONCONTEXT_PATH)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", jwtHeaderVal))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void patchNonContextEndpoint() throws Exception {
+    mvc.perform(
+        patch(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", jwtHeaderVal))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void putNonContextEndpoint() throws Exception {
+    mvc.perform(
+        put(FULL_NONCONTEXT_PATH)
+            .content("{}")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", jwtHeaderVal))
         .andExpect(status().isNotFound());
   }
 

--- a/FlySpring/edgechain-app/src/test/java/com/edgechain/testutil/TestJwtCreator.java
+++ b/FlySpring/edgechain-app/src/test/java/com/edgechain/testutil/TestJwtCreator.java
@@ -1,0 +1,26 @@
+package com.edgechain.testutil;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import java.util.Date;
+
+public final class TestJwtCreator {
+
+  private TestJwtCreator() {
+    // no
+  }
+
+  public static String generate(String role) {
+    Algorithm algo = Algorithm.HMAC256(System.getProperty("jwt.secret").getBytes());
+    Date d = new Date();
+    return JWT.create()
+        .withSubject("example JWT for testing")
+        .withClaim("email", "admin@machine.local")
+        .withClaim("role", role)
+        .withIssuer("edgechain-tester")
+        .withIssuedAt(d)
+        .withExpiresAt(new Date(d.getTime() + 25000))
+        .sign(algo);
+  }
+
+}

--- a/FlySpring/pom.xml
+++ b/FlySpring/pom.xml
@@ -28,7 +28,7 @@
 		<commons-io.version>2.11.0</commons-io.version>
 		<picocli.version>4.7.0</picocli.version>
 		<rxjava-reactive-streams.version>1.2.1</rxjava-reactive-streams.version>
-		<testcontainers.version>1.17.6</testcontainers.version>
+		<testcontainers.version>1.19.0</testcontainers.version>
 		<unidecode.version>0.0.7</unidecode.version>
 		<zeroturnaround.version>1.12</zeroturnaround.version>
 		<zip4j.version>2.11.3</zip4j.version>
@@ -61,6 +61,12 @@
 			<dependency>
 				<groupId>org.testcontainers</groupId>
 				<artifactId>testcontainers</artifactId>
+				<version>${testcontainers.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>junit-jupiter</artifactId>
 				<version>${testcontainers.version}</version>
 			</dependency>
 

--- a/FlySpring/pom.xml
+++ b/FlySpring/pom.xml
@@ -22,7 +22,7 @@
 		<maven-shade.version>3.4.1</maven-shade.version>
 		<maven-antrun.version>3.1.0</maven-antrun.version>
 		
-		<spring-boot.version>3.0.5</spring-boot.version>
+		<spring-boot.version>3.1.3</spring-boot.version>
 
 		<apache-tika.version>2.7.0</apache-tika.version>
 		<commons-io.version>2.11.0</commons-io.version>

--- a/FlySpring/readme.md
+++ b/FlySpring/readme.md
@@ -1,14 +1,21 @@
 # flyfly CLI
+
 ## Installation & Usage
+
 cd to autoroute directory 
-```console
-mvn clean package -P gofly
+
+```bash
+mvn clean package
 ```
+
 cd to flyfly directory
-```console
-mvn clean package -P gofly
+
+```bash
+mvn clean package
 ```
+
 Now cd into Examples/starter :- flyfly is ready to roll!
+
 ```bash
 java -jar flyfly.jar <command>
 ```
@@ -16,10 +23,13 @@ java -jar flyfly.jar <command>
 ## Commands 
 
 ### run  
+
 Runs the Spring Boot application. if the project has jpa and a database driver(connector) in the build file and there is not 'spring.datasource.url' in the application.properties. Then the CLI will start a TestContainers database and add temporary values to application.properties to allow the application to run successfully. That's if the driver is supported by the CLI and Docker is installed.  
-Currently supported DBs are: MySQL, Postgres, and MariaDB.  
+Currently supported DBs are: MySQL, Postgres, and MariaDB.
+
 
 ### format
+
 Format the code using Spotless.
  
 P.S. - New examples will be added soon!


### PR DESCRIPTION
Main branch is set to Spring Boot 3.0.5 due to issues with Spring Security
- empty pattern spec
- empty roles

This branch updates the project to Boot 3.1.3 with fixes for the above.

- if pattern spec is empty: use ** otherwise: use pattern spec as provided
- if there are no roles: use permitAll() otherwise: use hasAnyAuthority(...)

## Testing required with external dependencies

Effort has been made to test different web configurations. Actual integrations - supabase for example - should be done to ensure the Boot update works as expected.

Similarly, controller checks including `RedisHistoryContextController` should be made to ensure they function as expected when run using `java -jar edgechain.jar ...`

## Changes

- the default pattern spec is now **
- empty pattern spec (in existing projects) will be logged and ** used instead
- tests for context authentication (using Authorization header with auth key)
- tests for JWT with no roles
- tests for JWT with roles
- tests for JWT fixed pattern spec
- minor test dependency versions updated
- builds locally and runs an example app with `java -jar edgechain.jar jbang TinyApp.java`
- logging to support use and development
- the auth config in `WebSecurity` is now in a separate method for clarity; and useful line numbers if Spring Security gets stronger in future (instead of a tedious lambda exception)

