### PR TITLE
Added a '\' in the curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Now, you have to create a chat context, similar to a Chat Session in ChatGPT. Us
   'localhost:8080/v1/examples/historycontext' \
   --header 'Accept: /' \
   --header 'User-Agent: Thunder Client (https://www.thunderclient.com/)' \
-  --header 'Content-Type: application/json'
+  --header 'Content-Type: application/json' \
   --data-raw '{
     "maxTokens": 4096
   }'
@@ -157,7 +157,7 @@ Now, it's time to start chatting with the document by asking questions. For exam
 
 ```bash
 curl --location 'localhost:8080/v1/examples/redis/openai/chat?query=What%20is%20the%20transformer%20architecture%3F&namespace=machine-learning&id=historycontext%3A50756d25-e7e4-4d7c-862c-f81bf3f8eea0' \
---header 'Content-Type: application/json'
+--header 'Content-Type: application/json' \
  --data-raw '{
     "query": "What is the transformer architecture?"
 }


### PR DESCRIPTION
Descritption: In readme.md, while following the guide to install the edge chain I struck at this small issue. In two curl command one backslash was missing which resulted in command failure. 


Note: The change  was too small. So I didnt created a issue for that. Let me know if its necessary. 
Thanks for the review.