### PR TITLE
Security: Reflected/stored XSS via unsanitized HTML interpolation in search results

### DIFF
--- a/JS/edgechains/lib/create-edgechains/__common/src/routes/hydeSearch.route.ts
+++ b/JS/edgechains/lib/create-edgechains/__common/src/routes/hydeSearch.route.ts
@@ -3,6 +3,14 @@ import { hydeSearchAdaEmbedding } from "../service/HydeSearchService.js";
 import { HydeFragmentData } from "../types/HydeFragmentData.js";
 const HydeSearchRouter = new Hono();
 
+const escapeHtml = (value: unknown) =>
+    String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+
 HydeSearchRouter.get("/search", async (c) => {
     const query = await c.req.query();
     const arkRequest = {
@@ -35,7 +43,7 @@ HydeSearchRouter.get("/search", async (c) => {
     <html lang="en">
     <div>
         <div class="card card-active">
-            <div class="card-body">${data.final_answer}</div>
+            <div class="card-body">${escapeHtml(data.final_answer)}</div>
         </div>
             <ul class="list-unstyled mb-0">
               ${data.responses.map(
@@ -45,22 +53,22 @@ HydeSearchRouter.get("/search", async (c) => {
                       <div class="card-body">
                         ${
                             item.rawText != null
-                                ? `<div class="card card-body">${item.rawText}</div>`
-                                : `<div class="card card-body">${item.metadata}</div>`
+                                ? `<div class="card card-body">${escapeHtml(item.rawText)}</div>`
+                                : `<div class="card card-body">${escapeHtml(item.metadata)}</div>`
                         }
                         ${
                             item.filename != null
-                                ? `<div class="card card-body" style="color: blue;">${item.filename}</div>`
+                                ? `<div class="card card-body" style="color: blue;">${escapeHtml(item.filename)}</div>`
                                 : ""
                         }
                         ${
                             item.titleMetadata != null
-                                ? `<div class="card card-body" style="color: blue;">${item.titleMetadata}</div>`
+                                ? `<div class="card card-body" style="color: blue;">${escapeHtml(item.titleMetadata)}</div>`
                                 : ""
                         }
                         ${
                             item.documentDate != null
-                                ? `<div class="card card-body" style="color: blue;">${item.documentDate}</div>`
+                                ? `<div class="card card-body" style="color: blue;">${escapeHtml(item.documentDate)}</div>`
                                 : ""
                         }
                       </div>


### PR DESCRIPTION
## Problem

User-controlled and model-controlled values are directly interpolated into HTML (`final_answer`, `rawText`, `metadata`, `filename`, `titleMetadata`, `documentDate`) and returned with `c.html(...)` without output encoding. An attacker can inject `<script>` or event-handler payloads through query inputs or upstream content and execute JavaScript in victim browsers.

**Severity**: `high`
**File**: `JS/edgechains/lib/create-edgechains/__common/src/routes/hydeSearch.route.ts`

## Solution

HTML-escape all dynamic fields before interpolation, or render using a templating system with auto-escaping. Additionally apply a strict CSP and avoid returning raw concatenated HTML strings.

## Changes

- `JS/edgechains/lib/create-edgechains/__common/src/routes/hydeSearch.route.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
