### PR TITLE
Add Palm2-compatible Google AI provider

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,13 @@
 export { OpenAI } from "./lib/openai/openai.js";
-export { GeminiAI } from "./lib/gemini/gemini.js";
+export { GeminiAI, Palm2AI } from "./lib/gemini/gemini.js";
+export type {
+    GoogleAIChatOptions,
+    GoogleAIConstructionOptions,
+    GoogleAIContent,
+    GoogleAIContentPart,
+    GoogleAIGenerationConfig,
+    GoogleAIResponse,
+} from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
@@ -1,97 +1,135 @@
 import axios from "axios";
 import { retry } from "@lifeomic/attempt";
-const url = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
 
-interface GeminiAIConstructionOptions {
+export type GoogleAIResponseMimeType = "text/plain" | "application/json";
+export type GoogleAIRole = "user" | "model";
+
+export interface GoogleAIConstructionOptions {
     apiKey?: string;
+    baseUrl?: string;
+    defaultModel?: string;
 }
 
-type SafetyRating = {
-    category:
-        | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
-        | "HARM_CATEGORY_HATE_SPEECH"
-        | "HARM_CATEGORY_HARASSMENT"
-        | "HARM_CATEGORY_DANGEROUS_CONTENT";
-    probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
-};
-
-type ContentPart = {
+export interface GoogleAIContentPart {
     text: string;
-};
+}
 
-type Content = {
-    parts: ContentPart[];
-    role: string;
-};
+export interface GoogleAIContent {
+    role?: GoogleAIRole;
+    parts: GoogleAIContentPart[];
+}
 
-type Candidate = {
-    content: Content;
-    finishReason: string;
-    index: number;
-    safetyRatings: SafetyRating[];
-};
-
-type UsageMetadata = {
-    promptTokenCount: number;
-    candidatesTokenCount: number;
-    totalTokenCount: number;
-};
-
-type Response = {
-    candidates: Candidate[];
-    usageMetadata: UsageMetadata;
-};
-
-type responseMimeType = "text/plain" | "application/json";
-
-interface GeminiAIChatOptions {
-    model?: string;
-    max_output_tokens?: number;
+export interface GoogleAIGenerationConfig {
     temperature?: number;
-    prompt: string;
+    topP?: number;
+    topK?: number;
+    candidateCount?: number;
+    maxOutputTokens?: number;
+    responseMimeType?: GoogleAIResponseMimeType;
+}
+
+export interface GoogleAIChatOptions extends GoogleAIGenerationConfig {
+    model?: string;
+    prompt?: string;
+    contents?: GoogleAIContent[];
     max_retry?: number;
-    responseType?: responseMimeType;
     delay?: number;
 }
 
-export class GeminiAI {
+export interface GoogleAISafetyRating {
+    category: string;
+    probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
+}
+
+export interface GoogleAICandidate {
+    content: GoogleAIContent;
+    finishReason?: string;
+    index?: number;
+    safetyRatings?: GoogleAISafetyRating[];
+}
+
+export interface GoogleAIResponse {
+    candidates: GoogleAICandidate[];
+    usageMetadata?: {
+        promptTokenCount?: number;
+        candidatesTokenCount?: number;
+        totalTokenCount?: number;
+    };
+}
+
+const DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
+const DEFAULT_MODEL = "gemini-pro";
+
+function toContents(options: GoogleAIChatOptions): GoogleAIContent[] {
+    if (options.contents?.length) return options.contents;
+    if (!options.prompt) throw new Error("A prompt or contents array is required");
+
+    return [
+        {
+            role: "user",
+            parts: [{ text: options.prompt }],
+        },
+    ];
+}
+
+function textFromResponse(response: GoogleAIResponse): string {
+    return response.candidates?.[0]?.content?.parts?.map((part) => part.text).join("") ?? "";
+}
+
+export class Palm2AI {
     apiKey: string;
-    constructor(options: GeminiAIConstructionOptions) {
-        this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
+    baseUrl: string;
+    defaultModel: string;
+
+    constructor(options: GoogleAIConstructionOptions = {}) {
+        this.apiKey = options.apiKey || process.env.PALM2_API_KEY || process.env.GEMINI_API_KEY || "";
+        this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
+        this.defaultModel = options.defaultModel || DEFAULT_MODEL;
     }
 
-    async chat(chatOptions: GeminiAIChatOptions): Promise<Response> {
-        let data = JSON.stringify({
-            contents: [
-                {
-                    role: "user",
-                    parts: [
-                        {
-                            text: chatOptions.prompt,
-                        },
-                    ],
-                },
-            ],
+    async chat(chatOptions: GoogleAIChatOptions): Promise<GoogleAIResponse> {
+        const model = chatOptions.model || this.defaultModel;
+        const url = `${this.baseUrl}/${model}:generateContent`;
+        const generationConfig: GoogleAIGenerationConfig = {
+            temperature: chatOptions.temperature,
+            topP: chatOptions.topP,
+            topK: chatOptions.topK,
+            candidateCount: chatOptions.candidateCount,
+            maxOutputTokens: chatOptions.maxOutputTokens,
+            responseMimeType: chatOptions.responseMimeType,
+        };
+
+        Object.keys(generationConfig).forEach((key) => {
+            if (generationConfig[key as keyof GoogleAIGenerationConfig] === undefined) {
+                delete generationConfig[key as keyof GoogleAIGenerationConfig];
+            }
         });
 
-        let config = {
-            method: "post",
-            maxBodyLength: Infinity,
-            url,
-            headers: {
-                "Content-Type": "application/json",
-                "x-goog-api-key": this.apiKey,
-            },
-            temperature: chatOptions.temperature || "0.7",
-            responseMimeType: chatOptions.responseType || "text/plain",
-            max_output_tokens: chatOptions.max_output_tokens || 1024,
-            data: data,
-        };
-        return await retry(
+        return retry(
             async () => {
-                return (await axios.request(config)).data;
+                const response = await axios.post(
+                    url,
+                    {
+                        contents: toContents(chatOptions),
+                        ...(Object.keys(generationConfig).length ? { generationConfig } : {}),
+                    },
+                    {
+                        headers: {
+                            "Content-Type": "application/json",
+                            "x-goog-api-key": this.apiKey,
+                        },
+                    }
+                );
+
+                return response.data;
             },
             { maxAttempts: chatOptions.max_retry || 3, delay: chatOptions.delay || 200 }
         );
     }
+
+    async generateText(chatOptions: GoogleAIChatOptions): Promise<string> {
+        return textFromResponse(await this.chat(chatOptions));
+    }
 }
+
+export class GeminiAI extends Palm2AI {}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
@@ -1,0 +1,83 @@
+import axios from "axios";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { Palm2AI } from "../../lib/gemini/gemini.js";
+
+vi.mock("axios");
+
+const mockedAxios = vi.mocked(axios, true);
+
+describe("Palm2AI", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("sends prompts to the Google Generative Language API", async () => {
+        mockedAxios.post.mockResolvedValueOnce({
+            data: {
+                candidates: [
+                    {
+                        content: { role: "model", parts: [{ text: "Hello from Gemini" }] },
+                    },
+                ],
+            },
+        });
+
+        const client = new Palm2AI({ apiKey: "test-key" });
+        const response = await client.generateText({
+            prompt: "Say hello",
+            temperature: 0.2,
+            maxOutputTokens: 128,
+            max_retry: 1,
+        });
+
+        expect(response).toBe("Hello from Gemini");
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+            {
+                contents: [{ role: "user", parts: [{ text: "Say hello" }] }],
+                generationConfig: {
+                    temperature: 0.2,
+                    maxOutputTokens: 128,
+                },
+            },
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-goog-api-key": "test-key",
+                },
+            }
+        );
+    });
+
+    it("supports explicit contents, model, and JSON response mode", async () => {
+        mockedAxios.post.mockResolvedValueOnce({ data: { candidates: [] } });
+
+        const client = new Palm2AI({ apiKey: "test-key", baseUrl: "https://example.test/models" });
+
+        await client.chat({
+            model: "gemini-1.5-flash",
+            contents: [{ role: "user", parts: [{ text: "Return JSON" }] }],
+            responseMimeType: "application/json",
+            candidateCount: 1,
+            max_retry: 1,
+        });
+
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            "https://example.test/models/gemini-1.5-flash:generateContent",
+            {
+                contents: [{ role: "user", parts: [{ text: "Return JSON" }] }],
+                generationConfig: {
+                    candidateCount: 1,
+                    responseMimeType: "application/json",
+                },
+            },
+            expect.any(Object)
+        );
+    });
+
+    it("requires a prompt or contents array", async () => {
+        const client = new Palm2AI({ apiKey: "test-key" });
+
+        await expect(client.chat({ max_retry: 1 })).rejects.toThrow("A prompt or contents array is required");
+    });
+});

--- a/JS/edgechains/examples/palm2-jsonnet-chat/README.md
+++ b/JS/edgechains/examples/palm2-jsonnet-chat/README.md
@@ -1,0 +1,9 @@
+# Palm2/Gemini Jsonnet Chat Example
+
+This example keeps the prompt in Jsonnet and calls the EdgeChains Google Generative Language provider from TypeScript.
+
+## Usage
+
+1. Add your API key in `jsonnet/secrets.jsonnet`.
+2. Run `npm install && npm run build && npm start -- "Explain EdgeChains in one sentence"`.
+

--- a/JS/edgechains/examples/palm2-jsonnet-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-jsonnet-chat/jsonnet/main.jsonnet
@@ -1,0 +1,16 @@
+local promptTemplate = |||
+You are a concise developer assistant.
+
+Question:
+{question}
+|||;
+
+local question = std.extVar('question');
+local prompt = std.strReplace(promptTemplate, '{question}', question);
+
+{
+  model: 'gemini-pro',
+  prompt: prompt,
+  temperature: 0.2,
+  maxOutputTokens: 256,
+}

--- a/JS/edgechains/examples/palm2-jsonnet-chat/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-jsonnet-chat/jsonnet/secrets.jsonnet
@@ -1,0 +1,3 @@
+{
+  google_api_key: 'replace-me',
+}

--- a/JS/edgechains/examples/palm2-jsonnet-chat/package.json
+++ b/JS/edgechains/examples/palm2-jsonnet-chat/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "palm2-jsonnet-chat",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "build": "tsc",
+        "start": "node dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "^0.1.23",
+        "@arakoodev/jsonnet": "^0.25.0",
+        "file-uri-to-path": "^2.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^20.17.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/palm2-jsonnet-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-jsonnet-chat/src/index.ts
@@ -1,0 +1,34 @@
+import Jsonnet from "@arakoodev/jsonnet";
+import { Palm2AI } from "@arakoodev/edgechains.js/ai";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const question = process.argv.slice(2).join(" ") || "What is EdgeChains?";
+
+jsonnet.extString("question", question);
+
+const promptConfig = JSON.parse(
+    jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"))
+) as {
+    model: string;
+    prompt: string;
+    temperature: number;
+    maxOutputTokens: number;
+};
+
+const secrets = JSON.parse(
+    jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet"))
+) as { google_api_key: string };
+
+const client = new Palm2AI({ apiKey: process.env.GEMINI_API_KEY || secrets.google_api_key });
+
+const response = await client.generateText({
+    model: promptConfig.model,
+    prompt: promptConfig.prompt,
+    temperature: promptConfig.temperature,
+    maxOutputTokens: promptConfig.maxOutputTokens,
+});
+
+console.log(response);

--- a/JS/edgechains/examples/palm2-jsonnet-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-jsonnet-chat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "outDir": "dist",
+        "rootDir": "src"
+    },
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Closes #279
/claim #279

## Summary
- Reworks the Google Generative Language provider into a direct REST-based `Palm2AI` class with a `GeminiAI` compatibility export
- Adds typed contents, generation config, responses, JSON response mode, retry support, and text helper output
- Adds mocked unit tests under `src/ai/src/tests/palm2/`
- Adds a jsonnet-driven chat example where prompts live in jsonnet instead of TypeScript

## Validation
- `npm test -- --run src/ai/src/tests/palm2/gemini.test.ts`
- `npm run build`

Note: the example is included as source documentation for local usage after this package build includes the new `Palm2AI` export.