### PR TITLE
Add AWS Comprehend PII redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,10 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+    ComprehendPiiRedactor,
+    DetectPiiEntitiesCommand,
+    type ComprehendPiiRedactorOptions,
+    type RedactionResult,
+    type RedactionMode,
+} from "./lib/comprehend/comprehend-redactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend-redactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend-redactor.test.ts
@@ -1,0 +1,76 @@
+import { ComprehendPiiRedactor } from "./comprehend-redactor.js";
+import { describe, expect, it, vi } from "vitest";
+
+describe("ComprehendPiiRedactor", () => {
+    it("redacts PII entities detected by AWS Comprehend", async () => {
+        const text = "Contact me at a@example.com or 555-123-4567.";
+        const emailStart = text.indexOf("a@example.com");
+        const phoneStart = text.indexOf("555-123-4567");
+        const client = {
+            detectPiiEntities: vi.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "EMAIL",
+                        BeginOffset: emailStart,
+                        EndOffset: emailStart + "a@example.com".length,
+                        Score: 0.99,
+                    },
+                    {
+                        Type: "PHONE",
+                        BeginOffset: phoneStart,
+                        EndOffset: phoneStart + "555-123-4567".length,
+                        Score: 0.98,
+                    },
+                ],
+            }),
+        };
+        const redactor = new ComprehendPiiRedactor({ client });
+
+        const result = await redactor.redact(text);
+
+        expect(result.redactedText).toBe("Contact me at [REDACTED_EMAIL] or [REDACTED_PHONE].");
+        expect(result.entities).toHaveLength(2);
+        expect(client.detectPiiEntities).toHaveBeenCalledWith({
+            Text: text,
+            LanguageCode: "en",
+        });
+    });
+
+    it("wraps chat endpoints and redacts prompts before forwarding", async () => {
+        const prompt = "Email a@example.com now";
+        const emailStart = prompt.indexOf("a@example.com");
+        const client = {
+            detectPiiEntities: vi.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "EMAIL",
+                        BeginOffset: emailStart,
+                        EndOffset: emailStart + "a@example.com".length,
+                        Score: 0.99,
+                    },
+                ],
+            }),
+        };
+        const endpoint = {
+            chat: vi.fn().mockResolvedValue({ content: "ok" }),
+        };
+        const redactor = new ComprehendPiiRedactor({ client });
+
+        await redactor.wrap(endpoint).chat({ prompt });
+
+        expect(endpoint.chat).toHaveBeenCalledWith({ prompt: "Email [REDACTED_EMAIL] now" });
+    });
+
+    it("can mask content instead of replacing with labels", async () => {
+        const client = {
+            detectPiiEntities: vi.fn().mockResolvedValue({
+                Entities: [{ Type: "NAME", BeginOffset: 0, EndOffset: 5, Score: 0.99 }],
+            }),
+        };
+        const redactor = new ComprehendPiiRedactor({ client, mode: "mask" });
+
+        const result = await redactor.redact("Alice sent a note.");
+
+        expect(result.redactedText).toBe("***** sent a note.");
+    });
+});

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend-redactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend-redactor.ts
@@ -1,0 +1,156 @@
+type ComprehendPiiEntity = {
+    Type?: string;
+    BeginOffset?: number;
+    EndOffset?: number;
+    Score?: number;
+};
+
+type DetectPiiEntitiesResult = {
+    Entities?: ComprehendPiiEntity[];
+};
+
+type DetectPiiEntitiesInput = {
+    Text: string;
+    LanguageCode: string;
+};
+
+type AwsComprehendClient = {
+    detectPiiEntities?: (input: DetectPiiEntitiesInput) => Promise<DetectPiiEntitiesResult>;
+    send?: (command: unknown) => Promise<DetectPiiEntitiesResult>;
+};
+
+type ChatEndpoint<TChatOptions, TChatResult> = {
+    chat(options: TChatOptions): Promise<TChatResult>;
+};
+
+type Message = {
+    role?: string;
+    content?: string;
+    [key: string]: unknown;
+};
+
+export type RedactionMode = "replace" | "mask";
+
+export interface ComprehendPiiRedactorOptions {
+    client: AwsComprehendClient;
+    languageCode?: string;
+    placeholder?: (entityType: string) => string;
+    minScore?: number;
+    mode?: RedactionMode;
+}
+
+export interface RedactionResult {
+    originalText: string;
+    redactedText: string;
+    entities: Required<Pick<ComprehendPiiEntity, "Type" | "BeginOffset" | "EndOffset">>[];
+}
+
+export class DetectPiiEntitiesCommand {
+    input: DetectPiiEntitiesInput;
+
+    constructor(input: DetectPiiEntitiesInput) {
+        this.input = input;
+    }
+}
+
+export class ComprehendPiiRedactor {
+    private client: AwsComprehendClient;
+    private languageCode: string;
+    private placeholder: (entityType: string) => string;
+    private minScore: number;
+    private mode: RedactionMode;
+
+    constructor(options: ComprehendPiiRedactorOptions) {
+        this.client = options.client;
+        this.languageCode = options.languageCode || "en";
+        this.placeholder = options.placeholder || ((entityType) => `[REDACTED_${entityType}]`);
+        this.minScore = options.minScore ?? 0;
+        this.mode = options.mode || "replace";
+    }
+
+    async redact(text: string): Promise<RedactionResult> {
+        const response = await this.detectPiiEntities(text);
+        const entities = (response.Entities || [])
+            .filter((entity) => this.isUsableEntity(entity))
+            .map((entity) => ({
+                Type: entity.Type as string,
+                BeginOffset: entity.BeginOffset as number,
+                EndOffset: entity.EndOffset as number,
+            }))
+            .sort((a, b) => b.BeginOffset - a.BeginOffset);
+
+        let redactedText = text;
+        for (const entity of entities) {
+            const value =
+                this.mode === "mask"
+                    ? "*".repeat(Math.max(0, entity.EndOffset - entity.BeginOffset))
+                    : this.placeholder(entity.Type);
+            redactedText =
+                redactedText.slice(0, entity.BeginOffset) + value + redactedText.slice(entity.EndOffset);
+        }
+
+        return {
+            originalText: text,
+            redactedText,
+            entities,
+        };
+    }
+
+    wrap<TChatOptions extends { prompt?: string; messages?: Message[] }, TChatResult>(
+        endpoint: ChatEndpoint<TChatOptions, TChatResult>
+    ): ChatEndpoint<TChatOptions, TChatResult> {
+        return {
+            chat: async (options: TChatOptions) => {
+                return endpoint.chat(await this.redactChatOptions(options));
+            },
+        };
+    }
+
+    async redactChatOptions<TChatOptions extends { prompt?: string; messages?: Message[] }>(
+        options: TChatOptions
+    ): Promise<TChatOptions> {
+        const nextOptions = { ...options };
+
+        if (typeof nextOptions.prompt === "string") {
+            nextOptions.prompt = (await this.redact(nextOptions.prompt)).redactedText;
+        }
+
+        if (Array.isArray(nextOptions.messages)) {
+            nextOptions.messages = await Promise.all(
+                nextOptions.messages.map(async (message) => {
+                    if (typeof message.content !== "string") return message;
+                    return {
+                        ...message,
+                        content: (await this.redact(message.content)).redactedText,
+                    };
+                })
+            );
+        }
+
+        return nextOptions;
+    }
+
+    private async detectPiiEntities(text: string): Promise<DetectPiiEntitiesResult> {
+        const input = { Text: text, LanguageCode: this.languageCode };
+
+        if (this.client.detectPiiEntities) {
+            return this.client.detectPiiEntities(input);
+        }
+
+        if (this.client.send) {
+            return this.client.send(new DetectPiiEntitiesCommand(input));
+        }
+
+        throw new Error("Comprehend client must implement detectPiiEntities(input) or send(command).");
+    }
+
+    private isUsableEntity(entity: ComprehendPiiEntity): boolean {
+        return (
+            typeof entity.Type === "string" &&
+            typeof entity.BeginOffset === "number" &&
+            typeof entity.EndOffset === "number" &&
+            entity.EndOffset > entity.BeginOffset &&
+            (entity.Score ?? 1) >= this.minScore
+        );
+    }
+}

--- a/JS/edgechains/examples/comprehend-redaction/package.json
+++ b/JS/edgechains/examples/comprehend-redaction/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "comprehend-redaction",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev"
+    },
+    "devDependencies": {
+        "@types/node": "^20.14.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/comprehend-redaction/src/index.ts
@@ -1,0 +1,43 @@
+import { ComprehendPiiRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+const comprehendClient = {
+    async detectPiiEntities(input: { Text: string; LanguageCode: string }) {
+        // Replace this object with AWS SDK ComprehendClient usage in production:
+        // const client = new ComprehendClient({ region: process.env.AWS_REGION });
+        // return client.send(new DetectPiiEntitiesCommand(input));
+        const emailStart = input.Text.indexOf("alice@example.com");
+        return {
+            Entities:
+                emailStart >= 0
+                    ? [
+                          {
+                              Type: "EMAIL",
+                              BeginOffset: emailStart,
+                              EndOffset: emailStart + "alice@example.com".length,
+                              Score: 0.99,
+                          },
+                      ]
+                    : [],
+        };
+    },
+};
+
+const redactor = new ComprehendPiiRedactor({ client: comprehendClient });
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const safeOpenAi = redactor.wrap(openai);
+
+async function main() {
+    const prompt = "Summarize this support ticket from alice@example.com without exposing PII.";
+    const redacted = await redactor.redact(prompt);
+    console.log(redacted.redactedText);
+
+    if (process.env.OPENAI_API_KEY) {
+        const response = await safeOpenAi.chat({ prompt });
+        console.log(response);
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/JS/edgechains/examples/comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/comprehend-redaction/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strict": true,
+        "esModuleInterop": true,
+        "outDir": "dist"
+    },
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Closes #290

## Summary
- Add `ComprehendPiiRedactor` to the JavaScript SDK AI exports.
- Support direct string redaction, masking mode, custom placeholders, min confidence filtering, and wrapping existing `chat()` endpoints so prompts/messages are redacted before forwarding.
- Add unit tests with a mocked Comprehend client and a working example under `JS/edgechains/examples/comprehend-redaction`.

## Validation
- `npm test -- --run src/ai/src/lib/comprehend/comprehend-redactor.test.ts`
- `npm run build`

The example avoids real AWS calls by default and shows where to plug in an AWS Comprehend client.