### PR TITLE
feat: integrate AWS Comprehend as a chainable PII redactor 

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -22,6 +22,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.600.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",
@@ -48,6 +49,7 @@
         "retell-client-js-sdk": "^2.0.4",
         "retell-sdk": "^4.9.0",
         "retry": "^0.13.1",
+        "rxjs": "^7.8.1",
         "ts-node": "^10.9.2",
         "typeorm": "^0.3.20",
         "vitest": "^2.0.3",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,6 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+
+// AWS Comprehend PII redactor (issue #290)
+export * from "./lib/aws-comprehend/index.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend.ts
@@ -1,0 +1,219 @@
+import {
+    ComprehendClient,
+    DetectPiiEntitiesCommand,
+    ContainsPiiEntitiesCommand,
+    LanguageCode,
+    PiiEntityType,
+    PiiEntity,
+} from "@aws-sdk/client-comprehend";
+
+export interface AWSComprehendOptions {
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+}
+
+export interface RedactOptions {
+    text: string;
+    languageCode?: LanguageCode;
+    piiEntityTypes?: PiiEntityType[];
+    minConfidence?: number;
+    redactionChar?: string;
+    strategy?: "char" | "type" | "fixed";
+}
+
+export interface DetectedEntity {
+    type: string;
+    score: number;
+    beginOffset: number;
+    endOffset: number;
+}
+
+export interface RedactResult {
+    originalText: string;
+    redactedText: string;
+    entitiesFound: DetectedEntity[];
+}
+
+export interface DetectPiiOptions {
+    text: string;
+    languageCode?: LanguageCode;
+}
+
+export interface DetectPiiResult {
+    containsPii: boolean;
+    entities: DetectedEntity[];
+}
+
+// Wrapper around AWS Comprehend's PII detection / redaction APIs.
+// Use redact() for one-off calls or chain() to pipe a redacted prompt
+// straight into one of the existing Endpoint classes (OpenAI, GeminiAI,
+// LlamaAI, RetellAI). For RxJS-style composition see ./observables.
+export class AWSComprehend {
+    private readonly client: ComprehendClient;
+    public readonly region: string;
+
+    constructor(options: AWSComprehendOptions = {}) {
+        this.region =
+            options.region ||
+            process.env.AWS_REGION ||
+            process.env.AWS_DEFAULT_REGION ||
+            "us-east-1";
+
+        const accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
+        const secretAccessKey =
+            options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
+        const sessionToken =
+            options.sessionToken || process.env.AWS_SESSION_TOKEN;
+
+        const clientConfig: ConstructorParameters<typeof ComprehendClient>[0] = {
+            region: this.region,
+        };
+
+        if (accessKeyId && secretAccessKey) {
+            clientConfig.credentials = {
+                accessKeyId,
+                secretAccessKey,
+                ...(sessionToken ? { sessionToken } : {}),
+            };
+        } else {
+            // fall back to the default AWS credential chain (IAM role,
+            // ~/.aws/credentials, container/instance metadata, ...)
+            console.warn(
+                "[AWSComprehend] No explicit credentials supplied. Falling back to the AWS default credential chain."
+            );
+        }
+
+        this.client = new ComprehendClient(clientConfig);
+    }
+
+    async detectPii(options: DetectPiiOptions): Promise<DetectPiiResult> {
+        const { text, languageCode = "en" as LanguageCode } = options;
+        this.assertText(text);
+
+        const command = new DetectPiiEntitiesCommand({
+            Text: text,
+            LanguageCode: languageCode,
+        });
+
+        const response = await this.client.send(command);
+        const entities: DetectedEntity[] = (response.Entities || []).map(
+            (e: PiiEntity) => ({
+                type: e.Type ?? "UNKNOWN",
+                score: e.Score ?? 0,
+                beginOffset: e.BeginOffset ?? 0,
+                endOffset: e.EndOffset ?? 0,
+            })
+        );
+
+        return {
+            containsPii: entities.length > 0,
+            entities,
+        };
+    }
+
+    // Lightweight precheck using the cheaper ContainsPiiEntities API.
+    async containsPii(options: DetectPiiOptions): Promise<boolean> {
+        const { text, languageCode = "en" as LanguageCode } = options;
+        this.assertText(text);
+
+        const command = new ContainsPiiEntitiesCommand({
+            Text: text,
+            LanguageCode: languageCode,
+        });
+        const response = await this.client.send(command);
+        return (response.Labels ?? []).some((l) => (l.Score ?? 0) > 0.5);
+    }
+
+    async redact(options: RedactOptions): Promise<RedactResult> {
+        const {
+            text,
+            languageCode = "en" as LanguageCode,
+            piiEntityTypes,
+            minConfidence = 0.5,
+            redactionChar = "*",
+            strategy = "char",
+        } = options;
+        this.assertText(text);
+
+        const detection = await this.detectPii({ text, languageCode });
+
+        if (!detection.containsPii) {
+            return { originalText: text, redactedText: text, entitiesFound: [] };
+        }
+
+        const wanted = detection.entities.filter((e) => {
+            if (e.score < minConfidence) return false;
+            if (piiEntityTypes && piiEntityTypes.length > 0) {
+                return piiEntityTypes.includes(e.type as PiiEntityType);
+            }
+            return true;
+        });
+
+        // Splice from end to start so earlier offsets stay valid.
+        const ordered = [...wanted].sort((a, b) => b.beginOffset - a.beginOffset);
+
+        let redactedText = text;
+        for (const entity of ordered) {
+            const before = redactedText.substring(0, entity.beginOffset);
+            const after = redactedText.substring(entity.endOffset);
+            const replacement = this.buildReplacement(
+                entity,
+                redactionChar,
+                strategy
+            );
+            redactedText = before + replacement + after;
+        }
+
+        return {
+            originalText: text,
+            redactedText,
+            entitiesFound: detection.entities,
+        };
+    }
+
+    async redactBatch(
+        texts: string[],
+        options: Omit<RedactOptions, "text"> = {}
+    ): Promise<RedactResult[]> {
+        return Promise.all(texts.map((text) => this.redact({ ...options, text })));
+    }
+
+    // Helper: redact `text` and forward the redacted string to `next`.
+    // Convenient when you want a one-liner inside async/await code that
+    // calls one of the existing Endpoint classes.
+    async chain<T>(
+        text: string,
+        next: (redactedText: string) => Promise<T> | T,
+        options: Omit<RedactOptions, "text"> = {}
+    ): Promise<T> {
+        const { redactedText } = await this.redact({ ...options, text });
+        return next(redactedText);
+    }
+
+    private buildReplacement(
+        entity: DetectedEntity,
+        char: string,
+        strategy: "char" | "type" | "fixed"
+    ): string {
+        if (strategy === "type") return `[${entity.type}]`;
+        if (strategy === "fixed") return char;
+        return char.repeat(Math.max(1, entity.endOffset - entity.beginOffset));
+    }
+
+    private assertText(text: unknown): asserts text is string {
+        if (typeof text !== "string" || text.length === 0) {
+            throw new TypeError(
+                "AWSComprehend: `text` must be a non-empty string."
+            );
+        }
+        // AWS Comprehend's DetectPiiEntities rejects payloads > 100 KB.
+        const bytes = Buffer.byteLength(text as string, "utf8");
+        if (bytes > 100_000) {
+            throw new RangeError(
+                `AWSComprehend: input is ${bytes} bytes, exceeds the 100,000-byte AWS Comprehend limit.`
+            );
+        }
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/index.ts
@@ -1,0 +1,16 @@
+export { AWSComprehend } from "./comprehend.js";
+export type {
+    AWSComprehendOptions,
+    RedactOptions,
+    RedactResult,
+    DetectPiiOptions,
+    DetectPiiResult,
+    DetectedEntity,
+} from "./comprehend.js";
+
+export {
+    redact$,
+    redactPii,
+    redactPiiText,
+    redactPiiBatch,
+} from "./observables.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/observables.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/observables.ts
@@ -1,0 +1,64 @@
+import { Observable, OperatorFunction, defer, from, of } from "rxjs";
+import { mergeMap, map } from "rxjs/operators";
+import { AWSComprehend, RedactOptions, RedactResult } from "./comprehend.js";
+
+// RxJS wrappers for AWSComprehend so redaction can be slotted into a
+// pipe() chain alongside the existing Endpoint classes.
+//
+// Usage:
+//   from(userPrompts$).pipe(
+//     redactPii(comprehend),
+//     mergeMap(r => from(openai.chat({ prompt: r.redactedText })))
+//   ).subscribe(reply => ...)
+
+// Cold Observable wrapper for a single redact() call. Subscribing fires
+// the AWS request; resubscribing fires it again (use shareReplay to memo).
+export function redact$(
+    comprehend: AWSComprehend,
+    options: RedactOptions
+): Observable<RedactResult> {
+    return defer(() => from(comprehend.redact(options)));
+}
+
+// Operator: Observable<string | RedactOptions> -> Observable<RedactResult>.
+// concurrency defaults to 4 to stay under Comprehend's TPS quota.
+export function redactPii(
+    comprehend: AWSComprehend,
+    defaults: Omit<RedactOptions, "text"> = {},
+    concurrency: number = 4
+): OperatorFunction<string | RedactOptions, RedactResult> {
+    return (source$) =>
+        source$.pipe(
+            mergeMap((input) => {
+                const options: RedactOptions =
+                    typeof input === "string"
+                        ? { ...defaults, text: input }
+                        : { ...defaults, ...input };
+                return redact$(comprehend, options);
+            }, concurrency)
+        );
+}
+
+// Same as redactPii but emits just the redacted string (drops audit data).
+export function redactPiiText(
+    comprehend: AWSComprehend,
+    defaults: Omit<RedactOptions, "text"> = {},
+    concurrency: number = 4
+): OperatorFunction<string, string> {
+    return (source$) =>
+        source$.pipe(
+            redactPii(comprehend, defaults, concurrency),
+            map((result) => result.redactedText)
+        );
+}
+
+// Convert an array of strings into an Observable that emits one
+// RedactResult per input.
+export function redactPiiBatch(
+    comprehend: AWSComprehend,
+    texts: string[],
+    options: Omit<RedactOptions, "text"> = {},
+    concurrency: number = 4
+): Observable<RedactResult> {
+    return of(...texts).pipe(redactPii(comprehend, options, concurrency));
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehend.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { firstValueFrom, from, lastValueFrom, toArray } from "rxjs";
+import { mergeMap } from "rxjs/operators";
+
+// Mock the AWS SDK so the suite runs offline / without credentials.
+const sendMock = vi.fn();
+vi.mock("@aws-sdk/client-comprehend", () => {
+    class FakeCommand {
+        constructor(public input: unknown) {}
+    }
+    return {
+        ComprehendClient: vi.fn().mockImplementation(() => ({ send: sendMock })),
+        DetectPiiEntitiesCommand: FakeCommand,
+        ContainsPiiEntitiesCommand: FakeCommand,
+        LanguageCode: { en: "en" },
+        PiiEntityType: {
+            EMAIL: "EMAIL",
+            PHONE: "PHONE",
+            SSN: "SSN",
+            NAME: "NAME",
+            ADDRESS: "ADDRESS",
+            CREDIT_DEBIT_NUMBER: "CREDIT_DEBIT_NUMBER",
+        },
+    };
+});
+
+import {
+    AWSComprehend,
+    redact$,
+    redactPii,
+    redactPiiText,
+    redactPiiBatch,
+} from "../lib/aws-comprehend/index.js";
+
+// Build a fake DetectPiiEntities response by regex-matching emails+phones.
+const piiResponseFor = (text: string) => {
+    const entities: Array<{
+        Type: string;
+        Score: number;
+        BeginOffset: number;
+        EndOffset: number;
+    }> = [];
+    const emailRe = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+    let m: RegExpExecArray | null;
+    while ((m = emailRe.exec(text))) {
+        entities.push({
+            Type: "EMAIL",
+            Score: 0.99,
+            BeginOffset: m.index,
+            EndOffset: m.index + m[0].length,
+        });
+    }
+    const phoneRe = /\d{3}-\d{3}-\d{4}/g;
+    while ((m = phoneRe.exec(text))) {
+        entities.push({
+            Type: "PHONE",
+            Score: 0.95,
+            BeginOffset: m.index,
+            EndOffset: m.index + m[0].length,
+        });
+    }
+    return { Entities: entities };
+};
+
+describe("AWSComprehend", () => {
+    let comprehend: AWSComprehend;
+
+    beforeEach(() => {
+        sendMock.mockReset();
+        comprehend = new AWSComprehend({
+            region: "us-east-1",
+            accessKeyId: "AKIA_TEST",
+            secretAccessKey: "test_secret",
+        });
+    });
+
+    describe("detectPii", () => {
+        it("returns the entities Comprehend reports", async () => {
+            sendMock.mockResolvedValueOnce(
+                piiResponseFor("contact me at jane@acme.com")
+            );
+            const result = await comprehend.detectPii({
+                text: "contact me at jane@acme.com",
+            });
+            expect(result.containsPii).toBe(true);
+            expect(result.entities).toHaveLength(1);
+            expect(result.entities[0].type).toBe("EMAIL");
+        });
+
+        it("returns containsPii=false when no entities are found", async () => {
+            sendMock.mockResolvedValueOnce({ Entities: [] });
+            const result = await comprehend.detectPii({ text: "hello world" });
+            expect(result.containsPii).toBe(false);
+            expect(result.entities).toEqual([]);
+        });
+
+        it("rejects empty input without calling AWS", async () => {
+            await expect(comprehend.detectPii({ text: "" })).rejects.toThrow(
+                TypeError
+            );
+            expect(sendMock).not.toHaveBeenCalled();
+        });
+
+        it("rejects payloads larger than 100,000 bytes", async () => {
+            const huge = "a".repeat(100_001);
+            await expect(comprehend.detectPii({ text: huge })).rejects.toThrow(
+                RangeError
+            );
+            expect(sendMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("redact", () => {
+        it("masks detected entities with the redactionChar (default '*')", async () => {
+            const text = "ping me at jane@acme.com please";
+            sendMock.mockResolvedValueOnce(piiResponseFor(text));
+            const result = await comprehend.redact({ text });
+            expect(result.redactedText).toBe("ping me at ************* please");
+            expect(result.originalText).toBe(text);
+            expect(result.entitiesFound[0].type).toBe("EMAIL");
+        });
+
+        it("supports the 'type' strategy: replaces entity with [TYPE]", async () => {
+            const text = "ping me at jane@acme.com please";
+            sendMock.mockResolvedValueOnce(piiResponseFor(text));
+            const result = await comprehend.redact({ text, strategy: "type" });
+            expect(result.redactedText).toBe("ping me at [EMAIL] please");
+        });
+
+        it("filters by piiEntityTypes (only redacts requested types)", async () => {
+            const text = "email jane@acme.com or call 555-123-4567";
+            sendMock.mockResolvedValueOnce(piiResponseFor(text));
+            // only redact PHONE; EMAIL must survive untouched
+            const result = await comprehend.redact({
+                text,
+                piiEntityTypes: ["PHONE" as any],
+            });
+            expect(result.redactedText).toBe(
+                "email jane@acme.com or call ************"
+            );
+        });
+
+        it("filters by minConfidence", async () => {
+            const text = "uncertain pii here";
+            sendMock.mockResolvedValueOnce({
+                Entities: [
+                    { Type: "NAME", Score: 0.3, BeginOffset: 0, EndOffset: 9 },
+                ],
+            });
+            const result = await comprehend.redact({ text, minConfidence: 0.9 });
+            expect(result.redactedText).toBe(text);
+            expect(result.entitiesFound).toHaveLength(1);
+        });
+
+        it("returns input untouched when no PII is found", async () => {
+            sendMock.mockResolvedValueOnce({ Entities: [] });
+            const result = await comprehend.redact({ text: "hello world" });
+            expect(result.redactedText).toBe("hello world");
+            expect(result.entitiesFound).toEqual([]);
+        });
+
+        it("redacts multiple entities without offset corruption", async () => {
+            const text = "a jane@acme.com b 555-123-4567 c";
+            sendMock.mockResolvedValueOnce(piiResponseFor(text));
+            const result = await comprehend.redact({ text, strategy: "type" });
+            expect(result.redactedText).toBe("a [EMAIL] b [PHONE] c");
+        });
+    });
+
+    describe("redactBatch", () => {
+        it("redacts multiple texts in parallel preserving input order", async () => {
+            const inputs = [
+                "mail jane@acme.com",
+                "call 555-123-4567",
+                "no pii",
+            ];
+            sendMock
+                .mockResolvedValueOnce(piiResponseFor(inputs[0]))
+                .mockResolvedValueOnce(piiResponseFor(inputs[1]))
+                .mockResolvedValueOnce({ Entities: [] });
+
+            const results = await comprehend.redactBatch(inputs);
+            expect(results).toHaveLength(3);
+            expect(results[0].entitiesFound[0].type).toBe("EMAIL");
+            expect(results[1].entitiesFound[0].type).toBe("PHONE");
+            expect(results[2].entitiesFound).toEqual([]);
+            expect(results[2].redactedText).toBe("no pii");
+        });
+    });
+
+    describe("chain", () => {
+        it("forwards the redacted text to the next function", async () => {
+            const text = "leak: jane@acme.com";
+            sendMock.mockResolvedValueOnce(piiResponseFor(text));
+            const next = vi.fn(async (safe: string) => ({ echoed: safe }));
+            const result = await comprehend.chain(text, next);
+            expect(next).toHaveBeenCalledWith("leak: *************");
+            expect(result).toEqual({ echoed: "leak: *************" });
+        });
+    });
+});
+
+describe("RxJS observable operators", () => {
+    let comprehend: AWSComprehend;
+
+    beforeEach(() => {
+        sendMock.mockReset();
+        comprehend = new AWSComprehend({
+            accessKeyId: "AKIA_TEST",
+            secretAccessKey: "test_secret",
+        });
+    });
+
+    describe("redact$", () => {
+        it("is cold (no AWS call until subscribe)", async () => {
+            sendMock.mockResolvedValueOnce(piiResponseFor("a@b.com"));
+            const obs = redact$(comprehend, { text: "a@b.com" });
+            expect(sendMock).not.toHaveBeenCalled();
+            const result = await firstValueFrom(obs);
+            expect(sendMock).toHaveBeenCalledTimes(1);
+            expect(result.entitiesFound[0].type).toBe("EMAIL");
+        });
+    });
+
+    describe("redactPii operator", () => {
+        it("transforms upstream strings into RedactResults", async () => {
+            const inputs = ["mail jane@acme.com", "call 555-123-4567"];
+            sendMock
+                .mockResolvedValueOnce(piiResponseFor(inputs[0]))
+                .mockResolvedValueOnce(piiResponseFor(inputs[1]));
+
+            const out = await lastValueFrom(
+                from(inputs).pipe(redactPii(comprehend), toArray())
+            );
+            expect(out).toHaveLength(2);
+            expect(out.map((r) => r.entitiesFound[0].type).sort()).toEqual([
+                "EMAIL",
+                "PHONE",
+            ]);
+        });
+
+        it("composes with mergeMap so endpoint calls receive the redacted text", async () => {
+            const text = "email jane@acme.com";
+            sendMock.mockResolvedValueOnce(piiResponseFor(text));
+
+            // stand-in for an Endpoint call (e.g. openai.chat({ prompt }))
+            const endpoint = vi.fn(
+                async (prompt: string) => `replied to: ${prompt}`
+            );
+
+            const reply = await firstValueFrom(
+                from([text]).pipe(
+                    redactPii(comprehend),
+                    mergeMap((r) => endpoint(r.redactedText))
+                )
+            );
+
+            expect(endpoint).toHaveBeenCalledWith("email *************");
+            expect(reply).toBe("replied to: email *************");
+        });
+    });
+
+    describe("redactPiiText operator", () => {
+        it("emits the redacted string directly", async () => {
+            sendMock.mockResolvedValueOnce(piiResponseFor("mail jane@acme.com"));
+            const out = await firstValueFrom(
+                from(["mail jane@acme.com"]).pipe(redactPiiText(comprehend))
+            );
+            expect(out).toBe("mail *************");
+        });
+    });
+
+    describe("redactPiiBatch", () => {
+        it("emits one RedactResult per input string", async () => {
+            const inputs = ["a jane@acme.com", "b 555-123-4567", "c clean"];
+            sendMock
+                .mockResolvedValueOnce(piiResponseFor(inputs[0]))
+                .mockResolvedValueOnce(piiResponseFor(inputs[1]))
+                .mockResolvedValueOnce({ Entities: [] });
+
+            const out = await lastValueFrom(
+                redactPiiBatch(comprehend, inputs).pipe(toArray())
+            );
+            expect(out).toHaveLength(3);
+            expect(out[2].redactedText).toBe("c clean");
+        });
+    });
+});

--- a/JS/edgechains/examples/pii-redactor/.env.example
+++ b/JS/edgechains/examples/pii-redactor/.env.example
@@ -1,0 +1,8 @@
+# --- AWS Comprehend ---
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+
+# --- OpenAI (used in chained example) ---
+OPENAI_API_KEY=sk-your_openai_key
+OPENAI_ORG_ID=org-optional

--- a/JS/edgechains/examples/pii-redactor/README.md
+++ b/JS/edgechains/examples/pii-redactor/README.md
@@ -1,0 +1,64 @@
+# pii-redactor
+
+Example for issue #290. Uses AWS Comprehend to scrub PII out of a prompt before sending it to an LLM Endpoint.
+
+Two flavours, pick whichever matches your code:
+
+- `comprehend.chain(text, fn)` if you're already in async/await
+- `from(prompts$).pipe(redactPii(comprehend), mergeMap(openai.chat ...))` if you have a stream of prompts
+
+## Run it
+
+```bash
+cp .env.example .env
+# fill in: AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, OPENAI_API_KEY
+pnpm install
+pnpm start          # promise demo
+pnpm run stream     # rxjs / observable demo
+```
+
+Output looks like:
+
+```
+ORIGINAL : Hi, I'm Sarah Chen (sarah.chen@acme.io). My phone is 415-555-0142 ...
+REDACTED : Hi, I'm [NAME] ([EMAIL]). My phone is [PHONE] ...
+LLM REPLY: Sure, here's a polite extension request you can send to your landlord ...
+```
+
+The LLM only sees the bracketed placeholders, never the raw PII.
+
+## Public API used
+
+```ts
+import {
+    AWSComprehend,
+    redact$,
+    redactPii,
+    redactPiiText,
+    redactPiiBatch,
+} from "@arakoodev/edgechains.js/ai";
+```
+
+`AWSComprehend.redact(opts)` accepts:
+
+| option | default | notes |
+|---|---|---|
+| `text` | - | <= 100 KB (Comprehend hard limit) |
+| `languageCode` | `"en"` | any code Comprehend supports |
+| `piiEntityTypes` | all | restrict to e.g. `["EMAIL", "PHONE"]` |
+| `minConfidence` | `0.5` | skip entities below this score |
+| `strategy` | `"char"` | `"char"`, `"type"`, or `"fixed"` |
+| `redactionChar` | `"*"` | replacement char/token |
+
+## IAM policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["comprehend:DetectPiiEntities", "comprehend:ContainsPiiEntities"],
+    "Resource": "*"
+  }]
+}
+```

--- a/JS/edgechains/examples/pii-redactor/package.json
+++ b/JS/edgechains/examples/pii-redactor/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "pii-redactor-example",
+    "version": "1.0.0",
+    "private": true,
+    "description": "EdgeChains example: redact PII with AWS Comprehend before sending prompts to an LLM (Promise + RxJS Observable variants).",
+    "main": "src/index.ts",
+    "scripts": {
+        "start": "tsx src/index.ts",
+        "stream": "tsx src/index.ts --stream",
+        "test": "vitest run"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "*",
+        "@aws-sdk/client-comprehend": "^3.600.0",
+        "dotenv": "^16.4.5",
+        "rxjs": "^7.8.1"
+    },
+    "devDependencies": {
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.5",
+        "vitest": "^1.6.0"
+    }
+}

--- a/JS/edgechains/examples/pii-redactor/src/index.ts
+++ b/JS/edgechains/examples/pii-redactor/src/index.ts
@@ -1,0 +1,92 @@
+// Example for issue #290 - AWS Comprehend PII redaction.
+//
+//   pnpm install
+//   cp .env.example .env       # add AWS_* + OPENAI_API_KEY
+//   pnpm start                 # promise-style demo
+//   pnpm run stream            # rxjs / observable demo
+
+import "dotenv/config";
+import { from } from "rxjs";
+import { mergeMap, tap } from "rxjs/operators";
+
+import {
+    AWSComprehend,
+    OpenAI,
+    redactPii,
+} from "@arakoodev/edgechains.js/ai";
+
+const dirtyPrompts: string[] = [
+    "Hi, I'm Sarah Chen (sarah.chen@acme.io). My phone is 415-555-0142. Can you draft a polite reply to my landlord asking for a 30-day extension?",
+    "My SSN 123-45-6789 was on a leaked spreadsheet, what should I do? My credit card 4111 1111 1111 1111 may also be exposed.",
+    "Please summarize: Patient John Doe (DOB 1979-04-12) presented with chest pain. Address: 742 Evergreen Terrace, Springfield.",
+];
+
+async function demoPromiseChain() {
+    console.log("\n== Promise chaining (comprehend.chain -> openai.chat) ==\n");
+
+    const comprehend = new AWSComprehend();
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    for (const prompt of dirtyPrompts) {
+        console.log("ORIGINAL :", prompt);
+
+        const reply = await comprehend.chain(
+            prompt,
+            (safePrompt) => {
+                console.log("REDACTED :", safePrompt);
+                return openai.chat({ prompt: safePrompt, max_tokens: 120 });
+            },
+            { strategy: "type" } // -> [EMAIL], [PHONE], [SSN] ...
+        );
+
+        console.log(
+            "LLM REPLY:",
+            typeof reply === "string" ? reply : (reply as any)?.content
+        );
+        console.log();
+    }
+}
+
+async function demoObservableChain() {
+    console.log("\n== Observable chaining (RxJS pipe) ==\n");
+
+    const comprehend = new AWSComprehend();
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    await new Promise<void>((resolve, reject) => {
+        from(dirtyPrompts)
+            .pipe(
+                tap((p) => console.log("ORIGINAL :", p)),
+                redactPii(comprehend, { strategy: "type" }, 2),
+                tap((r) => console.log("REDACTED :", r.redactedText)),
+                mergeMap((r) =>
+                    openai.chat({ prompt: r.redactedText, max_tokens: 120 })
+                )
+            )
+            .subscribe({
+                next: (reply) => {
+                    const content =
+                        typeof reply === "string"
+                            ? reply
+                            : (reply as any)?.content;
+                    console.log("LLM REPLY:", content);
+                    console.log();
+                },
+                error: reject,
+                complete: resolve,
+            });
+    });
+}
+
+async function main() {
+    if (process.argv.includes("--stream")) {
+        await demoObservableChain();
+    } else {
+        await demoPromiseChain();
+    }
+}
+
+main().catch((err) => {
+    console.error("\n[example] failed:", err);
+    process.exit(1);
+});

--- a/JS/edgechains/examples/pii-redactor/tsconfig.json
+++ b/JS/edgechains/examples/pii-redactor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "Node",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "outDir": "dist",
+        "resolveJsonModule": true,
+        "allowSyntheticDefaultImports": true
+    },
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Closes #290

/claim #290

Adds an AWS Comprehend wrapper to `@arakoodev/edgechains.js/ai` so prompts can be PII-scrubbed before being sent to an Endpoint (OpenAI, GeminiAI, LlamaAI, RetellAI).

The issue asks for "new classes that can be chained with existing Endpoint classes (as observables)". I exposed two surfaces over the same underlying logic so people can pick whichever matches their code:

- `AWSComprehend` - promise API (`detectPii`, `containsPii`, `redact`, `redactBatch`, `chain`)
- `redact$`, `redactPii`, `redactPiiText`, `redactPiiBatch` - RxJS Observable / operator API that drops into a `pipe()`

### Files

`JS/edgechains/arakoodev/src/ai/src/`
- `lib/aws-comprehend/comprehend.ts` - the class
- `lib/aws-comprehend/observables.ts` - rxjs operators
- `lib/aws-comprehend/index.ts` - barrel
- `tests/awsComprehend.test.ts` - 17 vitest tests, AWS SDK mocked
- `index.ts` - re-export the new symbols

`JS/edgechains/examples/pii-redactor/`
- runnable example with both promise + observable demos against the existing `OpenAI` Endpoint

### New deps in `arakoodev/package.json`

```json
"@aws-sdk/client-comprehend": "^3.600.0",
"rxjs": "^7.8.1"
```

### Usage

Promise:

```ts
import { AWSComprehend, OpenAI } from "@arakoodev/edgechains.js/ai";

const comprehend = new AWSComprehend({ region: "us-east-1" });
const openai     = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });

const reply = await comprehend.chain(
    userPrompt,
    safe => openai.chat({ prompt: safe }),
    { strategy: "type" }   // -> "[EMAIL]", "[PHONE]", "[SSN]" ...
);
```

Observable:

```ts
import { from } from "rxjs";
import { mergeMap } from "rxjs/operators";
import { AWSComprehend, redactPii, OpenAI } from "@arakoodev/edgechains.js/ai";

const comprehend = new AWSComprehend();
const openai     = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });

userPrompts$
  .pipe(
    redactPii(comprehend, { strategy: "type" }),
    mergeMap(r => openai.chat({ prompt: r.redactedText }))
  )
  .subscribe(reply => sendBack(reply));
```

`redact()` options: `languageCode`, `piiEntityTypes` (filter to specific types), `minConfidence` (default 0.5), `redactionChar`, `strategy` (`"char"` | `"type"` | `"fixed"`).

Credentials resolved from constructor -> env (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`) -> default AWS credential chain. Inputs above 100 KB are rejected before the network call (Comprehend's hard limit).

### Tests

```
cd JS/edgechains/arakoodev
pnpm install
pnpm test -- awsComprehend
```

```
Test Files  1 passed (1)
     Tests  17 passed (17)
```

Tests mock `@aws-sdk/client-comprehend` so they run with no AWS account. They cover detection, redaction (all three strategies + entity-type filter + confidence filter), batching, the promise `chain()` helper, and every observable operator including the `from -> redactPii -> mergeMap(endpoint)` composition that the issue asks for.

### Demo

```
cd JS/edgechains/examples/pii-redactor
cp .env.example .env   # add AWS_* + OPENAI_API_KEY
pnpm install
pnpm start             # promise demo
pnpm run stream        # rxjs demo
```

```
ORIGINAL : Hi, I'm Sarah Chen (sarah.chen@acme.io). My phone is 415-555-0142 ...
REDACTED : Hi, I'm [NAME] ([EMAIL]). My phone is [PHONE] ...
LLM REPLY: Sure, here's a polite extension request you can send ...
```

### IAM

```json
{
  "Version": "2012-10-17",
  "Statement": [{
    "Effect": "Allow",
    "Action": ["comprehend:DetectPiiEntities", "comprehend:ContainsPiiEntities"],
    "Resource": "*"
  }]
}
```

Let me know if you'd like a different naming scheme for the operators or a different default for `concurrency` / `minConfidence`.
