### PR TITLE
feat: complete Gemini API support with types, tests, and jsonnet example

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
@@ -1,97 +1,175 @@
 import axios from "axios";
 import { retry } from "@lifeomic/attempt";
-const url = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
 
-interface GeminiAIConstructionOptions {
-    apiKey?: string;
+const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1/models";
+
+type HarmCategory =
+    | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
+    | "HARM_CATEGORY_HATE_SPEECH"
+    | "HARM_CATEGORY_HARASSMENT"
+    | "HARM_CATEGORY_DANGEROUS_CONTENT";
+
+type HarmProbability = "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
+
+type HarmBlockThreshold =
+    | "HARM_BLOCK_THRESHOLD_UNSPECIFIED"
+    | "BLOCK_LOW_AND_ABOVE"
+    | "BLOCK_MEDIUM_AND_ABOVE"
+    | "BLOCK_ONLY_HIGH"
+    | "BLOCK_NONE";
+
+export type GeminiModel =
+    | "gemini-pro"
+    | "gemini-1.5-pro"
+    | "gemini-1.5-flash"
+    | "gemini-2.0-flash";
+
+export type GeminiRole = "user" | "model";
+
+export type ResponseMimeType = "text/plain" | "application/json";
+
+export interface GeminiSafetyRating {
+    category: HarmCategory;
+    probability: HarmProbability;
 }
 
-type SafetyRating = {
-    category:
-        | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
-        | "HARM_CATEGORY_HATE_SPEECH"
-        | "HARM_CATEGORY_HARASSMENT"
-        | "HARM_CATEGORY_DANGEROUS_CONTENT";
-    probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
-};
+export interface GeminiSafetySetting {
+    category: HarmCategory;
+    threshold: HarmBlockThreshold;
+}
 
-type ContentPart = {
+export interface GeminiContentPart {
     text: string;
-};
+}
 
-type Content = {
-    parts: ContentPart[];
-    role: string;
-};
+export interface GeminiContent {
+    parts: GeminiContentPart[];
+    role: GeminiRole;
+}
 
-type Candidate = {
-    content: Content;
+export interface GeminiCandidate {
+    content: GeminiContent;
     finishReason: string;
     index: number;
-    safetyRatings: SafetyRating[];
-};
+    safetyRatings: GeminiSafetyRating[];
+}
 
-type UsageMetadata = {
+export interface GeminiUsageMetadata {
     promptTokenCount: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
-};
+}
 
-type Response = {
-    candidates: Candidate[];
-    usageMetadata: UsageMetadata;
-};
+export interface GeminiResponse {
+    candidates: GeminiCandidate[];
+    usageMetadata: GeminiUsageMetadata;
+}
 
-type responseMimeType = "text/plain" | "application/json";
+export interface GeminiConstructionOptions {
+    apiKey?: string;
+}
 
-interface GeminiAIChatOptions {
-    model?: string;
+export interface GeminiMessageOption {
+    role: GeminiRole;
+    content: string;
+}
+
+export interface GeminiChatOptions {
+    model?: GeminiModel;
     max_output_tokens?: number;
     temperature?: number;
-    prompt: string;
+    prompt?: string;
+    messages?: GeminiMessageOption[];
     max_retry?: number;
-    responseType?: responseMimeType;
+    responseType?: ResponseMimeType;
     delay?: number;
+    topP?: number;
+    topK?: number;
+    safetySettings?: GeminiSafetySetting[];
+}
+
+export interface GeminiChatReturnOptions {
+    content: string;
 }
 
 export class GeminiAI {
     apiKey: string;
-    constructor(options: GeminiAIConstructionOptions) {
+
+    constructor(options: GeminiConstructionOptions) {
         this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
+        if (!this.apiKey) {
+            console.error(
+                "API key is missing. Please provide a valid Gemini API key. You can add it in .env file as GEMINI_API_KEY"
+            );
+        }
     }
 
-    async chat(chatOptions: GeminiAIChatOptions): Promise<Response> {
-        let data = JSON.stringify({
-            contents: [
-                {
-                    role: "user",
-                    parts: [
-                        {
-                            text: chatOptions.prompt,
-                        },
-                    ],
-                },
-            ],
-        });
+    private buildContents(chatOptions: GeminiChatOptions): GeminiContent[] {
+        if (chatOptions.messages && chatOptions.messages.length > 0) {
+            return chatOptions.messages.map((msg) => ({
+                role: msg.role,
+                parts: [{ text: msg.content }],
+            }));
+        }
+        return [
+            {
+                role: "user",
+                parts: [{ text: chatOptions.prompt || "" }],
+            },
+        ];
+    }
 
-        let config = {
-            method: "post",
+    async chat(chatOptions: GeminiChatOptions): Promise<GeminiResponse> {
+        const model = chatOptions.model || "gemini-pro";
+        const url = `${GEMINI_BASE_URL}/${model}:generateContent`;
+
+        const requestBody: Record<string, any> = {
+            contents: this.buildContents(chatOptions),
+            generationConfig: {
+                temperature: chatOptions.temperature ?? 0.7,
+                maxOutputTokens: chatOptions.max_output_tokens ?? 1024,
+                responseMimeType: chatOptions.responseType || "text/plain",
+            },
+        };
+
+        if (chatOptions.topP !== undefined) {
+            requestBody.generationConfig.topP = chatOptions.topP;
+        }
+        if (chatOptions.topK !== undefined) {
+            requestBody.generationConfig.topK = chatOptions.topK;
+        }
+        if (chatOptions.safetySettings) {
+            requestBody.safetySettings = chatOptions.safetySettings;
+        }
+
+        const config = {
+            method: "post" as const,
             maxBodyLength: Infinity,
             url,
             headers: {
                 "Content-Type": "application/json",
                 "x-goog-api-key": this.apiKey,
             },
-            temperature: chatOptions.temperature || "0.7",
-            responseMimeType: chatOptions.responseType || "text/plain",
-            max_output_tokens: chatOptions.max_output_tokens || 1024,
-            data: data,
+            data: JSON.stringify(requestBody),
         };
+
         return await retry(
             async () => {
                 return (await axios.request(config)).data;
             },
-            { maxAttempts: chatOptions.max_retry || 3, delay: chatOptions.delay || 200 }
+            {
+                maxAttempts: chatOptions.max_retry || 3,
+                delay: chatOptions.delay || 200,
+            }
         );
+    }
+
+    async chatText(chatOptions: GeminiChatOptions): Promise<GeminiChatReturnOptions> {
+        const response = await this.chat(chatOptions);
+        const content =
+            response.candidates?.[0]?.content?.parts
+                ?.map((part) => part.text)
+                .join("") || "";
+        return { content };
     }
 }

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/geminiEndpoints.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/geminiEndpoints.test.ts
@@ -1,0 +1,255 @@
+import axios from "axios";
+import { GeminiAI } from "../../lib/gemini/gemini";
+
+jest.mock("axios");
+
+const mockGeminiResponse = {
+    candidates: [
+        {
+            content: {
+                parts: [{ text: "Hello! How can I help you today?" }],
+                role: "model",
+            },
+            finishReason: "STOP",
+            index: 0,
+            safetyRatings: [
+                {
+                    category: "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                    probability: "NEGLIGIBLE",
+                },
+                {
+                    category: "HARM_CATEGORY_HATE_SPEECH",
+                    probability: "NEGLIGIBLE",
+                },
+                {
+                    category: "HARM_CATEGORY_HARASSMENT",
+                    probability: "NEGLIGIBLE",
+                },
+                {
+                    category: "HARM_CATEGORY_DANGEROUS_CONTENT",
+                    probability: "NEGLIGIBLE",
+                },
+            ],
+        },
+    ],
+    usageMetadata: {
+        promptTokenCount: 4,
+        candidatesTokenCount: 10,
+        totalTokenCount: 14,
+    },
+};
+
+describe("GeminiAI", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("constructor", () => {
+        test("should initialize with provided API key", () => {
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            expect(gemini.apiKey).toBe("test_api_key");
+        });
+
+        test("should fall back to environment variable", () => {
+            process.env.GEMINI_API_KEY = "env_api_key";
+            const gemini = new GeminiAI({});
+            expect(gemini.apiKey).toBe("env_api_key");
+            delete process.env.GEMINI_API_KEY;
+        });
+
+        test("should warn when no API key is provided", () => {
+            const spy = jest.spyOn(console, "error").mockImplementation();
+            delete process.env.GEMINI_API_KEY;
+            new GeminiAI({});
+            expect(spy).toHaveBeenCalledWith(
+                expect.stringContaining("API key is missing")
+            );
+            spy.mockRestore();
+        });
+    });
+
+    describe("chat", () => {
+        test("should generate response with a simple prompt", async () => {
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: mockGeminiResponse,
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            const response = await gemini.chat({ prompt: "Hello" });
+
+            expect(response).toEqual(mockGeminiResponse);
+            expect(response.candidates[0].content.parts[0].text).toBe(
+                "Hello! How can I help you today?"
+            );
+            expect(axios.request).toHaveBeenCalledTimes(1);
+
+            const callArgs = (axios.request as jest.Mock).mock.calls[0][0];
+            expect(callArgs.url).toContain("gemini-pro:generateContent");
+            expect(callArgs.headers["x-goog-api-key"]).toBe("test_api_key");
+
+            const body = JSON.parse(callArgs.data);
+            expect(body.contents[0].role).toBe("user");
+            expect(body.contents[0].parts[0].text).toBe("Hello");
+        });
+
+        test("should use a custom model", async () => {
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: mockGeminiResponse,
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            await gemini.chat({ prompt: "Hello", model: "gemini-1.5-flash" });
+
+            const callArgs = (axios.request as jest.Mock).mock.calls[0][0];
+            expect(callArgs.url).toContain("gemini-1.5-flash:generateContent");
+        });
+
+        test("should pass generation config parameters", async () => {
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: mockGeminiResponse,
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            await gemini.chat({
+                prompt: "Hello",
+                temperature: 0.9,
+                max_output_tokens: 2048,
+                topP: 0.95,
+                topK: 40,
+                responseType: "application/json",
+            });
+
+            const callArgs = (axios.request as jest.Mock).mock.calls[0][0];
+            const body = JSON.parse(callArgs.data);
+            expect(body.generationConfig.temperature).toBe(0.9);
+            expect(body.generationConfig.maxOutputTokens).toBe(2048);
+            expect(body.generationConfig.topP).toBe(0.95);
+            expect(body.generationConfig.topK).toBe(40);
+            expect(body.generationConfig.responseMimeType).toBe("application/json");
+        });
+
+        test("should support multi-turn conversation with messages", async () => {
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: mockGeminiResponse,
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            await gemini.chat({
+                messages: [
+                    { role: "user", content: "What is TypeScript?" },
+                    {
+                        role: "model",
+                        content: "TypeScript is a typed superset of JavaScript.",
+                    },
+                    { role: "user", content: "What are its benefits?" },
+                ],
+            });
+
+            const callArgs = (axios.request as jest.Mock).mock.calls[0][0];
+            const body = JSON.parse(callArgs.data);
+            expect(body.contents).toHaveLength(3);
+            expect(body.contents[0].role).toBe("user");
+            expect(body.contents[1].role).toBe("model");
+            expect(body.contents[2].role).toBe("user");
+        });
+
+        test("should pass safety settings", async () => {
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: mockGeminiResponse,
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            await gemini.chat({
+                prompt: "Hello",
+                safetySettings: [
+                    {
+                        category: "HARM_CATEGORY_HARASSMENT",
+                        threshold: "BLOCK_ONLY_HIGH",
+                    },
+                ],
+            });
+
+            const callArgs = (axios.request as jest.Mock).mock.calls[0][0];
+            const body = JSON.parse(callArgs.data);
+            expect(body.safetySettings).toEqual([
+                {
+                    category: "HARM_CATEGORY_HARASSMENT",
+                    threshold: "BLOCK_ONLY_HIGH",
+                },
+            ]);
+        });
+
+        test("should retry on failure", async () => {
+            (axios.request as jest.Mock)
+                .mockRejectedValueOnce(new Error("Network error"))
+                .mockResolvedValueOnce({ data: mockGeminiResponse });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            const response = await gemini.chat({
+                prompt: "Hello",
+                max_retry: 3,
+                delay: 10,
+            });
+
+            expect(response).toEqual(mockGeminiResponse);
+            expect(axios.request).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("chatText", () => {
+        test("should return text content from response", async () => {
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: mockGeminiResponse,
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            const result = await gemini.chatText({ prompt: "Hello" });
+
+            expect(result.content).toBe("Hello! How can I help you today?");
+        });
+
+        test("should return empty string when no candidates", async () => {
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: { candidates: [], usageMetadata: {} },
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            const result = await gemini.chatText({ prompt: "Hello" });
+
+            expect(result.content).toBe("");
+        });
+
+        test("should concatenate multiple parts", async () => {
+            const multiPartResponse = {
+                candidates: [
+                    {
+                        content: {
+                            parts: [
+                                { text: "Part 1. " },
+                                { text: "Part 2." },
+                            ],
+                            role: "model",
+                        },
+                        finishReason: "STOP",
+                        index: 0,
+                        safetyRatings: [],
+                    },
+                ],
+                usageMetadata: {
+                    promptTokenCount: 4,
+                    candidatesTokenCount: 6,
+                    totalTokenCount: 10,
+                },
+            };
+
+            (axios.request as jest.Mock).mockResolvedValueOnce({
+                data: multiPartResponse,
+            });
+
+            const gemini = new GeminiAI({ apiKey: "test_api_key" });
+            const result = await gemini.chatText({ prompt: "Hello" });
+
+            expect(result.content).toBe("Part 1. Part 2.");
+        });
+    });
+});

--- a/JS/edgechains/arakoodev/src/ai/src/types/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/types/index.ts
@@ -22,3 +22,20 @@ export type ChatModel =
     | "gpt-3.5-turbo-16k-0613";
 
 export type role = "user" | "assistant" | "system";
+
+export type {
+    GeminiModel,
+    GeminiRole,
+    ResponseMimeType,
+    GeminiSafetyRating,
+    GeminiSafetySetting,
+    GeminiContentPart,
+    GeminiContent,
+    GeminiCandidate,
+    GeminiUsageMetadata,
+    GeminiResponse,
+    GeminiConstructionOptions,
+    GeminiMessageOption,
+    GeminiChatOptions,
+    GeminiChatReturnOptions,
+} from "../lib/gemini/gemini.js";

--- a/JS/edgechains/examples/chat-with-gemini/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/chat-with-gemini/jsonnet/main.jsonnet
@@ -1,0 +1,15 @@
+local promptTemplate = |||
+  You are a helpful assistant powered by Google Gemini.
+  Answer the following question concisely and accurately: {question}
+|||;
+
+local key = std.extVar('gemini_api_key');
+local UserQuestion = std.extVar('question');
+
+local promptWithQuestion = std.strReplace(promptTemplate, '{question}', UserQuestion + '\n');
+
+local main() =
+  local response = arakoo.native('geminiCall')({ prompt: promptWithQuestion, geminiApiKey: key });
+  response;
+
+main()

--- a/JS/edgechains/examples/chat-with-gemini/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/chat-with-gemini/jsonnet/secrets.jsonnet
@@ -1,0 +1,6 @@
+
+local GEMINI_API_KEY = "your-gemini-api-key-here";
+
+{
+    "gemini_api_key": GEMINI_API_KEY,
+}

--- a/JS/edgechains/examples/chat-with-gemini/package.json
+++ b/JS/edgechains/examples/chat-with-gemini/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "chat-with-gemini",
+    "version": "1.0.0",
+    "description": "Example of using Gemini API with EdgeChains",
+    "main": "index.js",
+    "type": "module",
+    "keywords": [],
+    "author": "",
+    "scripts": {
+        "start": "tsc && node --experimental-wasm-modules ./dist/index.js"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0",
+        "path": "^0.12.7"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/chat-with-gemini/readme.md
+++ b/JS/edgechains/examples/chat-with-gemini/readme.md
@@ -1,0 +1,43 @@
+# Chat with Gemini Example
+
+## Installation
+
+1. Install the required dependencies:
+
+    ```bash
+    npm install
+    ```
+
+## Configuration
+
+1. Add your Gemini API key in `jsonnet/secrets.jsonnet`:
+
+    ```jsonnet
+    local GEMINI_API_KEY = "your-gemini-api-key-here";
+    ```
+
+   You can get a free API key from [Google AI Studio](https://aistudio.google.com/apikey).
+
+## Usage
+
+1. Start the server:
+
+    ```bash
+    npm run start
+    ```
+
+2. Hit the `POST` endpoint at `http://localhost:3000/chat`:
+
+    ```bash
+    curl -X POST http://localhost:3000/chat \
+      -H "Content-Type: application/json" \
+      -d '{"question": "What is EdgeChains?"}'
+    ```
+
+    Request body:
+
+    ```json
+    {
+        "question": "What is EdgeChains?"
+    }
+    ```

--- a/JS/edgechains/examples/chat-with-gemini/src/index.ts
+++ b/JS/edgechains/examples/chat-with-gemini/src/index.ts
@@ -1,0 +1,33 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+const server = new ArakooServer();
+
+const app = server.createApp();
+
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const geminiCall = createSyncRPC(path.join(__dirname, "./lib/generateResponse.cjs"));
+
+app.post("/chat", async (c: any) => {
+    try {
+        const { question } = await c.req.json();
+        const key = JSON.parse(
+            jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet"))
+        ).gemini_api_key;
+        jsonnet.extString("gemini_api_key", key);
+        jsonnet.extString("question", question || "");
+        jsonnet.javascriptCallback("geminiCall", geminiCall);
+        let response = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+        return c.json(JSON.parse(response));
+    } catch (error) {
+        console.log("error occurred", error);
+    }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/chat-with-gemini/src/lib/generateResponse.cts
+++ b/JS/edgechains/examples/chat-with-gemini/src/lib/generateResponse.cts
@@ -1,0 +1,13 @@
+const { GeminiAI } = require("@arakoodev/edgechains.js/ai");
+
+async function geminiCall({ prompt, geminiApiKey }: any) {
+    try {
+        const gemini = new GeminiAI({ apiKey: geminiApiKey });
+        let res = await gemini.chatText({ prompt });
+        return JSON.stringify(res);
+    } catch (error) {
+        return error;
+    }
+}
+
+module.exports = geminiCall;


### PR DESCRIPTION
## Summary

Completes the Gemini (Palm2 replacement) API support for the JS SDK as requested in #279.

/claim #279

### What's done

**1. Enhanced GeminiAI class** (`src/ai/src/lib/gemini/gemini.ts`)
- Multi-turn conversation support via `messages` parameter (array of `{role, content}`)
- Proper `generationConfig` with `temperature`, `maxOutputTokens`, `topP`, `topK`, `responseMimeType`
- Safety settings support (`safetySettings` array)
- New `chatText()` convenience method that extracts text content directly
- Full TypeScript types for all request/response shapes

**2. Exported TypeScript types** (`src/ai/src/types/index.ts`)
- All Gemini types re-exported: `GeminiModel`, `GeminiRole`, `GeminiResponse`, `GeminiChatOptions`, etc.

**3. Unit tests in `testcases/palm2` folder** (`src/ai/src/tests/palm2/geminiEndpoints.test.ts`)
- Constructor tests (API key from param, env var, missing key warning)
- Chat tests: simple prompt, custom model, generation config params, multi-turn messages, safety settings, retry on failure
- ChatText tests: text extraction, empty candidates, multi-part concatenation
- Uses mocked axios (same pattern as OpenAI tests)

**4. Jsonnet example** (`examples/chat-with-gemini/`)
- Prompts defined in `jsonnet/main.jsonnet` (not hardcoded)
- API key in `jsonnet/secrets.jsonnet`
- Hono server with `/chat` POST endpoint
- Follows same structure as `chat-with-llm` example

### Acceptance criteria from issue
- [x] Classes and TypeScript types for Gemini API
- [x] Unit testcases in testcases folder named "palm2"
- [x] Example with jsonnet prompts (not hardcoded)

### Implementation notes
- Uses native HTTP calls via axios (not Google's `@google/generative-ai` SDK), matching the existing OpenAI implementation pattern
- Gemini API replaces deprecated Palm2 as confirmed by maintainer @sandys
- Backward compatible: existing `GeminiAI.chat()` API preserved, new features are additive