### PR TITLE
Add AWS Comprehend PII redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -3,3 +3,23 @@ Installation
 ```
 npm install arakoodev
 ```
+
+## AWS Comprehend PII redaction
+
+`AwsComprehendRedactor` wraps AWS Comprehend `DetectPiiEntities` and returns redacted text plus the detected entity metadata. It accepts either an AWS SDK v2-style client with `detectPiiEntities()` or an AWS SDK v3-style client with `send()` and a command factory.
+
+```ts
+import { ComprehendClient, DetectPiiEntitiesCommand } from "@aws-sdk/client-comprehend";
+import { AwsComprehendRedactor } from "@arakoodev/edgechains.js/ai";
+
+const redactor = new AwsComprehendRedactor({
+    client: new ComprehendClient({ region: "us-east-1" }),
+    commandFactory: DetectPiiEntitiesCommand,
+    minScore: 0.9,
+});
+
+const result = await redactor.redact("Jane can be reached at jane@example.com");
+console.log(result.redactedText); // [NAME_REDACTED] can be reached at [EMAIL_REDACTED]
+```
+
+Options include `languageCode`, `minScore`, `entityTypes`, and a static or callback `replacement` for custom redaction tokens.

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,15 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AwsComprehendRedactor } from "./lib/aws-comprehend/awsComprehendRedactor.js";
+export type {
+    AwsComprehendCommandClient,
+    AwsComprehendCommandFactory,
+    AwsComprehendDetectPiiClient,
+    AwsComprehendDetectPiiResponse,
+    AwsComprehendPiiEntity,
+    AwsComprehendPiiEntityType,
+    AwsComprehendRedactorOptions,
+    RedactPiiOptions,
+    RedactPiiResult,
+} from "./lib/aws-comprehend/awsComprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
@@ -1,0 +1,176 @@
+export type AwsComprehendPiiEntityType =
+    | "BANK_ACCOUNT_NUMBER"
+    | "BANK_ROUTING"
+    | "CREDIT_DEBIT_NUMBER"
+    | "CREDIT_DEBIT_CVV"
+    | "CREDIT_DEBIT_EXPIRY"
+    | "PIN"
+    | "EMAIL"
+    | "ADDRESS"
+    | "NAME"
+    | "PHONE"
+    | "SSN"
+    | "DATE_TIME"
+    | "PASSPORT_NUMBER"
+    | "DRIVER_ID"
+    | "URL"
+    | "AGE"
+    | "USERNAME"
+    | "PASSWORD"
+    | "AWS_ACCESS_KEY"
+    | "AWS_SECRET_KEY"
+    | "IP_ADDRESS"
+    | "MAC_ADDRESS"
+    | "ALL";
+
+export interface AwsComprehendPiiEntity {
+    Type?: AwsComprehendPiiEntityType | string;
+    BeginOffset?: number;
+    EndOffset?: number;
+    Score?: number;
+}
+
+export interface AwsComprehendDetectPiiResponse {
+    Entities?: AwsComprehendPiiEntity[];
+}
+
+export interface AwsComprehendDetectPiiClient {
+    detectPiiEntities(input: {
+        Text: string;
+        LanguageCode: string;
+    }): Promise<AwsComprehendDetectPiiResponse> | AwsComprehendDetectPiiResponse;
+}
+
+export interface AwsComprehendCommandClient {
+    send(command: unknown): Promise<AwsComprehendDetectPiiResponse> | AwsComprehendDetectPiiResponse;
+}
+
+export type AwsComprehendCommandFactory = new (input: {
+    Text: string;
+    LanguageCode: string;
+}) => unknown;
+
+export interface AwsComprehendRedactorOptions {
+    client: AwsComprehendDetectPiiClient | AwsComprehendCommandClient;
+    languageCode?: string;
+    commandFactory?: AwsComprehendCommandFactory;
+    minScore?: number;
+    replacement?: string | ((entity: AwsComprehendPiiEntity) => string);
+    entityTypes?: AwsComprehendPiiEntityType[] | string[];
+}
+
+export interface RedactPiiOptions {
+    languageCode?: string;
+    minScore?: number;
+    replacement?: string | ((entity: AwsComprehendPiiEntity) => string);
+    entityTypes?: AwsComprehendPiiEntityType[] | string[];
+}
+
+export interface RedactPiiResult {
+    redactedText: string;
+    entities: AwsComprehendPiiEntity[];
+}
+
+function hasDetectPiiEntities(client: unknown): client is AwsComprehendDetectPiiClient {
+    return typeof (client as AwsComprehendDetectPiiClient).detectPiiEntities === "function";
+}
+
+function hasSend(client: unknown): client is AwsComprehendCommandClient {
+    return typeof (client as AwsComprehendCommandClient).send === "function";
+}
+
+function normalizeEntity(entity: AwsComprehendPiiEntity): AwsComprehendPiiEntity | null {
+    if (typeof entity.BeginOffset !== "number" || typeof entity.EndOffset !== "number") {
+        return null;
+    }
+
+    if (entity.BeginOffset < 0 || entity.EndOffset <= entity.BeginOffset) {
+        return null;
+    }
+
+    return entity;
+}
+
+function buildReplacement(
+    replacement: string | ((entity: AwsComprehendPiiEntity) => string),
+    entity: AwsComprehendPiiEntity
+): string {
+    return typeof replacement === "function" ? replacement(entity) : replacement;
+}
+
+export class AwsComprehendRedactor {
+    private readonly client: AwsComprehendDetectPiiClient | AwsComprehendCommandClient;
+    private readonly languageCode: string;
+    private readonly commandFactory?: AwsComprehendCommandFactory;
+    private readonly minScore: number;
+    private readonly replacement: string | ((entity: AwsComprehendPiiEntity) => string);
+    private readonly entityTypes?: Set<string>;
+
+    constructor(options: AwsComprehendRedactorOptions) {
+        if (!options.client) {
+            throw new Error("AwsComprehendRedactor requires an AWS Comprehend client");
+        }
+
+        if (hasSend(options.client) && !options.commandFactory) {
+            throw new Error("commandFactory is required when using an AWS SDK v3 send() client");
+        }
+
+        this.client = options.client;
+        this.languageCode = options.languageCode || "en";
+        this.commandFactory = options.commandFactory;
+        this.minScore = options.minScore ?? 0;
+        this.replacement = options.replacement || ((entity) => `[${entity.Type || "PII"}_REDACTED]`);
+        this.entityTypes = options.entityTypes ? new Set(options.entityTypes.map((type) => String(type))) : undefined;
+    }
+
+    async detectPiiEntities(text: string, options: RedactPiiOptions = {}): Promise<AwsComprehendPiiEntity[]> {
+        const input = {
+            Text: text,
+            LanguageCode: options.languageCode || this.languageCode,
+        };
+
+        const response = hasDetectPiiEntities(this.client)
+            ? await this.client.detectPiiEntities(input)
+            : await this.client.send(new this.commandFactory!(input));
+
+        const minScore = options.minScore ?? this.minScore;
+        const entityTypes = options.entityTypes ? new Set(options.entityTypes.map((type) => String(type))) : this.entityTypes;
+
+        return (response.Entities || [])
+            .map(normalizeEntity)
+            .filter((entity): entity is AwsComprehendPiiEntity => Boolean(entity))
+            .filter((entity) => (entity.Score ?? 1) >= minScore)
+            .filter((entity) => !entityTypes || entityTypes.has(String(entity.Type)))
+            .sort((left, right) => left.BeginOffset! - right.BeginOffset! || right.EndOffset! - left.EndOffset!);
+    }
+
+    async redact(text: string, options: RedactPiiOptions = {}): Promise<RedactPiiResult> {
+        const detectedEntities = await this.detectPiiEntities(text, options);
+        const replacement = options.replacement || this.replacement;
+        const nonOverlappingEntities: AwsComprehendPiiEntity[] = [];
+        let lastEndOffset = -1;
+
+        for (const entity of detectedEntities) {
+            if (entity.BeginOffset! >= lastEndOffset) {
+                nonOverlappingEntities.push(entity);
+                lastEndOffset = entity.EndOffset!;
+            }
+        }
+
+        let cursor = 0;
+        let redactedText = "";
+
+        for (const entity of nonOverlappingEntities) {
+            redactedText += text.slice(cursor, entity.BeginOffset);
+            redactedText += buildReplacement(replacement, entity);
+            cursor = entity.EndOffset!;
+        }
+
+        redactedText += text.slice(cursor);
+
+        return {
+            redactedText,
+            entities: nonOverlappingEntities,
+        };
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
@@ -1,0 +1,74 @@
+import { AwsComprehendRedactor } from "../lib/aws-comprehend/awsComprehendRedactor";
+
+describe("AwsComprehendRedactor", () => {
+    test("redacts PII entities returned by AWS Comprehend", async () => {
+        const client = {
+            detectPiiEntities: jest.fn().mockResolvedValue({
+                Entities: [
+                    { Type: "NAME", BeginOffset: 0, EndOffset: 10, Score: 0.99 },
+                    { Type: "EMAIL", BeginOffset: 26, EndOffset: 42, Score: 0.98 },
+                ],
+            }),
+        };
+
+        const redactor = new AwsComprehendRedactor({ client });
+        const result = await redactor.redact("Jane Smith can be reached jane@example.com");
+
+        expect(client.detectPiiEntities).toHaveBeenCalledWith({
+            Text: "Jane Smith can be reached jane@example.com",
+            LanguageCode: "en",
+        });
+        expect(result.redactedText).toBe("[NAME_REDACTED] can be reached [EMAIL_REDACTED]");
+        expect(result.entities).toHaveLength(2);
+    });
+
+    test("supports score, type filters and custom replacement", async () => {
+        const client = {
+            detectPiiEntities: jest.fn().mockResolvedValue({
+                Entities: [
+                    { Type: "NAME", BeginOffset: 0, EndOffset: 4, Score: 0.99 },
+                    { Type: "PHONE", BeginOffset: 11, EndOffset: 19, Score: 0.4 },
+                    { Type: "EMAIL", BeginOffset: 23, EndOffset: 34, Score: 0.95 },
+                ],
+            }),
+        };
+
+        const redactor = new AwsComprehendRedactor({
+            client,
+            minScore: 0.9,
+            entityTypes: ["EMAIL", "PHONE"],
+            replacement: (entity) => `<${entity.Type}>`,
+        });
+
+        const result = await redactor.redact("John phone 555-1212 or a@b.example");
+
+        expect(result.redactedText).toBe("John phone 555-1212 or <EMAIL>");
+        expect(result.entities.map((entity) => entity.Type)).toEqual(["EMAIL"]);
+    });
+
+    test("supports AWS SDK v3 clients through send and a command factory", async () => {
+        class DetectPiiEntitiesCommand {
+            input: unknown;
+            constructor(input: unknown) {
+                this.input = input;
+            }
+        }
+
+        const client = {
+            send: jest.fn().mockResolvedValue({
+                Entities: [{ Type: "SSN", BeginOffset: 4, EndOffset: 15, Score: 1 }],
+            }),
+        };
+
+        const redactor = new AwsComprehendRedactor({
+            client,
+            commandFactory: DetectPiiEntitiesCommand,
+            replacement: "[REDACTED]",
+        });
+
+        const result = await redactor.redact("SSN 123-45-6789");
+
+        expect(client.send).toHaveBeenCalledWith(expect.any(DetectPiiEntitiesCommand));
+        expect(result.redactedText).toBe("SSN [REDACTED]");
+    });
+});


### PR DESCRIPTION
Closes #290

## Summary
- add `AwsComprehendRedactor` utility for AWS Comprehend DetectPiiEntities
- support AWS SDK v2-style `detectPiiEntities()` clients and SDK v3 `send()` clients via a command factory
- add score/type filtering, custom replacement tokens, entity metadata return, README usage, and Jest coverage

## Verification
- `npm run build`
- `npx jest src/ai/src/tests/awsComprehendRedactor.test.ts --runInBand`
