### PR TITLE
Move Next.js template under ec-2

### DIFF
--- a/.github/workflows/ec2-tests.yml
+++ b/.github/workflows/ec2-tests.yml
@@ -1,6 +1,6 @@
 name: EC2 Next.js Tests
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
     paths:
       - "ec-2/**"

--- a/.github/workflows/ec2-tests.yml
+++ b/.github/workflows/ec2-tests.yml
@@ -1,0 +1,21 @@
+name: EC2 Next.js Tests
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    paths:
+      - "ec-2/**"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Install dependencies
+        run: npm install
+        working-directory: ec-2/nextjs-chat-template
+      - name: Run tests
+        run: npm test -- --run
+        working-directory: ec-2/nextjs-chat-template

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn.lock
 package-lock.json
 .DS_Store
 pnpm-lock.yaml
+/ec-2/nextjs-chat-template/example.pdf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 EdgeChains treats Generative AI as a configuration management problem. Libraries are kept minimal and stable.
 
+**Important:** All new Next.js code must be placed inside the top-level `ec-2` directory. Do not add Next.js apps elsewhere in the repository.
+
+> **Strict rule:** Any Next.js project found outside `ec-2` will be rejected.
+
 ## Why Jsonnet
 
 - Prompts and chain logic live in `.jsonnet` files so they are versionable and diffable.
@@ -25,6 +29,7 @@ These decisions are stated in the README:
 - `JS/jsonnet` – legacy Wasm build of Jsonnet. Ignore this directory because `@hanazuki/node-jsonnet` already bundles native functions.
 - `JS/wasm` – early WebAssembly experiments. Also ignore.
 - `JS/edgechains/examples` – starter templates covering many use cases. Each contains conditional Jsonnet that calls JavaScript native functions at runtime.
+- `ec-2` – directory for all new Next.js examples and templates. Place no Next.js code outside of this folder.
 - Rust crates and the `Makefile` build the CLI and WebAssembly runtime.
 
 ## Development Style
@@ -32,9 +37,10 @@ These decisions are stated in the README:
 - Keep examples compact: one TypeScript script and one Jsonnet file.
 - Place prompts in Jsonnet rather than inline strings.
 - Use Next.js with React Server Actions for routing and UI.
-- Every example lives under `JS/edgechains/examples/<name>` with a `jsonnet/` folder containing `main.jsonnet` and `secrets.jsonnet`. The TypeScript script registers any native callbacks.
+- Legacy examples live under `JS/edgechains/examples/<name>`. **All new Next.js examples must reside in the `ec-2/` directory.** Each example contains a `jsonnet/` folder with `main.jsonnet` and `secrets.jsonnet`; the TypeScript script registers native callbacks.
 - Format code with Prettier and keep TypeScript types.
-- Tests (when present) use Vitest.
+- Tests (when present) use Vitest. Next.js templates under `ec-2/` must include
+  a test suite and workflow to run it in GitHub Actions.
 
 ## Migration TODO
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
-# EdgeChains Packages [![](https://img.shields.io/npm/v/%40arakoodev%2Fedgechains.js?style=flat-square&label=npmjs%3A%20%40arakoodev%2Fedgechains.js&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40arakoodev%2Fedgechains.js)](https://www.npmjs.com/package/@arakoodev/edgechains.js)  [![](https://img.shields.io/npm/v/%40arakoodev%2Fjsonnet?style=flat-square&label=npmjs%3A%20%40arakoodev%2Fjsonnet&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40arakoodev%2Fjsonnet)](https://www.npmjs.com/package/@arakoodev/jsonnet)
-
-
-
+# EdgeChains Packages [![](https://img.shields.io/npm/v/%40arakoodev%2Fedgechains.js?style=flat-square&label=npmjs%3A%20%40arakoodev%2Fedgechains.js&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40arakoodev%2Fedgechains.js)](https://www.npmjs.com/package/@arakoodev/edgechains.js) [![](https://img.shields.io/npm/v/%40arakoodev%2Fjsonnet?style=flat-square&label=npmjs%3A%20%40arakoodev%2Fjsonnet&link=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40arakoodev%2Fjsonnet)](https://www.npmjs.com/package/@arakoodev/jsonnet)
 
 ---
+
 **Join our [Discord](https://discord.gg/aehBPdPqf5) - we are one of the friendliest and nicest dev groups in Generative AI !**
 
-### ***Jump straight into our [examples](JS/edgechains/examples) WITH VIDEOS!!***
-
+### **_Jump straight into our [examples](JS/edgechains/examples) WITH VIDEOS!!_**
 
 ## Is EdgeChains production ready ?
-unlike a lot of frameworks  - we built it on top of honojs and  jsonnet, both of which are built by cloudflare and google respectively.
+
+unlike a lot of frameworks - we built it on top of honojs and jsonnet, both of which are built by cloudflare and google respectively.
 so even if u dont trust me...u can trust them ;)
 
 we dont build our own flavor of json or a specific DSL (that is inherently fragile) and give u compilation steps. Our underlying libraries are rock solid and stable.
+
 <div align="center">
 
   <img src="https://img.shields.io/github/repo-size/arakoodev/EdgeChains?style=flat-square" />
@@ -26,59 +25,68 @@ we dont build our own flavor of json or a specific DSL (that is inherently fragi
   <img src="https://img.shields.io/github/contributors/arakoodev/EdgeChains?style=flat-square" />
   <img src="https://img.shields.io/github/last-commit/arakoodev/EdgeChains?style=flat-square" />
   </div>
-  
 
 ## Understanding EdgeChains
 
 At EdgeChains, we take a unique approach to Generative AI - we think Generative AI is a deployment and configuration management challenge rather than a UI and library design pattern challenge. We build on top of a tech that has solved this problem in a different domain - Kubernetes Config Management - and bring that to Generative AI.
-Edgechains is built on top of jsonnet, originally built by Google based on their experience managing a vast amount of configuration code in the Borg infrastructure. 
+Edgechains is built on top of jsonnet, originally built by Google based on their experience managing a vast amount of configuration code in the Borg infrastructure.
 
 Edgechains gives you:
 
-* **Just One Script File**: EdgeChains is engineered to be extremely simple - Executing production-ready GenAI applications is just one script file and one jsonnet file. You'll be pleasantly surprised!
-* **Versioning for Prompts**: Prompts are written in jsonnet. Makes them easily versionable and diffable. 
-* **Automatic parallelism**: EdgeChains automatically parallelizes LLM chains & chain-of-thought tasks across CPUs, GPUs, and TPUs using the WebAssembly runtime.
-* **Fault tolerance**: EdgeChains is designed to be fault-tolerant, and can continue to retry & backoff even if some of the requests in the system fail.
-* **Scalability**: EdgeChains is designed to be scalable, and can be used to write your chain-of-thought applications on large number of APIs, prompt lengths and vector datasets.
+- **Just One Script File**: EdgeChains is engineered to be extremely simple - Executing production-ready GenAI applications is just one script file and one jsonnet file. You'll be pleasantly surprised!
+- **Versioning for Prompts**: Prompts are written in jsonnet. Makes them easily versionable and diffable.
+- **Automatic parallelism**: EdgeChains automatically parallelizes LLM chains & chain-of-thought tasks across CPUs, GPUs, and TPUs using the WebAssembly runtime.
+- **Fault tolerance**: EdgeChains is designed to be fault-tolerant, and can continue to retry & backoff even if some of the requests in the system fail.
+- **Scalability**: EdgeChains is designed to be scalable, and can be used to write your chain-of-thought applications on large number of APIs, prompt lengths and vector datasets.
 
 ## Why do you need Prompt & Chain Engineering
+
 Most people who are new to Generative AI think that the way to use OpenAI or other LLMs is to simply ask it a question and have it magically reply. The answer is extremely different and complex.
 
 ### Complexity of Prompt Engineering
+
 Generative AI, OpenAI and LLMs need you to write your prompt in very specific ways. Each of these ways to write prompts is very involved and highly complex - it is in fact so complex that there are research papers published for this. E.g.:
+
 - [Reason & Act - REACT style prompt chains](https://ai.googleblog.com/2022/11/react-synergizing-reasoning-and-acting.html)
 - [HyDE prompt chains - Precise Zero-Shot Dense Retrieval without Relevance Labels](https://arxiv.org/abs/2212.10496)
 - [FrugalGPT: How to Use Large Language Models While Reducing Cost and Improving Performance](https://arxiv.org/abs/2305.05176)
 
-### *Prompt Explosion* - Too many Prompts for too many LLMs
+### _Prompt Explosion_ - Too many Prompts for too many LLMs
+
 Moreover, these prompt techniques work on one kind of LLMs, but dont work on other LLMs. For e.g. prompts & chains that are written in a specific way for GPT-3.5 will need to be rewritten for Llama2 **to achieve the same goal**. This causes prompts to explode in number, making them challenging to version and manage.
 
-### Prompt ***Drift***
+### Prompt **_Drift_**
+
 Prompts change over time. This is called Prompt Drift. There is enough published research to show how chatGPT's behavior changes. Your infrastructure needs to be capable enough to version/change with this drift. If you use libraries, where prompts are hidden under many layers, then you will find it IMPOSSIBLE to do this.
 Your production code will rot over time, even if you did nothing.
 
 -[How is ChatGPT's behavior changing over time?](https://arxiv.org/abs/2307.09009)
 
 ### Testability in Production
-One of the big challenge in production is how to keep testing your prompts & chains and iterate on them quickly. If your prompts sit beneath many layers of libraries and abstractions, this is impossible. But if your prompts ***live outside the code*** and are declarative, this is easy to do. In fact, in EdgeChains, you can have your entire prompt & chain logic sit in s3 or an API.
+
+One of the big challenge in production is how to keep testing your prompts & chains and iterate on them quickly. If your prompts sit beneath many layers of libraries and abstractions, this is impossible. But if your prompts **_live outside the code_** and are declarative, this is easy to do. In fact, in EdgeChains, you can have your entire prompt & chain logic sit in s3 or an API.
 
 ### Token costs & measurement
-Each prompt or chain has a token cost associated with it. You may think that a certain prompt is very good...but it may be consuming a huge amount of tokens. For example, Chain-of-Thought style prompts consume atleast 3X as many **output tokens** as a normal prompt. you need to have fine-grained tracking and measurement built into your framework to be able to manage this. Edgechains has this built in.
 
+Each prompt or chain has a token cost associated with it. You may think that a certain prompt is very good...but it may be consuming a huge amount of tokens. For example, Chain-of-Thought style prompts consume atleast 3X as many **output tokens** as a normal prompt. you need to have fine-grained tracking and measurement built into your framework to be able to manage this. Edgechains has this built in.
 
 ---
 
 # Setup
+
 1. Clone the repo into a public GitHub repository (or fork [https://github.com/arakoodev/EdgeChains/fork](https://github.com/arakoodev/EdgeChains/fork)).
 
-``` 
+```
   git clone https://github.com/arakoodev/EdgeChains/
 ```
 
 2. Go to the project folder
+
 ```
   cd EdgeChains
 ```
+
+All new Next.js templates live under `ec-2/`. Do not add them elsewhere.
 
 # Run the ChatWithPdf example
 
@@ -87,31 +95,33 @@ This section provides instructions for developers on how to utilize the chat wit
 ---
 
 1. Go to the ChatWithPdfExample
+
 ```
   cd JS/edgechains/examples/chat-with-pdf/
 ```
 
 2. Install packages with npm
 
-``` 
+```
   npm install
 ```
 
 3. Setup you secrets in `secrets.jsonnet`
+
 ```
   local SUPABASE_API_KEY = "your supabase api key here";
 
 
   local OPENAI_API_KEY = "your openai api key here";
-    
+
   local SUPABASE_URL = "your supabase url here";
-    
+
   {
     "supabase_api_key":SUPABASE_API_KEY,
     "supabase_url":SUPABASE_URL,
     "openai_api_key":OPENAI_API_KEY,
   }
-   
+
 ```
 
 4. Database Configuration
@@ -129,8 +139,8 @@ create table if not exists documents (
   );
 
 create or replace function public.match_documents (
-   query_embedding vector(1536), 
-  similarity_threshold float, 
+   query_embedding vector(1536),
+  similarity_threshold float,
     match_count int
 )
 returns table (
@@ -154,40 +164,53 @@ as $$
 
 - You should see a success message in the Result tab.
 
-
 ## Usage
 
 1. Start the server:
 
-    ```bash
-    npm run start
-    ```
+   ```bash
+   npm run start
+   ```
 
 2. Hit the `GET` endpoint.
 
-    ```bash
-    http://localhost:3000/chatWithpdf?question=who is nirmala sitarama
-   
+   ```bash
+   http://localhost:3000/chatWithpdf?question=who is nirmala sitarama
+
+   ```
+
 - Then you can run the ChatWithPdf example using npm run start and continue chatting with the example.pdf.
-  
+
 ⚠️👉Remember: Comment out the InsertToSupabase function if you are running the code again; otherwise, the PDF data will be pushed again to the Supabase vector data.
 
+---
+
+## Next.js Chat Template
+
+EdgeChains also includes a minimal Next.js template using React Server Components.
+
+```bash
+cd ec-2/nextjs-chat-template
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000` to ask questions. The logic lives in `jsonnet/main.jsonnet` and the callbacks in `lib/` are registered from server actions.
 
 ## Contribution guidelines
 
-**If you want to contribute to EdgeChains, make sure to read the [Contribution CLA](https://github.com/arakoodev/.github/blob/main/CLA.md). This project adheres to EdgeChains [code of conduct]( https://github.com/arakoodev/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.**
+**If you want to contribute to EdgeChains, make sure to read the [Contribution CLA](https://github.com/arakoodev/.github/blob/main/CLA.md). This project adheres to EdgeChains [code of conduct](https://github.com/arakoodev/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.**
 
 **We use [GitHub issues](https://github.com/arakoodev/edgechains/issues) for tracking requests and bugs.**
 
-
-
 ## 💌 Acknowledgements
+
 We would like to express our sincere gratitude to the following individuals and projects for their contributions and inspiration:
+
 - We draw inspiration from the spirit of [Nextjs](https://github.com/vercel/next.js/).
 - We extend our appreciation to all the [contributors](https://github.com/wootzapp/wootz-browser/graphs/contributors) who have supported and enriched this project.
 - Respect to LangChain, Anthropic, Mosaic and the rest of the open-source LLM community. We are deeply grateful for sharing your knowledge and never turning anyone away.
 
-
 ## License
 
-EdgeChains  is licensed under the GNU Affero General Public License v3.0 and as commercial software. For commercial licensing, please contact us or raise a issue in this github.
+EdgeChains is licensed under the GNU Affero General Public License v3.0 and as commercial software. For commercial licensing, please contact us or raise a issue in this github.

--- a/ec-2/nextjs-chat-template/app/actions/ask.ts
+++ b/ec-2/nextjs-chat-template/app/actions/ask.ts
@@ -1,0 +1,31 @@
+"use server";
+import path from "path";
+// @ts-ignore
+import createClient from "sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import Jsonnet from "@arakoodev/jsonnet";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const jsonnet = new Jsonnet();
+
+const openAICall = createClient(
+  path.join(__dirname, "../lib/generateResponse.cjs"),
+);
+const getQueryMatch = createClient(
+  path.join(__dirname, "../lib/getQueryMatch.cjs"),
+);
+const getEmbeddings = createClient(
+  path.join(__dirname, "../lib/getEmbeddings.cjs"),
+);
+
+export async function ask(question: string) {
+  jsonnet.extString("query", question.toLowerCase());
+  jsonnet.extString("content", "");
+  jsonnet.javascriptCallback("getEmbeddings", getEmbeddings);
+  jsonnet.javascriptCallback("getQueryMatch", getQueryMatch);
+  jsonnet.javascriptCallback("openAICall", openAICall);
+  const response = JSON.parse(
+    jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet")),
+  );
+  return response;
+}

--- a/ec-2/nextjs-chat-template/app/api/chat/route.ts
+++ b/ec-2/nextjs-chat-template/app/api/chat/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+// @ts-ignore
+import createClient from "sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import Jsonnet from "@arakoodev/jsonnet";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const jsonnet = new Jsonnet();
+
+const openAICall = createClient(
+  path.join(__dirname, "../../lib/generateResponse.cjs"),
+);
+const getQueryMatch = createClient(
+  path.join(__dirname, "../../lib/getQueryMatch.cjs"),
+);
+const getEmbeddings = createClient(
+  path.join(__dirname, "../../lib/getEmbeddings.cjs"),
+);
+
+export async function GET(request: NextRequest) {
+  console.time("ExecutionTime");
+  const searchStr = (
+    request.nextUrl.searchParams.get("question") || ""
+  ).toLowerCase();
+  jsonnet.extString("query", searchStr);
+  jsonnet.javascriptCallback("getEmbeddings", getEmbeddings);
+  jsonnet.javascriptCallback("getQueryMatch", getQueryMatch);
+  jsonnet.javascriptCallback("openAICall", openAICall);
+  const response = JSON.parse(
+    jsonnet.evaluateFile(path.join(__dirname, "../../../jsonnet/main.jsonnet")),
+  );
+  console.timeEnd("ExecutionTime");
+  return NextResponse.json(response);
+}

--- a/ec-2/nextjs-chat-template/app/page.tsx
+++ b/ec-2/nextjs-chat-template/app/page.tsx
@@ -1,0 +1,18 @@
+import { ask } from "./actions/ask";
+
+export default function Page() {
+  async function submit(formData: FormData) {
+    "use server";
+    const question = String(formData.get("question") || "");
+    return await ask(question);
+  }
+
+  return (
+    <main style={{ padding: "2rem" }}>
+      <form action={submit}>
+        <input type="text" name="question" placeholder="Ask a question" />
+        <button type="submit">Ask</button>
+      </form>
+    </main>
+  );
+}

--- a/ec-2/nextjs-chat-template/jsonnet/main.jsonnet
+++ b/ec-2/nextjs-chat-template/jsonnet/main.jsonnet
@@ -1,0 +1,26 @@
+local CUSTOM_TEMPLATE = |||
+                            You are a senior software developer seeking accurate answers based on provided content. Your task is to find answers exclusively from the given content and the answer should be verbose and detailedfull. If the answer is not present within the provided content, respond with "Sorry! I don't know the answer.
+                            Content:{content}
+                            Question:{}
+                        |||;
+
+
+local updateQueryPrompt(promptTemplate, query, content) =
+    local updatedPrompt = std.strReplace(promptTemplate, '{}', query + "\n");
+    local updatedContent = std.strReplace(updatedPrompt, '{content}', content + "\n");
+    updatedContent;
+
+
+local query = std.extVar("query");
+local content = std.extVar("content");
+
+local getQueryMatch(query)= 
+    local queryEmbeddings = arakoo.native("getEmbeddings")(query);
+    local content = arakoo.native("getQueryMatch")(queryEmbeddings);
+    content;
+
+local updatedQueryPrompt = updateQueryPrompt(CUSTOM_TEMPLATE, query, getQueryMatch(query));
+
+local getOpenAiResponse = arakoo.native("openAICall")(updatedQueryPrompt);
+
+getOpenAiResponse

--- a/ec-2/nextjs-chat-template/jsonnet/secrets.jsonnet
+++ b/ec-2/nextjs-chat-template/jsonnet/secrets.jsonnet
@@ -1,0 +1,11 @@
+local SUPABASE_API_KEY = "your supabase api key here";
+
+local OPENAI_API_KEY = "your openai api key here";
+
+local SUPABASE_URL = "your supabase url here";
+
+{
+    "supabase_api_key":SUPABASE_API_KEY,
+    "supabase_url":SUPABASE_URL,
+    "openai_api_key":OPENAI_API_KEY,
+}

--- a/ec-2/nextjs-chat-template/lib/InsertToSupabase.ts
+++ b/ec-2/nextjs-chat-template/lib/InsertToSupabase.ts
@@ -1,0 +1,64 @@
+import fileURLToPath from "file-uri-to-path";
+import { Spinner } from "cli-spinner";
+import { PdfLoader } from "@arakoodev/edgechains.js/document-loader";
+import { TextSplitter } from "@arakoodev/edgechains.js/splitter";
+import { createRequire } from "module";
+import { Supabase } from "@arakoodev/edgechains.js/vector-db";
+import Jsonnet from "@arakoodev/jsonnet";
+import path from "path";
+import fs from "fs";
+
+const require = createRequire(import.meta.url);
+
+const getEmbeddings = require("./getEmbeddings.cjs");
+
+const __dirname = fileURLToPath(import.meta.url);
+
+const pdfPath = path.join(__dirname, "../../../example.pdf");
+const pdfData = fs.readFileSync(pdfPath);
+const bufferPdf = Buffer.from(pdfData);
+const loader = new PdfLoader(bufferPdf);
+const docs = await loader.loadPdf();
+const splitter = new TextSplitter();
+export const splitedDocs = await splitter.splitTextIntoChunks(docs, 500);
+
+const secretsPath = path.join(__dirname, "../../../jsonnet/secrets.jsonnet");
+
+const jsonnet = new Jsonnet();
+
+const secretsLoader = jsonnet.evaluateFile(secretsPath);
+const supabaseApiKey = await JSON.parse(secretsLoader).supabase_api_key;
+const supabaseUrl = await JSON.parse(secretsLoader).supabase_url;
+const supabase = new Supabase(supabaseUrl, supabaseApiKey);
+const client = supabase.createClient();
+
+export async function InsertToSupabase(content: any) {
+  var spinner = new Spinner("Inserting to Supabase.. %s");
+  try {
+    spinner.setSpinnerString("|/-\\");
+    spinner.start();
+
+    const response = await getEmbeddings()(content);
+    for (let i = 0; i < response?.length; i++) {
+      if (content[i].length <= 1) {
+        continue;
+      }
+
+      const element = response[i].embedding;
+      await supabase.insertVectorData({
+        client,
+        tableName: "documents",
+        content: content[i].toLowerCase(),
+        embedding: element,
+      });
+    }
+    if (!response) {
+      return console.log("Error inserting to Supabase");
+    }
+    console.log("Inserted to Supabase");
+  } catch (error) {
+    console.log("Error inserting to Supabase", error);
+  } finally {
+    spinner.stop();
+  }
+}

--- a/ec-2/nextjs-chat-template/lib/generateResponse.cjs
+++ b/ec-2/nextjs-chat-template/lib/generateResponse.cjs
@@ -1,0 +1,30 @@
+const path = require("path");
+const { OpenAI } = require("@arakoodev/edgechains.js/openai");
+const z = require("zod");
+const Jsonnet = require("@arakoodev/jsonnet");
+const jsonnet = new Jsonnet();
+
+const secretsPath = path.join(__dirname, "../jsonnet/secrets.jsonnet");
+const openAIApiKey = JSON.parse(
+  jsonnet.evaluateFile(secretsPath),
+).openai_api_key;
+
+const openai = new OpenAI({ apiKey: openAIApiKey });
+
+const schema = z.object({
+  answer: z.string().describe("The answer to the question"),
+});
+
+function openAICall() {
+  return function (prompt) {
+    try {
+      return openai.zodSchemaResponse({ prompt, schema }).then((res) => {
+        return JSON.stringify(res);
+      });
+    } catch (error) {
+      return error;
+    }
+  };
+}
+
+module.exports = openAICall;

--- a/ec-2/nextjs-chat-template/lib/getEmbeddings.cjs
+++ b/ec-2/nextjs-chat-template/lib/getEmbeddings.cjs
@@ -1,0 +1,22 @@
+const { OpenAI } = require("@arakoodev/edgechains.js/openai");
+const path = require("path");
+const Jsonnet = require("@arakoodev/jsonnet");
+
+const jsonnet = new Jsonnet();
+const secretsPath = path.join(__dirname, "../jsonnet/secrets.jsonnet");
+const openAIApiKey = JSON.parse(
+  jsonnet.evaluateFile(secretsPath),
+).openai_api_key;
+
+const llm = new OpenAI({ apiKey: openAIApiKey });
+
+function getEmbeddings() {
+  return (content) => {
+    const embeddings = llm.generateEmbeddings(content).then((res) => {
+      return JSON.stringify(res);
+    });
+    return embeddings;
+  };
+}
+
+module.exports = getEmbeddings;

--- a/ec-2/nextjs-chat-template/lib/getQueryMatch.cjs
+++ b/ec-2/nextjs-chat-template/lib/getQueryMatch.cjs
@@ -1,0 +1,36 @@
+const path = require("path");
+const Jsonnet = require("@arakoodev/jsonnet");
+const { Supabase } = require("@arakoodev/edgechains.js/vector-db");
+
+const secretsPath = path.join(__dirname, "../jsonnet/secrets.jsonnet");
+const jsonnet = new Jsonnet();
+const secretsLoader = jsonnet.evaluateFile(secretsPath);
+const supabaseApiKey = JSON.parse(secretsLoader).supabase_api_key;
+const supabaseUrl = JSON.parse(secretsLoader).supabase_url;
+
+const supabase = new Supabase(supabaseUrl, supabaseApiKey);
+const client = supabase.createClient();
+
+function getQueryMatch() {
+  return function (embeddings) {
+    const response = supabase
+      .getDataFromQuery({
+        client,
+        functionNameToCall: "match_documents",
+        query_embedding: JSON.parse(embeddings)[0].embedding,
+        similarity_threshold: 0.5,
+        match_count: 1,
+      })
+      .then((response) => {
+        const contentArr = [];
+        for (let i = 0; i < response?.length; i++) {
+          const element = response[i];
+          contentArr.push(element.content);
+        }
+        return contentArr.join(" ");
+      });
+    return response;
+  };
+}
+
+module.exports = getQueryMatch;

--- a/ec-2/nextjs-chat-template/next-env.d.ts
+++ b/ec-2/nextjs-chat-template/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/ec-2/nextjs-chat-template/next.config.mjs
+++ b/ec-2/nextjs-chat-template/next.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  experimental: {
+    serverActions: true,
+  },
+};

--- a/ec-2/nextjs-chat-template/package.json
+++ b/ec-2/nextjs-chat-template/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "nextjs-chat-template",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@arakoodev/edgechains.js": "^0.23.6",
+    "@arakoodev/jsonnet": "^0.23.6",
+    "zod": "^3.23.8",
+    "file-uri-to-path": "^2.0.0",
+    "sync-rpc": "^1.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.5.3"
+  },
+  "type": "module"
+}

--- a/ec-2/nextjs-chat-template/readme.md
+++ b/ec-2/nextjs-chat-template/readme.md
@@ -1,0 +1,18 @@
+# Next.js Chat Template
+
+This example demonstrates how to use EdgeChains with Next.js and React Server Components. The logic lives in `jsonnet/main.jsonnet` and JavaScript functions inside `lib/` are registered as Jsonnet callbacks.
+
+## Setup
+
+```bash
+cd ec-2/nextjs-chat-template
+npm install
+```
+
+Edit `jsonnet/secrets.jsonnet` with your API keys then run the development server:
+
+```bash
+npm run dev
+```
+
+Visit `http://localhost:3000` and ask a question.

--- a/ec-2/nextjs-chat-template/tests/jsonnet.test.ts
+++ b/ec-2/nextjs-chat-template/tests/jsonnet.test.ts
@@ -1,0 +1,14 @@
+import Jsonnet from "@arakoodev/jsonnet";
+import { describe, it, expect } from "vitest";
+
+describe("jsonnet", () => {
+  it("evaluates with callbacks", () => {
+    const jsonnet = new Jsonnet();
+    jsonnet.javascriptCallback(
+      "add",
+      (a: any, b: any) => Number(a) + Number(b),
+    );
+    const out = jsonnet.evaluateSnippet("arakoo.native('add')(1,2)");
+    expect(JSON.parse(out)).toBe("3");
+  });
+});

--- a/ec-2/nextjs-chat-template/tsconfig.json
+++ b/ec-2/nextjs-chat-template/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["jsonnet", "lib", "node_modules"]
+}

--- a/ec-2/nextjs-chat-template/vitest.config.ts
+++ b/ec-2/nextjs-chat-template/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "packages/template/*"],
+  },
+});


### PR DESCRIPTION
## Summary
- relocate `nextjs-chat-template` into new top-level `ec-2` folder
- update references in README and example README
- document in `AGENTS.md` that all future Next.js code belongs in `ec-2`
- setup Vitest for the template and add a minimal test
- run tests via new `ec2-tests.yml` GitHub Actions workflow
- format README and run the test suite
- remove large example.pdf and ignore it

## Testing
- `npm install` && `npm test -- --run` in `ec-2/nextjs-chat-template`


------
https://chatgpt.com/codex/tasks/task_e_68827b86dec483339e95ad5228fe6bc9