### PR TITLE
fix: wasm build

### DIFF
--- a/.github/workflows/webassembly-pr-build.yml
+++ b/.github/workflows/webassembly-pr-build.yml
@@ -7,7 +7,7 @@ on:
       - reopened
       - synchronize
     paths:
-      - 'JS/wasm/**'
+      - 'JS/**'
 
 jobs:
   changes:
@@ -24,7 +24,7 @@ jobs:
         with:
           filters: |
             wasm:
-              - 'JS/wasm/**'
+              - 'JS/**'
 
   wasm:
     needs: changes


### PR DESCRIPTION
- Earlier `webassembly-pr-build.yml` will be triggered only when there is change on `JS/wasm`
- Now `webassembly-pr-build.yml` will be triggered when there is change on `JS/`