### PR TITLE
Fix workflow run - "pr-build"

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -93,7 +93,7 @@ jobs:
         run: npm install prettier
       - name: Install ESLint
         run: >
-          npm install eslint@latest && 
+          npm install eslint@^8 && 
           npm install @microsoft/eslint-formatter-sarif@latest eslint-config-google@latest eslint-plugin-import@latest @typescript-eslint/eslint-plugin@latest @typescript-eslint/parser@latest eslint-config-prettier@latest eslint-plugin-prettier@latest
       - name: Get cache date
         id: get-date

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Cargo.lock
 yarn.lock
 package-lock.json
 .DS_Store
+pnpm-lock.yaml


### PR DESCRIPTION
The workflow is failing because the latest version of eslint is 9 while the latest version of eslint supported by eslint-plugin-import is 8 as of now . So this pr downgrades the eslint version from latest to 8 for the time being .