### PR TITLE
feat: add SmartRouter for unified LLM routing

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,4 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { SmartRouter } from "./lib/smart-router/smartRouter.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/smart-router/smartRouter.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/smart-router/smartRouter.ts
@@ -1,0 +1,263 @@
+/**
+ * SmartRouter - Unified LLM routing that auto-detects providers from model names.
+ *
+ * Works like LiteLLM: pass any model name and the router automatically
+ * selects the correct provider (OpenAI, Gemini, Llama, etc.)
+ */
+
+import { OpenAI } from "../openai/openai.js";
+import { GeminiAI } from "../gemini/gemini.js";
+import { LlamaAI } from "../llama/llama.js";
+
+// ─── Provider detection rules ───────────────────────────────────────────────
+
+interface ProviderConfig {
+    name: string;
+    patterns: RegExp[];
+    factory: (apiKey?: string) => SmartLLMProvider;
+}
+
+interface SmartLLMProvider {
+    chat(options: { model?: string; prompt: string; temperature?: number; max_tokens?: number }): Promise<{ content: string }>;
+}
+
+interface SmartRouterOptions {
+    openaiApiKey?: string;
+    geminiApiKey?: string;
+    llamaApiKey?: string;
+    /** Custom provider configs for extensibility */
+    providers?: ProviderConfig[];
+    /** Fallback order when model doesn't match any pattern */
+    fallbackOrder?: string[];
+}
+
+interface ChatOptions {
+    model?: string;
+    prompt: string;
+    temperature?: number;
+    max_tokens?: number;
+    messages?: Array<{ role: string; content: string }>;
+}
+
+interface ChatResponse {
+    content: string;
+    provider: string;
+    model: string;
+}
+
+// ─── Default provider patterns ──────────────────────────────────────────────
+
+const DEFAULT_PROVIDER_CONFIGS: Array<{
+    name: string;
+    patterns: RegExp[];
+}> = [
+    {
+        name: "openai",
+        patterns: [
+            /^gpt-/i,
+            /^o1-/i,
+            /^o3-/i,
+            /^chatgpt/i,
+            /^text-embedding/i,
+            /^dall-e/i,
+        ],
+    },
+    {
+        name: "gemini",
+        patterns: [
+            /^gemini/i,
+            /^palm/i,
+            /^bison/i,
+        ],
+    },
+    {
+        name: "llama",
+        patterns: [
+            /^llama/i,
+            /^meta-llama/i,
+            /^mixtral/i,
+            /^mistral/i,
+            /^qwen/i,
+            /^deepseek/i,
+        ],
+    },
+];
+
+// ─── SmartRouter ────────────────────────────────────────────────────────────
+
+export class SmartRouter {
+    private providers: Map<string, SmartLLMProvider> = new Map();
+    private configs: ProviderConfig[] = [];
+    private fallbackOrder: string[];
+
+    constructor(options: SmartRouterOptions = {}) {
+        // Register built-in providers
+        if (options.openaiApiKey || process.env.OPENAI_API_KEY) {
+            const openai = new OpenAI({ apiKey: options.openaiApiKey });
+            this.providers.set("openai", {
+                chat: (opts) =>
+                    openai.chat({
+                        model: opts.model as any,
+                        prompt: opts.prompt,
+                        temperature: opts.temperature,
+                        max_tokens: opts.max_tokens,
+                    }),
+            });
+        }
+
+        if (options.geminiApiKey || process.env.GEMINI_API_KEY) {
+            const gemini = new GeminiAI({ apiKey: options.geminiApiKey });
+            this.providers.set("gemini", {
+                chat: (opts) =>
+                    gemini.chat({
+                        model: opts.model,
+                        prompt: opts.prompt,
+                        temperature: opts.temperature,
+                        max_output_tokens: opts.max_tokens,
+                    }),
+            });
+        }
+
+        if (options.llamaApiKey || process.env.LLAMA_API_KEY) {
+            const llama = new LlamaAI({ apiKey: options.llamaApiKey });
+            this.providers.set("llama", {
+                chat: (opts) =>
+                    llama.chat({
+                        model: opts.model,
+                        prompt: opts.prompt,
+                        temperature: opts.temperature,
+                        max_tokens: opts.max_tokens,
+                    }),
+            });
+        }
+
+        // Register custom providers
+        if (options.providers) {
+            for (const p of options.providers) {
+                this.configs.push(p);
+            }
+        }
+
+        this.fallbackOrder = options.fallbackOrder || ["openai", "gemini", "llama"];
+    }
+
+    /**
+     * Detect which provider should handle the given model name.
+     */
+    detectProvider(model: string): string | null {
+        // Check custom configs first
+        for (const config of this.configs) {
+            for (const pattern of config.patterns) {
+                if (pattern.test(model)) {
+                    return config.name;
+                }
+            }
+        }
+
+        // Check built-in patterns
+        for (const config of DEFAULT_PROVIDER_CONFIGS) {
+            for (const pattern of config.patterns) {
+                if (pattern.test(model)) {
+                    return config.name;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Route a chat request to the appropriate provider.
+     * Auto-detects provider from model name if not specified.
+     */
+    async chat(options: ChatOptions): Promise<ChatResponse> {
+        const model = options.model || "gpt-4o";
+        let providerName = this.detectProvider(model);
+
+        // Fallback: try providers in order
+        if (!providerName || !this.providers.has(providerName)) {
+            for (const name of this.fallbackOrder) {
+                if (this.providers.has(name)) {
+                    providerName = name;
+                    break;
+                }
+            }
+        }
+
+        if (!providerName) {
+            throw new Error(
+                `SmartRouter: No provider available for model "${model}". ` +
+                `Available providers: ${Array.from(this.providers.keys()).join(", ") || "none"}`
+            );
+        }
+
+        const provider = this.providers.get(providerName)!;
+
+        try {
+            const response = await provider.chat({
+                model,
+                prompt: options.prompt,
+                temperature: options.temperature,
+                max_tokens: options.max_tokens,
+            });
+
+            return {
+                content: response.content,
+                provider: providerName,
+                model,
+            };
+        } catch (error) {
+            // Try fallback providers on failure
+            for (const fallbackName of this.fallbackOrder) {
+                if (fallbackName === providerName) continue;
+                const fallback = this.providers.get(fallbackName);
+                if (!fallback) continue;
+
+                try {
+                    const response = await fallback.chat({
+                        model,
+                        prompt: options.prompt,
+                        temperature: options.temperature,
+                        max_tokens: options.max_tokens,
+                    });
+
+                    return {
+                        content: response.content,
+                        provider: fallbackName,
+                        model,
+                    };
+                } catch {
+                    continue;
+                }
+            }
+
+            throw error;
+        }
+    }
+
+    /**
+     * List all registered providers and their status.
+     */
+    listProviders(): Array<{ name: string; available: boolean }> {
+        const allNames = new Set([
+            ...this.providers.keys(),
+            ...DEFAULT_PROVIDER_CONFIGS.map((c) => c.name),
+            ...this.configs.map((c) => c.name),
+        ]);
+
+        return Array.from(allNames).map((name) => ({
+            name,
+            available: this.providers.has(name),
+        }));
+    }
+
+    /**
+     * Check if a model is supported by any registered provider.
+     */
+    isModelSupported(model: string): boolean {
+        const provider = this.detectProvider(model);
+        return provider !== null && this.providers.has(provider);
+    }
+}
+
+export default SmartRouter;

--- a/JS/edgechains/arakoodev/src/ai/src/tests/smart-router.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/smart-router.test.ts
@@ -1,0 +1,71 @@
+import { SmartRouter } from "../lib/smart-router/smartRouter.js";
+
+describe("SmartRouter", () => {
+    describe("detectProvider", () => {
+        const router = new SmartRouter();
+
+        it("should detect OpenAI models", () => {
+            expect(router.detectProvider("gpt-4o")).toBe("openai");
+            expect(router.detectProvider("gpt-4-turbo")).toBe("openai");
+            expect(router.detectProvider("gpt-3.5-turbo")).toBe("openai");
+            expect(router.detectProvider("o1-preview")).toBe("openai");
+            expect(router.detectProvider("o3-mini")).toBe("openai");
+        });
+
+        it("should detect Gemini models", () => {
+            expect(router.detectProvider("gemini-pro")).toBe("gemini");
+            expect(router.detectProvider("gemini-1.5-pro")).toBe("gemini");
+            expect(router.detectProvider("gemini-2.0-flash")).toBe("gemini");
+        });
+
+        it("should detect Llama models", () => {
+            expect(router.detectProvider("llama-3-70b")).toBe("llama");
+            expect(router.detectProvider("meta-llama/Llama-3-8B")).toBe("llama");
+            expect(router.detectProvider("mixtral-8x7b")).toBe("llama");
+            expect(router.detectProvider("qwen-72b")).toBe("llama");
+            expect(router.detectProvider("deepseek-coder")).toBe("llama");
+        });
+
+        it("should return null for unknown models", () => {
+            expect(router.detectProvider("unknown-model")).toBeNull();
+            expect(router.detectProvider("")).toBeNull();
+        });
+    });
+
+    describe("listProviders", () => {
+        it("should list all providers with availability", () => {
+            const router = new SmartRouter();
+            const providers = router.listProviders();
+            expect(providers.length).toBeGreaterThan(0);
+            expect(providers[0]).toHaveProperty("name");
+            expect(providers[0]).toHaveProperty("available");
+        });
+    });
+
+    describe("isModelSupported", () => {
+        it("should return true for known model patterns", () => {
+            const router = new SmartRouter();
+            // Even without API keys, pattern detection works
+            expect(router.isModelSupported("gpt-4o")).toBe(true);
+            expect(router.isModelSupported("gemini-pro")).toBe(true);
+        });
+    });
+
+    describe("custom providers", () => {
+        it("should support custom provider configs", () => {
+            const router = new SmartRouter({
+                providers: [
+                    {
+                        name: "custom",
+                        patterns: [/^custom-/i],
+                        factory: () => ({
+                            chat: async (opts) => ({ content: "custom response" }),
+                        }),
+                    },
+                ],
+            });
+
+            expect(router.detectProvider("custom-model")).toBe("custom");
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds a SmartRouter class that works like LiteLLM - pass any model name and it auto-routes to the correct provider.

### Features:
- **Auto-detection**: Model name prefix determines provider (gpt-* → OpenAI, gemini-* → Gemini, llama-* → Llama)
- **Fallback chain**: If primary provider fails, tries next provider in priority order
- **Extensible**: Register custom providers via config
- **Unified API**: Single `router.chat({ model, prompt })` call regardless of backend
- **Utilities**: `listProviders()`, `isModelSupported()`, `detectProvider()`

### Provider Patterns:
| Provider | Model Patterns |
|----------|---------------|
| OpenAI | gpt-*, o1-*, o3-*, chatgpt-*, text-embedding-*, dall-e-* |
| Gemini | gemini-*, palm-*, bison-* |
| Llama | llama-*, meta-llama/*, mixtral-*, mistral-*, qwen-*, deepseek-* |

### Usage:
```typescript
import { SmartRouter } from "@arakoodev/edgechains";

const router = new SmartRouter({
    openaiApiKey: process.env.OPENAI_API_KEY,
    geminiApiKey: process.env.GEMINI_API_KEY,
});

// Auto-routes to correct provider based on model name
const response = await router.chat({
    model: "gpt-4o",
    prompt: "Hello!",
});
// response = { content: "...", provider: "openai", model: "gpt-4o" }

// Fallback: if OpenAI fails, tries Gemini
const response2 = await router.chat({
    model: "gpt-4o",
    prompt: "Hello!",
});
// Falls back to Gemini if OpenAI errors
```

### Files Added:
- `JS/edgechains/arakoodev/src/ai/src/lib/smart-router/smartRouter.ts`
- `JS/edgechains/arakoodev/src/ai/src/tests/smart-router.test.ts`

### Files Modified:
- `JS/edgechains/arakoodev/src/ai/src/index.ts` — added SmartRouter export

Closes #286

/claim #286