### PR TITLE
Add Google PaLM2 API support

### DIFF
--- a/JS/edgechains/arakoodev/examples/palm2/README.md
+++ b/JS/edgechains/arakoodev/examples/palm2/README.md
@@ -1,0 +1,16 @@
+# PaLM2 example
+
+This example keeps prompt content in `prompt.jsonnet`, matching the EdgeChains convention that prompts/config live in Jsonnet rather than being hardcoded in application code.
+
+```ts
+import { Palm2AI } from "@arakoodev/edgechains.js/ai";
+
+const palm2 = new Palm2AI({ apiKey: process.env.PALM2_API_KEY });
+
+// Load/evaluate examples/palm2/prompt.jsonnet with your Jsonnet tooling, then pass
+// prompt.text into generateText or chat.messages/context into chat.
+const textResponse = await palm2.generateText({
+  prompt: prompt.text,
+  model: "text-bison-001",
+});
+```

--- a/JS/edgechains/arakoodev/examples/palm2/prompt.jsonnet
+++ b/JS/edgechains/arakoodev/examples/palm2/prompt.jsonnet
@@ -1,0 +1,14 @@
+{
+  prompt: {
+    text: 'Summarize why EdgeChains makes LLM workflows easier in one sentence.',
+  },
+  chat: {
+    context: 'You are a concise assistant for EdgeChains JavaScript examples.',
+    messages: [
+      {
+        author: 'user',
+        content: 'Explain how to configure a PaLM2 call.',
+      },
+    ],
+  },
+}

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,17 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
+export type {
+    Palm2ChatMessage,
+    Palm2ChatOptions,
+    Palm2ChatResponse,
+    Palm2ConstructionOptions,
+    Palm2GenerateTextResponse,
+    Palm2SafetyCategory,
+    Palm2SafetySetting,
+    Palm2SafetyThreshold,
+    Palm2TextOptions,
+} from "./lib/palm2/palm2.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,174 @@
+import axios, { AxiosInstance } from "axios";
+import { retry } from "@lifeomic/attempt";
+
+const DEFAULT_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta2";
+const DEFAULT_TEXT_MODEL = "text-bison-001";
+const DEFAULT_CHAT_MODEL = "chat-bison-001";
+
+export type Palm2SafetyCategory =
+    | "HARM_CATEGORY_DEROGATORY"
+    | "HARM_CATEGORY_TOXICITY"
+    | "HARM_CATEGORY_VIOLENCE"
+    | "HARM_CATEGORY_SEXUAL"
+    | "HARM_CATEGORY_MEDICAL"
+    | "HARM_CATEGORY_DANGEROUS";
+
+export type Palm2SafetyThreshold =
+    | "BLOCK_NONE"
+    | "BLOCK_ONLY_HIGH"
+    | "BLOCK_MEDIUM_AND_ABOVE"
+    | "BLOCK_LOW_AND_ABOVE";
+
+export interface Palm2SafetySetting {
+    category: Palm2SafetyCategory;
+    threshold: Palm2SafetyThreshold;
+}
+
+export interface Palm2ConstructionOptions {
+    apiKey?: string;
+    baseUrl?: string;
+    client?: AxiosInstance;
+}
+
+export interface Palm2TextOptions {
+    prompt: string;
+    model?: string;
+    temperature?: number;
+    candidateCount?: number;
+    maxOutputTokens?: number;
+    topP?: number;
+    topK?: number;
+    safetySettings?: Palm2SafetySetting[];
+    maxRetry?: number;
+    delay?: number;
+}
+
+export interface Palm2ChatMessage {
+    author: string;
+    content: string;
+}
+
+export interface Palm2ChatOptions {
+    messages: Palm2ChatMessage[];
+    model?: string;
+    context?: string;
+    examples?: Array<{ input: Palm2ChatMessage; output: Palm2ChatMessage }>;
+    temperature?: number;
+    candidateCount?: number;
+    topP?: number;
+    topK?: number;
+    safetySettings?: Palm2SafetySetting[];
+    maxRetry?: number;
+    delay?: number;
+}
+
+export interface Palm2TextCandidate {
+    output: string;
+    safetyRatings?: Array<{ category: Palm2SafetyCategory; probability: string }>;
+    citationMetadata?: unknown;
+}
+
+export interface Palm2GenerateTextResponse {
+    candidates: Palm2TextCandidate[];
+    filters?: Array<{ reason: string; message?: string }>;
+}
+
+export interface Palm2ChatCandidate {
+    author: string;
+    content: string;
+    citationMetadata?: unknown;
+}
+
+export interface Palm2ChatResponse {
+    candidates: Palm2ChatCandidate[];
+    messages?: Palm2ChatMessage[];
+    filters?: Array<{ reason: string; message?: string }>;
+}
+
+export class Palm2AI {
+    apiKey: string;
+    baseUrl: string;
+    private client: AxiosInstance;
+
+    constructor(options: Palm2ConstructionOptions = {}) {
+        this.apiKey = options.apiKey || process.env.PALM2_API_KEY || process.env.GOOGLE_API_KEY || "";
+        this.baseUrl = (options.baseUrl || DEFAULT_API_BASE_URL).replace(/\/$/, "");
+        this.client = options.client || axios.create();
+    }
+
+    async generateText(options: Palm2TextOptions): Promise<Palm2GenerateTextResponse> {
+        const payload = {
+            prompt: { text: options.prompt },
+            temperature: options.temperature,
+            candidateCount: options.candidateCount,
+            maxOutputTokens: options.maxOutputTokens,
+            topP: options.topP,
+            topK: options.topK,
+            safetySettings: options.safetySettings,
+        };
+
+        return retry(
+            async () => {
+                const response = await this.client.post<Palm2GenerateTextResponse>(
+                    this.buildUrl(options.model || DEFAULT_TEXT_MODEL, "generateText"),
+                    this.withoutUndefined(payload),
+                    this.requestConfig()
+                );
+                return response.data;
+            },
+            { maxAttempts: options.maxRetry || 3, delay: options.delay || 200 }
+        );
+    }
+
+    async chat(options: Palm2ChatOptions): Promise<Palm2ChatResponse> {
+        const payload = {
+            prompt: {
+                context: options.context,
+                examples: options.examples,
+                messages: options.messages,
+            },
+            temperature: options.temperature,
+            candidateCount: options.candidateCount,
+            topP: options.topP,
+            topK: options.topK,
+            safetySettings: options.safetySettings,
+        };
+
+        return retry(
+            async () => {
+                const response = await this.client.post<Palm2ChatResponse>(
+                    this.buildUrl(options.model || DEFAULT_CHAT_MODEL, "generateMessage"),
+                    this.withoutUndefined(payload),
+                    this.requestConfig()
+                );
+                return response.data;
+            },
+            { maxAttempts: options.maxRetry || 3, delay: options.delay || 200 }
+        );
+    }
+
+    private buildUrl(model: string, method: "generateText" | "generateMessage"): string {
+        return `${this.baseUrl}/models/${model}:${method}`;
+    }
+
+    private requestConfig() {
+        return {
+            params: { key: this.apiKey },
+            headers: { "Content-Type": "application/json" },
+        };
+    }
+
+    private withoutUndefined<T>(value: T): T {
+        if (Array.isArray(value)) {
+            return value.map((item) => this.withoutUndefined(item)) as T;
+        }
+        if (value && typeof value === "object") {
+            return Object.fromEntries(
+                Object.entries(value as Record<string, unknown>)
+                    .filter(([, entryValue]) => entryValue !== undefined)
+                    .map(([key, entryValue]) => [key, this.withoutUndefined(entryValue)])
+            ) as T;
+        }
+        return value;
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/testcases/palm2/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/testcases/palm2/palm2.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from "vitest";
+import { Palm2AI } from "../../lib/palm2/palm2";
+
+describe("Palm2AI", () => {
+    test("generates text with the PaLM2 text-bison endpoint", async () => {
+        const post = vi.fn().mockResolvedValueOnce({
+            data: { candidates: [{ output: "Hello from PaLM2" }] },
+        });
+        const palm2 = new Palm2AI({ apiKey: "test-key", client: { post } as any });
+
+        const response = await palm2.generateText({
+            prompt: "Say hello",
+            temperature: 0.2,
+            maxOutputTokens: 64,
+            maxRetry: 1,
+        });
+
+        expect(response.candidates[0].output).toBe("Hello from PaLM2");
+        expect(post).toHaveBeenCalledWith(
+            "https://generativelanguage.googleapis.com/v1beta2/models/text-bison-001:generateText",
+            {
+                prompt: { text: "Say hello" },
+                temperature: 0.2,
+                maxOutputTokens: 64,
+            },
+            {
+                params: { key: "test-key" },
+                headers: { "Content-Type": "application/json" },
+            }
+        );
+    });
+
+    test("sends chat messages to the PaLM2 chat-bison endpoint", async () => {
+        const post = vi.fn().mockResolvedValueOnce({
+            data: { candidates: [{ author: "bot", content: "A short answer" }] },
+        });
+        const palm2 = new Palm2AI({ apiKey: "test-key", client: { post } as any });
+
+        const response = await palm2.chat({
+            context: "Answer tersely.",
+            messages: [{ author: "user", content: "What is EdgeChains?" }],
+            maxRetry: 1,
+        });
+
+        expect(response.candidates[0].content).toBe("A short answer");
+        expect(post).toHaveBeenCalledWith(
+            "https://generativelanguage.googleapis.com/v1beta2/models/chat-bison-001:generateMessage",
+            {
+                prompt: {
+                    context: "Answer tersely.",
+                    messages: [{ author: "user", content: "What is EdgeChains?" }],
+                },
+            },
+            {
+                params: { key: "test-key" },
+                headers: { "Content-Type": "application/json" },
+            }
+        );
+    });
+});


### PR DESCRIPTION
Closes #279.

## Summary
- Adds a typed `Palm2AI` client for Google PaLM2 text-bison and chat-bison endpoints.
- Exports PaLM2 classes/types from the AI package entrypoint.
- Adds unit testcases in a `testcases/palm2` folder covering text and chat request payloads.
- Adds a PaLM2 example with prompts/config kept in `examples/palm2/prompt.jsonnet` instead of hardcoded prompt strings.

## Verification
- `npm run build`
- `npx vitest run src/ai/src/testcases/palm2/palm2.test.ts`
