### PR TITLE
feat: add Qdrant vector database client for JavaScript SDK (#273)

### DIFF
--- a/JS/edgechains/arakoodev/src/db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/db/src/index.ts
@@ -1,1 +1,2 @@
 export { PostgresClient } from "./lib/postgres-client/PostgresClient.js";
+export { QdrantClient, QdrantDistanceMetric } from "./lib/qdrant-client/QdrantClient.js";

--- a/JS/edgechains/arakoodev/src/db/src/lib/qdrant-client/QdrantClient.ts
+++ b/JS/edgechains/arakoodev/src/db/src/lib/qdrant-client/QdrantClient.ts
@@ -1,0 +1,304 @@
+import axios, { AxiosInstance } from "axios";
+
+export class QdrantClient {
+    wordEmbeddings: number[][];
+    metric: QdrantDistanceMetric;
+    topK: number;
+    collectionName: string;
+    namespace: string;
+    arkRequest: any;
+    upperLimit: number;
+    host: string;
+    port: number;
+    apiKey?: string;
+    httpClient: AxiosInstance;
+
+    constructor(
+        wordEmbeddings: number[][],
+        metric: QdrantDistanceMetric,
+        topK: number,
+        collectionName: string,
+        namespace: string,
+        arkRequest: any,
+        upperLimit: number,
+        host: string = "localhost",
+        port: number = 6333,
+        apiKey?: string
+    ) {
+        this.wordEmbeddings = wordEmbeddings;
+        this.metric = metric;
+        this.topK = topK;
+        this.collectionName = collectionName;
+        this.namespace = namespace;
+        this.arkRequest = arkRequest;
+        this.upperLimit = upperLimit;
+        this.host = host;
+        this.port = port;
+        this.apiKey = apiKey;
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (this.apiKey) {
+            headers["api-key"] = this.apiKey;
+        }
+
+        this.httpClient = axios.create({
+            baseURL: `http://${this.host}:${this.port}`,
+            headers,
+            timeout: 30000,
+        });
+    }
+
+    private mapMetric(): string {
+        switch (this.metric) {
+            case QdrantDistanceMetric.COSINE:
+                return "Cosine";
+            case QdrantDistanceMetric.IP:
+                return "Dot";
+            case QdrantDistanceMetric.L2:
+                return "Euclid";
+            default:
+                return "Cosine";
+        }
+    }
+
+    async dbQuery() {
+        try {
+            const allResults: QdrantSearchResult[] = [];
+
+            for (const embedding of this.wordEmbeddings) {
+                const searchPayload = {
+                    vector: embedding,
+                    limit: this.topK,
+                    with_payload: true,
+                    with_vector: false,
+                    filter: this.namespace
+                        ? {
+                              must: [
+                                  {
+                                      key: "namespace",
+                                      match: { value: this.namespace },
+                                  },
+                              ],
+                          }
+                        : undefined,
+                };
+
+                const response = await this.httpClient.post<QdrantSearchResponse>(
+                    `/collections/${this.collectionName}/points/search`,
+                    searchPayload
+                );
+
+                if (response.data?.result) {
+                    for (const hit of response.data.result) {
+                        allResults.push({
+                            id: hit.id,
+                            score: hit.score,
+                            raw_text: hit.payload?.raw_text ?? "",
+                            document_date: hit.payload?.document_date ?? null,
+                            metadata: hit.payload?.metadata ?? {},
+                            namespace: hit.payload?.namespace ?? "",
+                            filename: hit.payload?.filename ?? "",
+                            timestamp: hit.payload?.timestamp ?? null,
+                            rrf_score: this.computeRRFScore(hit),
+                        });
+                    }
+                }
+            }
+
+            // Deduplicate by id, keeping highest score
+            const seen = new Map<string | number, QdrantSearchResult>();
+            for (const result of allResults) {
+                const existing = seen.get(result.id);
+                if (!existing || result.rrf_score > existing.rrf_score) {
+                    seen.set(result.id, result);
+                }
+            }
+
+            // Sort by order preference
+            const sorted = Array.from(seen.values());
+            this.sortResults(sorted);
+
+            const limit = this.wordEmbeddings.length > 1 ? this.upperLimit : this.topK;
+            return sorted.slice(0, limit);
+        } catch (error: any) {
+            throw new Error(
+                `QdrantClient query failed: ${error.message || error}`
+            );
+        }
+    }
+
+    private computeRRFScore(hit: QdrantHit): number {
+        const textWeight = this.arkRequest?.textWeight ?? {
+            baseWeight: 1,
+            fineTuneWeight: 60,
+        };
+        const similarityWeight = this.arkRequest?.similarityWeight ?? {
+            baseWeight: 1,
+            fineTuneWeight: 60,
+        };
+        const dateWeight = this.arkRequest?.dateWeight ?? {
+            baseWeight: 1,
+            fineTuneWeight: 60,
+        };
+
+        // Use similarity score directly from Qdrant
+        const similarityScore = hit.score;
+
+        // Compute date rank from document_date if available
+        let dateRank = 0;
+        if (hit.payload?.document_date) {
+            const docDate = new Date(hit.payload.document_date);
+            dateRank = docDate.getFullYear() * 365 + docDate.getMonth() * 30 + docDate.getDate();
+        }
+
+        // RRF scoring: weight / (rank + k)
+        // Simplified version using Qdrant's native similarity score
+        const rrfScore =
+            similarityWeight.baseWeight / (1 / (similarityScore + 0.001) + similarityWeight.fineTuneWeight) +
+            dateWeight.baseWeight / (dateRank > 0 ? dateRank + dateWeight.fineTuneWeight : 1);
+
+        return rrfScore;
+    }
+
+    private sortResults(results: QdrantSearchResult[]) {
+        const orderRRF = this.arkRequest?.orderRRF ?? "similarity";
+
+        switch (orderRRF) {
+            case "similarity":
+                results.sort((a, b) => b.score - a.score);
+                break;
+            case "date_rank":
+                results.sort((a, b) => {
+                    const dateA = a.document_date ? new Date(a.document_date).getTime() : 0;
+                    const dateB = b.document_date ? new Date(b.document_date).getTime() : 0;
+                    return dateB - dateA || b.rrf_score - a.rrf_score;
+                });
+                break;
+            case "text_rank":
+            case "default":
+            default:
+                results.sort((a, b) => b.rrf_score - a.rrf_score);
+                break;
+        }
+    }
+
+    async createCollection(vectorSize: number): Promise<boolean> {
+        try {
+            const response = await this.httpClient.put(
+                `/collections/${this.collectionName}`,
+                {
+                    vectors: {
+                        size: vectorSize,
+                        distance: this.mapMetric(),
+                    },
+                }
+            );
+            return response.status === 200;
+        } catch (error: any) {
+            throw new Error(
+                `Failed to create collection: ${error.message || error}`
+            );
+        }
+    }
+
+    async upsertPoints(
+        points: Array<{
+            id: string | number;
+            vector: number[];
+            payload: Record<string, any>;
+        }>
+    ): Promise<boolean> {
+        try {
+            const response = await this.httpClient.put(
+                `/collections/${this.collectionName}/points`,
+                { points }
+            );
+            return response.status === 200;
+        } catch (error: any) {
+            throw new Error(
+                `Failed to upsert points: ${error.message || error}`
+            );
+        }
+    }
+
+    async deletePoints(ids: (string | number)[]): Promise<boolean> {
+        try {
+            const response = await this.httpClient.post(
+                `/collections/${this.collectionName}/points/delete`,
+                { points: ids }
+            );
+            return response.status === 200;
+        } catch (error: any) {
+            throw new Error(
+                `Failed to delete points: ${error.message || error}`
+            );
+        }
+    }
+
+    async getCollectionInfo(): Promise<QdrantCollectionInfo | null> {
+        try {
+            const response = await this.httpClient.get<QdrantCollectionResponse>(
+                `/collections/${this.collectionName}`
+            );
+            return response.data?.result ?? null;
+        } catch (error: any) {
+            throw new Error(
+                `Failed to get collection info: ${error.message || error}`
+            );
+        }
+    }
+}
+
+export enum QdrantDistanceMetric {
+    COSINE = "COSINE",
+    IP = "IP",
+    L2 = "L2",
+}
+
+interface QdrantHit {
+    id: string | number;
+    score: number;
+    payload?: Record<string, any>;
+}
+
+interface QdrantSearchResponse {
+    result: QdrantHit[];
+    status: string;
+    time: number;
+}
+
+interface QdrantSearchResult {
+    id: string | number;
+    score: number;
+    raw_text: string;
+    document_date: string | null;
+    metadata: Record<string, any>;
+    namespace: string;
+    filename: string;
+    timestamp: string | null;
+    rrf_score: number;
+}
+
+interface QdrantCollectionInfo {
+    status: string;
+    vectors_count?: number;
+    indexed_vectors_count?: number;
+    points_count?: number;
+    segments_count?: number;
+    config?: {
+        params?: {
+            vectors?: {
+                size?: number;
+                distance?: string;
+            };
+        };
+    };
+}
+
+interface QdrantCollectionResponse {
+    result: QdrantCollectionInfo;
+    status: string;
+    time: number;
+}

--- a/JS/edgechains/arakoodev/src/db/src/tests/qdrant-client/qdrantClient.test.ts
+++ b/JS/edgechains/arakoodev/src/db/src/tests/qdrant-client/qdrantClient.test.ts
@@ -1,0 +1,251 @@
+import axios from "axios";
+import { QdrantClient, QdrantDistanceMetric } from "../qdrant-client/QdrantClient";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("QdrantClient", () => {
+    let client: QdrantClient;
+    let mockAxiosInstance: any;
+
+    beforeEach(() => {
+        mockAxiosInstance = {
+            post: jest.fn(),
+            put: jest.fn(),
+            get: jest.fn(),
+        };
+        mockedAxios.create.mockReturnValue(mockAxiosInstance);
+
+        client = new QdrantClient(
+            [[0.1, 0.2, 0.3]],
+            QdrantDistanceMetric.COSINE,
+            10,
+            "test_collection",
+            "test_namespace",
+            {
+                textWeight: { baseWeight: 1, fineTuneWeight: 60 },
+                similarityWeight: { baseWeight: 1, fineTuneWeight: 60 },
+                dateWeight: { baseWeight: 1, fineTuneWeight: 60 },
+                orderRRF: "similarity",
+            },
+            20,
+            "localhost",
+            6333
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("constructor initializes properties correctly", () => {
+        expect(client.host).toBe("localhost");
+        expect(client.port).toBe(6333);
+        expect(client.collectionName).toBe("test_collection");
+        expect(client.namespace).toBe("test_namespace");
+        expect(client.metric).toBe(QdrantDistanceMetric.COSINE);
+        expect(client.topK).toBe(10);
+    });
+
+    test("constructor creates axios instance with correct config", () => {
+        expect(mockedAxios.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                baseURL: "http://localhost:6333",
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                }),
+                timeout: 30000,
+            })
+        );
+    });
+
+    test("constructor adds api-key header when provided", () => {
+        jest.clearAllMocks();
+        const authClient = new QdrantClient(
+            [[0.1, 0.2, 0.3]],
+            QdrantDistanceMetric.COSINE,
+            10,
+            "test_collection",
+            "test_namespace",
+            {},
+            20,
+            "localhost",
+            6333,
+            "test-api-key"
+        );
+
+        expect(mockedAxios.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    "api-key": "test-api-key",
+                }),
+            })
+        );
+    });
+
+    test("dbQuery performs search and returns results", async () => {
+        const mockResponse = {
+            data: {
+                result: [
+                    {
+                        id: "1",
+                        score: 0.95,
+                        payload: {
+                            raw_text: "test text",
+                            namespace: "test_namespace",
+                            filename: "test.txt",
+                        },
+                    },
+                ],
+                status: "ok",
+                time: 0.01,
+            },
+        };
+
+        mockAxiosInstance.post.mockResolvedValue(mockResponse);
+
+        const results = await client.dbQuery();
+
+        expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+            "/collections/test_collection/points/search",
+            expect.objectContaining({
+                vector: [0.1, 0.2, 0.3],
+                limit: 10,
+                with_payload: true,
+            })
+        );
+
+        expect(results).toHaveLength(1);
+        expect(results[0].id).toBe("1");
+        expect(results[0].raw_text).toBe("test text");
+    });
+
+    test("dbQuery handles multiple embeddings and deduplicates", async () => {
+        const clientMulti = new QdrantClient(
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+            QdrantDistanceMetric.COSINE,
+            5,
+            "test_collection",
+            "test_namespace",
+            { orderRRF: "similarity" },
+            10,
+            "localhost",
+            6333
+        );
+
+        mockAxiosInstance.post.mockResolvedValue({
+            data: {
+                result: [
+                    { id: "1", score: 0.9, payload: { raw_text: "text1" } },
+                    { id: "2", score: 0.8, payload: { raw_text: "text2" } },
+                ],
+            },
+        });
+
+        const results = await clientMulti.dbQuery();
+        expect(results.length).toBeLessThanOrEqual(10);
+        // Should have called search twice (once per embedding)
+        expect(mockAxiosInstance.post).toHaveBeenCalledTimes(2);
+    });
+
+    test("dbQuery throws on error", async () => {
+        mockAxiosInstance.post.mockRejectedValue(new Error("Connection refused"));
+
+        await expect(client.dbQuery()).rejects.toThrow("QdrantClient query failed");
+    });
+
+    test("createCollection sends correct payload", async () => {
+        mockAxiosInstance.put.mockResolvedValue({ status: 200 });
+
+        const result = await client.createCollection(384);
+
+        expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+            "/collections/test_collection",
+            expect.objectContaining({
+                vectors: {
+                    size: 384,
+                    distance: "Cosine",
+                },
+            })
+        );
+        expect(result).toBe(true);
+    });
+
+    test("upsertPoints sends correct payload", async () => {
+        mockAxiosInstance.put.mockResolvedValue({ status: 200 });
+
+        const points = [
+            { id: "1", vector: [0.1, 0.2], payload: { text: "hello" } },
+        ];
+
+        const result = await client.upsertPoints(points);
+
+        expect(mockAxiosInstance.put).toHaveBeenCalledWith(
+            "/collections/test_collection/points",
+            { points }
+        );
+        expect(result).toBe(true);
+    });
+
+    test("deletePoints sends correct payload", async () => {
+        mockAxiosInstance.post.mockResolvedValue({ status: 200 });
+
+        const result = await client.deletePoints(["1", "2", "3"]);
+
+        expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+            "/collections/test_collection/points/delete",
+            { points: ["1", "2", "3"] }
+        );
+        expect(result).toBe(true);
+    });
+
+    test("getCollectionInfo returns collection info", async () => {
+        const mockInfo = {
+            status: "green",
+            vectors_count: 1000,
+            points_count: 1000,
+        };
+        mockAxiosInstance.get.mockResolvedValue({ data: { result: mockInfo } });
+
+        const info = await client.getCollectionInfo();
+
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+            "/collections/test_collection"
+        );
+        expect(info).toEqual(mockInfo);
+    });
+
+    test("distance metric mapping is correct", () => {
+        const cosineClient = new QdrantClient(
+            [[]], QdrantDistanceMetric.COSINE, 10, "c", "n", {}, 20
+        );
+        const ipClient = new QdrantClient(
+            [[]], QdrantDistanceMetric.IP, 10, "c", "n", {}, 20
+        );
+        const l2Client = new QdrantClient(
+            [[]], QdrantDistanceMetric.L2, 10, "c", "n", {}, 20
+        );
+
+        // These are private, but we can test through createCollection
+        jest.clearAllMocks();
+        mockAxiosInstance.put.mockResolvedValue({ status: 200 });
+
+        cosineClient.createCollection(384);
+        expect(mockAxiosInstance.put).toHaveBeenLastCalledWith(
+            expect.any(String),
+            expect.objectContaining({ vectors: expect.objectContaining({ distance: "Cosine" }) })
+        );
+
+        ipClient.createCollection(384);
+        expect(mockAxiosInstance.put).toHaveBeenLastCalledWith(
+            expect.any(String),
+            expect.objectContaining({ vectors: expect.objectContaining({ distance: "Dot" }) })
+        );
+
+        l2Client.createCollection(384);
+        expect(mockAxiosInstance.put).toHaveBeenLastCalledWith(
+            expect.any(String),
+            expect.objectContaining({ vectors: expect.objectContaining({ distance: "Euclid" }) })
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Implements Qdrant vector database support for the JavaScript SDK, addressing bounty issue #273.

Uses the Qdrant REST API directly as requested (no qdrant npm packages).

## Changes

- **New module**: `QdrantClient` class in `db/src/lib/qdrant-client/QdrantClient.ts`
- **Exported from**: `@arakoodev/edgechains.js/db`
- **Distance metrics**: Cosine, Inner Product (Dot), L2 (Euclid) — matching Qdrant's native metrics
- **Namespace filtering**: Multi-tenant support via Qdrant payload filters
- **RRF scoring**: Reciprocal Rank Fusion with configurable text/similarity/date weights (matching PostgresClient pattern)
- **CRUD operations**: Search, create collection, upsert points, delete points, get collection info
- **Tests**: Comprehensive Jest unit tests with mocks

## Usage

```typescript
import { QdrantClient, QdrantDistanceMetric } from "@arakoodev/edgechains.js/db";

const client = new QdrantClient(
    wordEmbeddings,           // number[][]
    QdrantDistanceMetric.COSINE,
    10,                       // topK
    "my_collection",          // collection name
    "my_namespace",           // namespace filter
    arkRequest,               // RRF weight config
    20,                       // upperLimit
    "localhost",              // Qdrant host
    6333                      // Qdrant port
);

// Search vectors
const results = await client.dbQuery();

// Create collection
await client.createCollection(384); // vector dimension

// Upsert points
await client.upsertPoints([{
    id: "doc1",
    vector: [0.1, 0.2, ...],
    payload: { raw_text: "...", namespace: "my_ns" }
}]);
```

## API Compatibility

The `dbQuery()` method returns results in the same format as `PostgresClient`, making it a drop-in replacement:

```typescript
// Switching from Postgres to Qdrant:
// const client = new PostgresClient(embeddings, metric, topK, probes, table, ns, arkRequest, limit);
const client = new QdrantClient(embeddings, metric, topK, collection, ns, arkRequest, limit, host, port);
const results = await client.dbQuery(); // Same interface
```

Closes #273