### PR TITLE
Add database-backed triggers and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,22 +111,22 @@ let result = jsonnet.javascriptCallback("addSomeNumber", addSomeNumber)
 
 The `ec-2/nexusflow` example separates workflow logic into two types of nodes:
 
-* **Action nodes** – BullMQ workers that execute tasks. They are stateless and
+- **Action nodes** – BullMQ workers that execute tasks. They are stateless and
   can run on any worker process. An example is `nodes/actions/log.ts`, which
   writes to the `action_logs` table when a job completes.
-* **Trigger nodes** – components that start workflows. They run in the server
+- **Trigger nodes** – components that start workflows. They run in the server
   process and use a `FlowProducer` to enqueue the first job in a workflow run.
   Two variants exist:
-  * **Webhook triggers** handle HTTP requests and immediately launch a workflow
+  - **Webhook triggers** handle HTTP requests and immediately launch a workflow
     (`nodes/triggers/webhook.ts`).
-  * **Polling triggers** run on a schedule, storing progress in the
+  - **Polling triggers** run on a schedule, storing progress in the
     `trigger_state` table so they only process new data
     (`nodes/triggers/polling.ts`).
-* Workflows are defined in PostgreSQL. `lib/workflow.ts` loads a definition,
+- Workflows are defined in PostgreSQL. `lib/workflow.ts` loads a definition,
   inserts a row in `workflow_runs`, and builds a job tree for BullMQ.
-* Integration tests under `ec-2/nexusflow/tests` bring up Redis and a
+- Integration tests under `ec-2/nexusflow/tests` bring up Redis and a
   `pg-mem` Postgres instance to verify both trigger types and action workers.
-* Node definitions live in PostgreSQL so new workflows can be added without
+- Node definitions live in PostgreSQL so new workflows can be added without
   changing the codebase. Triggers read their configuration from the database
   before enqueuing the first job, while action workers simply execute jobs that
   reference the stored definition.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,23 @@ let result = jsonnet.javascriptCallback("addSomeNumber", addSomeNumber)
 - Tests mock this helper but still rely on Redis for queue processing; without Redis the suite fails.
 - Run `mise deactivate` to silence warnings before git commands.
 - Future work should improve commit messages and documentation and flesh out the UI and workflow features in more depth.
+
+## NexusFlow Node Architecture
+
+The `ec-2/nexusflow` example separates workflow logic into two types of nodes:
+
+* **Action nodes** – BullMQ workers that execute tasks. They are stateless and
+  can run on any worker process. An example is `nodes/actions/log.ts`, which
+  writes to the `action_logs` table when a job completes.
+* **Trigger nodes** – components that start workflows. They run in the server
+  process and use a `FlowProducer` to enqueue the first job in a workflow run.
+  Two variants exist:
+  * **Webhook triggers** handle HTTP requests and immediately launch a workflow
+    (`nodes/triggers/webhook.ts`).
+  * **Polling triggers** run on a schedule, storing progress in the
+    `trigger_state` table so they only process new data
+    (`nodes/triggers/polling.ts`).
+* Workflows are defined in PostgreSQL. `lib/workflow.ts` loads a definition,
+  inserts a row in `workflow_runs`, and builds a job tree for BullMQ.
+* Integration tests under `ec-2/nexusflow/tests` bring up Redis and a
+  `pg-mem` Postgres instance to verify both trigger types and action workers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,7 @@ The `ec-2/nexusflow` example separates workflow logic into two types of nodes:
   inserts a row in `workflow_runs`, and builds a job tree for BullMQ.
 * Integration tests under `ec-2/nexusflow/tests` bring up Redis and a
   `pg-mem` Postgres instance to verify both trigger types and action workers.
+* Node definitions live in PostgreSQL so new workflows can be added without
+  changing the codebase. Triggers read their configuration from the database
+  before enqueuing the first job, while action workers simply execute jobs that
+  reference the stored definition.

--- a/ec-2/nexusflow/lib/workflow.ts
+++ b/ec-2/nexusflow/lib/workflow.ts
@@ -1,6 +1,6 @@
-import { flowProducer } from './queue';
-import { pool } from './db';
-import { v4 as uuidv4 } from 'uuid';
+import { flowProducer } from "./queue";
+import { pool } from "./db";
+import { v4 as uuidv4 } from "uuid";
 
 interface NodeDef {
   name: string;
@@ -21,16 +21,16 @@ export async function runWorkflow(
   producer = flowProducer,
 ) {
   const { rows } = await dbPool.query(
-    'SELECT definition FROM workflows WHERE id=$1',
+    "SELECT definition FROM workflows WHERE id=$1",
     [workflowId],
   );
-  if (rows.length === 0) throw new Error('workflow not found');
+  if (rows.length === 0) throw new Error("workflow not found");
   const def = rows[0].definition as WorkflowDef;
   const runId = uuidv4();
 
   await dbPool.query(
-    'INSERT INTO workflow_runs(id, workflow_id, status) VALUES ($1,$2,$3)',
-    [runId, workflowId, 'running'],
+    "INSERT INTO workflow_runs(id, workflow_id, status) VALUES ($1,$2,$3)",
+    [runId, workflowId, "running"],
   );
 
   const tree = buildTree(def.root, def.nodes, runId, rootData, def.root);

--- a/ec-2/nexusflow/lib/workflow.ts
+++ b/ec-2/nexusflow/lib/workflow.ts
@@ -14,24 +14,46 @@ interface WorkflowDef {
   nodes: Record<string, NodeDef>;
 }
 
-export async function runWorkflow(workflowId: string) {
-  const { rows } = await pool.query('SELECT definition FROM workflows WHERE id=$1', [workflowId]);
+export async function runWorkflow(
+  workflowId: string,
+  rootData: Record<string, any> = {},
+  dbPool = pool,
+  producer = flowProducer,
+) {
+  const { rows } = await dbPool.query(
+    'SELECT definition FROM workflows WHERE id=$1',
+    [workflowId],
+  );
   if (rows.length === 0) throw new Error('workflow not found');
   const def = rows[0].definition as WorkflowDef;
   const runId = uuidv4();
 
-  const tree = buildTree(def.root, def.nodes, runId);
-  const result = await flowProducer.add(tree);
+  await dbPool.query(
+    'INSERT INTO workflow_runs(id, workflow_id, status) VALUES ($1,$2,$3)',
+    [runId, workflowId, 'running'],
+  );
+
+  const tree = buildTree(def.root, def.nodes, runId, rootData, def.root);
+  const result = await producer.add(tree);
   return { runId, job: result.job };
 }
 
-function buildTree(id: string, nodes: Record<string, NodeDef>, runId: string): any {
+function buildTree(
+  id: string,
+  nodes: Record<string, NodeDef>,
+  runId: string,
+  rootData: Record<string, any>,
+  rootId: string,
+): any {
   const node = nodes[id];
   if (!node) throw new Error(`node ${id} missing`);
+  const extra = id === rootId ? rootData : {};
   return {
     name: node.name,
     queueName: node.queue,
-    data: { ...node.data, workflow_run_id: runId },
-    children: (node.children || []).map(child => buildTree(child, nodes, runId)),
+    data: { ...node.data, ...extra, workflow_run_id: runId },
+    children: (node.children || []).map((child) =>
+      buildTree(child, nodes, runId, rootData, rootId),
+    ),
   };
 }

--- a/ec-2/nexusflow/migrations/005_trigger_state.sql
+++ b/ec-2/nexusflow/migrations/005_trigger_state.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS trigger_state (
+  workflow_id UUID PRIMARY KEY,
+  state JSONB,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/ec-2/nexusflow/migrations/006_action_logs.sql
+++ b/ec-2/nexusflow/migrations/006_action_logs.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS action_logs (
+  id SERIAL PRIMARY KEY,
+  workflow_run_id UUID,
+  message TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/ec-2/nexusflow/nodes/actions/log.ts
+++ b/ec-2/nexusflow/nodes/actions/log.ts
@@ -1,0 +1,28 @@
+import { Worker } from "bullmq";
+import { Redis } from "ioredis";
+import { withJobClient } from "../../lib/db";
+
+const defaultConnection = new Redis(
+  process.env.REDIS_URL ?? "redis://localhost:6379",
+  {
+    maxRetriesPerRequest: null,
+  },
+);
+
+export function startLogWorker(conn: Redis = defaultConnection) {
+  return new Worker(
+    "log",
+    async (job) => {
+      const { workflow_run_id, message } = job.data;
+      if (!workflow_run_id) throw new Error("missing workflow_run_id");
+      await withJobClient(workflow_run_id, async (client) => {
+        await client.query(
+          "INSERT INTO action_logs (workflow_run_id, message) VALUES ($1, $2)",
+          [workflow_run_id, message],
+        );
+      });
+      return { logged: true };
+    },
+    { connection: conn },
+  );
+}

--- a/ec-2/nexusflow/nodes/triggers/polling.ts
+++ b/ec-2/nexusflow/nodes/triggers/polling.ts
@@ -1,0 +1,32 @@
+import { FlowProducer } from "bullmq";
+import { Pool } from "pg";
+import { runWorkflow } from "../../lib/workflow";
+
+export class CounterPollingTrigger {
+  constructor(
+    private pool: Pool,
+    private producer: FlowProducer,
+    private workflowId: string,
+  ) {}
+
+  async poll() {
+    const res = await this.pool.query(
+      "SELECT state FROM trigger_state WHERE workflow_id=$1",
+      [this.workflowId],
+    );
+    const prev = res.rows[0]?.state?.count ?? 0;
+    const count = prev + 1;
+    await this.pool.query(
+      `INSERT INTO trigger_state (workflow_id, state) VALUES ($1, $2)
+       ON CONFLICT (workflow_id) DO UPDATE SET state = EXCLUDED.state`,
+      [this.workflowId, { count }],
+    );
+    await runWorkflow(
+      this.workflowId,
+      { message: `count:${count}` },
+      this.pool,
+      this.producer,
+    );
+    return count;
+  }
+}

--- a/ec-2/nexusflow/nodes/triggers/webhook.ts
+++ b/ec-2/nexusflow/nodes/triggers/webhook.ts
@@ -1,0 +1,21 @@
+import { FlowProducer } from "bullmq";
+import { Pool } from "pg";
+import { runWorkflow } from "../../lib/workflow";
+
+export class SimpleWebhookTrigger {
+  constructor(
+    private pool: Pool,
+    private producer: FlowProducer,
+    private workflowId: string,
+  ) {}
+
+  async webhook(message: string) {
+    const { runId } = await runWorkflow(
+      this.workflowId,
+      { message },
+      this.pool,
+      this.producer,
+    );
+    return runId;
+  }
+}

--- a/ec-2/nexusflow/tests/merge.test.ts
+++ b/ec-2/nexusflow/tests/merge.test.ts
@@ -24,6 +24,15 @@ vi.mock("../lib/queue", () => ({
 
 function startRedis() {
   execSync("redis-server --save '' --appendonly no --daemonize yes");
+  for (let i = 0; i < 50; i++) {
+    try {
+      execSync("redis-cli ping");
+      return;
+    } catch {
+      execSync("sleep 0.1");
+    }
+  }
+  throw new Error("redis failed to start");
 }
 
 function stopRedis() {
@@ -95,9 +104,9 @@ describe("merge workflow", () => {
   });
 
   afterAll(async () => {
-    await queueEvents.close();
-    await flowProducer.close();
-    await connection.quit();
+    if (queueEvents) await queueEvents.close();
+    if (flowProducer) await flowProducer.close();
+    if (connection) await connection.quit();
     stopRedis();
   });
 

--- a/ec-2/nexusflow/tests/merge.test.ts
+++ b/ec-2/nexusflow/tests/merge.test.ts
@@ -4,7 +4,6 @@ import { v4 as uuidv4 } from "uuid";
 import { vi } from "vitest";
 import { readFile } from "fs/promises";
 import Redis from "ioredis";
-import { execSync } from "child_process";
 import { runWorkflow } from "../lib/workflow";
 let pool: any;
 let flowProducer: any;
@@ -22,31 +21,11 @@ vi.mock("../lib/queue", () => ({
   },
 }));
 
-function startRedis() {
-  execSync("redis-server --save '' --appendonly no --daemonize yes");
-  for (let i = 0; i < 50; i++) {
-    try {
-      execSync("redis-cli ping");
-      return;
-    } catch {
-      execSync("sleep 0.1");
-    }
-  }
-  throw new Error("redis failed to start");
-}
-
-function stopRedis() {
-  try {
-    execSync("redis-cli shutdown");
-  } catch {}
-}
-
 describe("merge workflow", () => {
   let queueEvents: any;
   let connection: any;
 
   beforeAll(async () => {
-    startRedis();
     const db = newDb();
     db.registerLanguage("plpgsql", () => {});
     db.public.registerFunction({
@@ -107,13 +86,14 @@ describe("merge workflow", () => {
     if (queueEvents) await queueEvents.close();
     if (flowProducer) await flowProducer.close();
     if (connection) await connection.quit();
-    stopRedis();
   });
 
   afterEach(async () => {
     await pool.query("TRUNCATE workflows RESTART IDENTITY CASCADE");
     await pool.query("TRUNCATE workflow_runs RESTART IDENTITY CASCADE");
-    await pool.query("TRUNCATE workflow_merge_staging RESTART IDENTITY CASCADE");
+    await pool.query(
+      "TRUNCATE workflow_merge_staging RESTART IDENTITY CASCADE",
+    );
     await connection.flushall();
   });
 

--- a/ec-2/nexusflow/tests/merge.test.ts
+++ b/ec-2/nexusflow/tests/merge.test.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import { vi } from "vitest";
 import { readFile } from "fs/promises";
 import Redis from "ioredis";
+import { execSync } from "child_process";
 import { runWorkflow } from "../lib/workflow";
 let pool: any;
 let flowProducer: any;
@@ -21,11 +22,22 @@ vi.mock("../lib/queue", () => ({
   },
 }));
 
+function startRedis() {
+  execSync("redis-server --save '' --appendonly no --daemonize yes");
+}
+
+function stopRedis() {
+  try {
+    execSync("redis-cli shutdown");
+  } catch {}
+}
+
 describe("merge workflow", () => {
   let queueEvents: any;
   let connection: any;
 
   beforeAll(async () => {
+    startRedis();
     const db = newDb();
     db.registerLanguage("plpgsql", () => {});
     db.public.registerFunction({
@@ -86,6 +98,7 @@ describe("merge workflow", () => {
     await queueEvents.close();
     await flowProducer.close();
     await connection.quit();
+    stopRedis();
   });
 
   afterEach(async () => {

--- a/ec-2/nexusflow/tests/nodes.test.ts
+++ b/ec-2/nexusflow/tests/nodes.test.ts
@@ -1,9 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  vi,
+} from "vitest";
 import { newDb } from "pg-mem";
 import { readFile } from "fs/promises";
 import { v4 as uuidv4 } from "uuid";
 import Redis from "ioredis";
-import { execSync } from "child_process";
 
 import { SimpleWebhookTrigger } from "../nodes/triggers/webhook";
 import { CounterPollingTrigger } from "../nodes/triggers/polling";
@@ -30,28 +37,8 @@ let flowProducer: any;
 let queueEvents: any;
 let worker: any;
 
-function startRedis() {
-  execSync("redis-server --save '' --appendonly no --daemonize yes");
-  for (let i = 0; i < 50; i++) {
-    try {
-      execSync("redis-cli ping");
-      return;
-    } catch {
-      execSync("sleep 0.1");
-    }
-  }
-  throw new Error("redis failed to start");
-}
-function stopRedis() {
-  try {
-    execSync("redis-cli shutdown");
-  } catch {}
-}
-
 describe("action and trigger nodes", () => {
   beforeAll(async () => {
-    startRedis();
-
     const db = newDb();
     db.registerLanguage("plpgsql", () => {});
     db.public.registerFunction({
@@ -90,7 +77,6 @@ describe("action and trigger nodes", () => {
     if (queueEvents) await queueEvents.close();
     if (flowProducer) await flowProducer.close();
     if (connection) await connection.quit();
-    stopRedis();
   });
 
   afterEach(async () => {

--- a/ec-2/nexusflow/tests/nodes.test.ts
+++ b/ec-2/nexusflow/tests/nodes.test.ts
@@ -32,6 +32,15 @@ let worker: any;
 
 function startRedis() {
   execSync("redis-server --save '' --appendonly no --daemonize yes");
+  for (let i = 0; i < 50; i++) {
+    try {
+      execSync("redis-cli ping");
+      return;
+    } catch {
+      execSync("sleep 0.1");
+    }
+  }
+  throw new Error("redis failed to start");
 }
 function stopRedis() {
   try {
@@ -77,10 +86,10 @@ describe("action and trigger nodes", () => {
   });
 
   afterAll(async () => {
-    await worker.close();
-    await queueEvents.close();
-    await flowProducer.close();
-    await connection.quit();
+    if (worker) await worker.close();
+    if (queueEvents) await queueEvents.close();
+    if (flowProducer) await flowProducer.close();
+    if (connection) await connection.quit();
     stopRedis();
   });
 

--- a/ec-2/nexusflow/tests/nodes.test.ts
+++ b/ec-2/nexusflow/tests/nodes.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
+import { newDb } from "pg-mem";
+import { readFile } from "fs/promises";
+import { v4 as uuidv4 } from "uuid";
+import Redis from "ioredis";
+import { execSync } from "child_process";
+
+import { SimpleWebhookTrigger } from "../nodes/triggers/webhook";
+import { CounterPollingTrigger } from "../nodes/triggers/polling";
+import { startLogWorker } from "../nodes/actions/log";
+
+vi.mock("../lib/db", () => ({
+  get pool() {
+    return pool;
+  },
+  async withJobClient(_jobId: string, fn: (client: any) => Promise<any>) {
+    return fn(pool);
+  },
+}));
+
+vi.mock("../lib/queue", () => ({
+  get flowProducer() {
+    return flowProducer;
+  },
+}));
+
+let pool: any;
+let connection: any;
+let flowProducer: any;
+let queueEvents: any;
+let worker: any;
+
+function startRedis() {
+  execSync("redis-server --save '' --appendonly no --daemonize yes");
+}
+function stopRedis() {
+  try {
+    execSync("redis-cli shutdown");
+  } catch {}
+}
+
+describe("action and trigger nodes", () => {
+  beforeAll(async () => {
+    startRedis();
+
+    const db = newDb();
+    db.registerLanguage("plpgsql", () => {});
+    db.public.registerFunction({
+      name: "gen_random_uuid",
+      returns: "text",
+      implementation: uuidv4,
+    });
+    const pg = db.adapters.createPg();
+    pool = new pg.Pool();
+
+    const migrationFiles = [
+      "001_init.sql",
+      "002_runs_and_merge.sql",
+      "005_trigger_state.sql",
+      "006_action_logs.sql",
+    ];
+    for (const file of migrationFiles) {
+      const sql = await readFile(
+        new URL(`../migrations/${file}`, import.meta.url),
+        "utf8",
+      );
+      await pool.query(sql);
+    }
+
+    const { FlowProducer, QueueEvents } = await import("bullmq");
+    connection = new Redis({ maxRetriesPerRequest: null });
+    flowProducer = new FlowProducer({ connection });
+    queueEvents = new QueueEvents("log", { connection });
+    await queueEvents.waitUntilReady();
+
+    worker = startLogWorker(connection);
+  });
+
+  afterAll(async () => {
+    await worker.close();
+    await queueEvents.close();
+    await flowProducer.close();
+    await connection.quit();
+    stopRedis();
+  });
+
+  afterEach(async () => {
+    await pool.query("TRUNCATE workflows RESTART IDENTITY CASCADE");
+    await pool.query("TRUNCATE workflow_runs RESTART IDENTITY CASCADE");
+    await pool.query("TRUNCATE trigger_state RESTART IDENTITY CASCADE");
+    await pool.query("TRUNCATE action_logs RESTART IDENTITY CASCADE");
+    await connection.flushall();
+  });
+
+  it("webhook trigger starts workflow and logs message", async () => {
+    const wfDef = {
+      root: "log",
+      nodes: {
+        log: { name: "log", queue: "log" },
+      },
+    };
+    const { rows: wfRows } = await pool.query(
+      "INSERT INTO workflows(name, definition) VALUES($1,$2) RETURNING id",
+      ["wf", wfDef],
+    );
+    const workflowId = wfRows[0].id;
+    const trigger = new SimpleWebhookTrigger(pool, flowProducer, workflowId);
+    await trigger.webhook("hello");
+
+    await new Promise((resolve) => {
+      queueEvents.on("completed", () => resolve(null));
+    });
+
+    const { rows: logRows } = await pool.query(
+      "SELECT message FROM action_logs",
+    );
+    expect(logRows[0].message).toBe("hello");
+  });
+
+  it("polling trigger increments state", async () => {
+    const wfDef = {
+      root: "log",
+      nodes: {
+        log: { name: "log", queue: "log" },
+      },
+    };
+    const { rows: wfRows } = await pool.query(
+      "INSERT INTO workflows(name, definition) VALUES($1,$2) RETURNING id",
+      ["wf", wfDef],
+    );
+    const workflowId = wfRows[0].id;
+    const trigger = new CounterPollingTrigger(pool, flowProducer, workflowId);
+    await trigger.poll();
+    await new Promise((resolve) => {
+      queueEvents.on("completed", () => resolve(null));
+    });
+
+    const { rows: stateRows } = await pool.query(
+      "SELECT state FROM trigger_state WHERE workflow_id=$1",
+      [workflowId],
+    );
+    expect(stateRows[0].state.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `runWorkflow` with root data overrides and job insertion
- update webhook and polling triggers to use DB workflows
- insert workflow definitions in trigger tests
- manage Redis for merge workflow tests

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_688773b8ab2083338dfee1d8e7dbbe70