### PR TITLE
feat: add Qdrant vector database client for JavaScript SDK (#273)

### DIFF
--- a/JS/edgechains/arakoodev/src/db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/db/src/index.ts
@@ -1,1 +1,2 @@
 export { PostgresClient } from "./lib/postgres-client/PostgresClient.js";
+export { QdrantClient, QdrantDistanceMetric } from "./lib/qdrant-client/QdrantClient.js";

--- a/JS/edgechains/arakoodev/src/db/src/lib/qdrant-client/QdrantClient.ts
+++ b/JS/edgechains/arakoodev/src/db/src/lib/qdrant-client/QdrantClient.ts
@@ -1,0 +1,279 @@
+/**
+ * QdrantClient - Vector database client for EdgeChains using Qdrant REST API
+ * Issue: https://github.com/arakoodev/EdgeChains/issues/273
+ */
+
+export interface QdrantPoint {
+    id: string | number;
+    vector: number[];
+    payload?: Record<string, any>;
+}
+
+export interface QdrantSearchResult {
+    id: string | number;
+    score: number;
+    payload?: Record<string, any>;
+    version?: number;
+}
+
+export enum QdrantDistanceMetric {
+    COSINE = "Cosine",
+    EUCLID = "Euclid",
+    DOT = "Dot",
+}
+
+export class QdrantClient {
+    private baseUrl: string;
+    private apiKey?: string;
+    wordEmbeddings: number[][];
+    metric: QdrantDistanceMetric;
+    topK: number;
+    collectionName: string;
+    namespace: string;
+    arkRequest: any;
+    upperLimit: number;
+
+    constructor(
+        baseUrl: string,
+        wordEmbeddings: number[][],
+        metric: QdrantDistanceMetric,
+        topK: number,
+        collectionName: string,
+        namespace: string,
+        arkRequest: any,
+        upperLimit: number,
+        apiKey?: string
+    ) {
+        this.baseUrl = baseUrl.replace(/\/$/, "");
+        this.wordEmbeddings = wordEmbeddings;
+        this.metric = metric;
+        this.topK = topK;
+        this.collectionName = collectionName;
+        this.namespace = namespace;
+        this.arkRequest = arkRequest;
+        this.upperLimit = upperLimit;
+        this.apiKey = apiKey;
+    }
+
+    private getHeaders(): Record<string, string> {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (this.apiKey) {
+            headers["api-key"] = this.apiKey;
+        }
+        return headers;
+    }
+
+    /**
+     * Search for similar vectors in Qdrant
+     */
+    async searchVectors(
+        vector: number[],
+        filter?: Record<string, any>,
+        withPayload: boolean = true
+    ): Promise<QdrantSearchResult[]> {
+        const response = await fetch(
+            `${this.baseUrl}/collections/${this.collectionName}/points/search`,
+            {
+                method: "POST",
+                headers: this.getHeaders(),
+                body: JSON.stringify({
+                    vector,
+                    limit: this.topK,
+                    with_payload: withPayload,
+                    filter: filter || this.buildNamespaceFilter(),
+                    with_vector: false,
+                }),
+            }
+        );
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`Qdrant search failed: ${response.status} - ${error}`);
+        }
+
+        const data = await response.json();
+        return (data.result || []).map((item: any) => ({
+            id: item.id,
+            score: item.score,
+            payload: item.payload,
+            version: item.version,
+        }));
+    }
+
+    /**
+     * Perform batch search across multiple vectors (rrf-style combining)
+     */
+    async dbQuery(): Promise<QdrantSearchResult[]> {
+        const allResults: QdrantSearchResult[][] = [];
+
+        for (const embedding of this.wordEmbeddings) {
+            const results = await this.searchVectors(embedding);
+            allResults.push(results);
+        }
+
+        // Combine and deduplicate results, then sort by score
+        const combinedResults = this.combineAndRankResults(allResults);
+
+        return combinedResults.slice(0, this.upperLimit || this.topK);
+    }
+
+    /**
+     * Upsert points into Qdrant collection
+     */
+    async upsertPoints(points: QdrantPoint[]): Promise<boolean> {
+        const response = await fetch(
+            `${this.baseUrl}/collections/${this.collectionName}/points?wait=true`,
+            {
+                method: "PUT",
+                headers: this.getHeaders(),
+                body: JSON.stringify({ points }),
+            }
+        );
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`Qdrant upsert failed: ${response.status} - ${error}`);
+        }
+
+        const data = await response.json();
+        return data.result?.status === "completed" || data.result?.operation_id !== undefined;
+    }
+
+    /**
+     * Delete points by ID
+     */
+    async deletePoints(ids: (string | number)[]): Promise<boolean> {
+        const response = await fetch(
+            `${this.baseUrl}/collections/${this.collectionName}/points/delete?wait=true`,
+            {
+                method: "POST",
+                headers: this.getHeaders(),
+                body: JSON.stringify({ points: ids }),
+            }
+        );
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(`Qdrant delete failed: ${response.status} - ${error}`);
+        }
+
+        const data = await response.json();
+        return data.result?.status === "completed" || data.result?.operation_id !== undefined;
+    }
+
+    /**
+     * Get collection info
+     */
+    async getCollectionInfo(): Promise<Record<string, any>> {
+        const response = await fetch(
+            `${this.baseUrl}/collections/${this.collectionName}`,
+            {
+                method: "GET",
+                headers: this.getHeaders(),
+            }
+        );
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(
+                `Qdrant getCollectionInfo failed: ${response.status} - ${error}`
+            );
+        }
+
+        return await response.json();
+    }
+
+    /**
+     * Create a new collection with specified parameters
+     */
+    async createCollection(
+        vectorSize: number,
+        distance: QdrantDistanceMetric = QdrantDistanceMetric.COSINE
+    ): Promise<boolean> {
+        const response = await fetch(
+            `${this.baseUrl}/collections/${this.collectionName}`,
+            {
+                method: "PUT",
+                headers: this.getHeaders(),
+                body: JSON.stringify({
+                    vectors: {
+                        size: vectorSize,
+                        distance,
+                    },
+                }),
+            }
+        );
+
+        if (!response.ok) {
+            const error = await response.text();
+            throw new Error(
+                `Qdrant createCollection failed: ${response.status} - ${error}`
+            );
+        }
+
+        const data = await response.json();
+        return data.result === true;
+    }
+
+    /**
+     * Check if Qdrant server is reachable
+     */
+    async healthCheck(): Promise<boolean> {
+        try {
+            const response = await fetch(`${this.baseUrl}/`, {
+                method: "GET",
+                headers: this.getHeaders(),
+            });
+            return response.ok;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Build a filter for namespace filtering
+     */
+    private buildNamespaceFilter(): Record<string, any> | undefined {
+        if (!this.namespace) return undefined;
+
+        return {
+            must: [
+                {
+                    key: "namespace",
+                    match: {
+                        value: this.namespace,
+                    },
+                },
+            ],
+        };
+    }
+
+    /**
+     * Combine results from multiple searches, deduplicate, and rank by score
+     */
+    private combineAndRankResults(
+        results: QdrantSearchResult[][]
+    ): QdrantSearchResult[] {
+        if (results.length === 0) return [];
+        if (results.length === 1) return results[0];
+
+        // Use a map to deduplicate by ID, keeping the highest score
+        const scoreMap = new Map<string | number, QdrantSearchResult>();
+
+        for (const batch of results) {
+            for (const result of batch) {
+                const existing = scoreMap.get(result.id);
+                if (!existing || result.score > existing.score) {
+                    scoreMap.set(result.id, result);
+                }
+            }
+        }
+
+        // Convert back to array and sort by score descending
+        return Array.from(scoreMap.values()).sort(
+            (a, b) => b.score - a.score
+        );
+    }
+}

--- a/JS/edgechains/arakoodev/src/db/src/tests/qdrant-client/qdrantClient.test.ts
+++ b/JS/edgechains/arakoodev/src/db/src/tests/qdrant-client/qdrantClient.test.ts
@@ -1,0 +1,371 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+    QdrantClient,
+    QdrantDistanceMetric,
+    QdrantPoint,
+    QdrantSearchResult,
+} from "../../../../../dist/db/src/lib/qdrant-client/QdrantClient.js";
+
+describe("QdrantClient", () => {
+    let client: QdrantClient;
+    const baseUrl = "http://localhost:6333";
+
+    beforeEach(() => {
+        client = new QdrantClient(
+            baseUrl,
+            [[0.1, 0.2, 0.3]],
+            QdrantDistanceMetric.COSINE,
+            5,
+            "test_collection",
+            "test_namespace",
+            {
+                textWeight: { baseWeight: 1, fineTuneWeight: 0.5 },
+                similarityWeight: { baseWeight: 1, fineTuneWeight: 0.5 },
+                dateWeight: { baseWeight: 1, fineTuneWeight: 0.5 },
+                orderRRF: "text_rank",
+                metadataTable: "test_metadata",
+                query: "test_query",
+            },
+            10,
+            "test-api-key"
+        );
+        vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    describe("searchVectors", () => {
+        test("should search vectors successfully", async () => {
+            const mockResults = [
+                {
+                    id: "1",
+                    score: 0.95,
+                    payload: { text: "result 1", namespace: "test_namespace" },
+                    version: 1,
+                },
+                {
+                    id: "2",
+                    score: 0.85,
+                    payload: { text: "result 2", namespace: "test_namespace" },
+                    version: 1,
+                },
+            ];
+
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ result: mockResults, status: "ok", time: 0.001 }),
+            } as Response);
+
+            const vector = [0.1, 0.2, 0.3];
+            const results = await client.searchVectors(vector);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                `${baseUrl}/collections/test_collection/points/search`,
+                expect.objectContaining({
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "api-key": "test-api-key",
+                    },
+                    body: expect.any(String),
+                })
+            );
+
+            expect(results).toHaveLength(2);
+            expect(results[0].id).toBe("1");
+            expect(results[0].score).toBe(0.95);
+        });
+
+        test("should throw error when search fails", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                text: async () => "Collection not found",
+            } as Response);
+
+            await expect(client.searchVectors([0.1, 0.2, 0.3])).rejects.toThrow(
+                "Qdrant search failed: 404 - Collection not found"
+            );
+        });
+    });
+
+    describe("dbQuery", () => {
+        test("should perform batch search and combine results", async () => {
+            const clientWithMultipleEmbeddings = new QdrantClient(
+                baseUrl,
+                [
+                    [0.1, 0.2, 0.3],
+                    [0.4, 0.5, 0.6],
+                ],
+                QdrantDistanceMetric.COSINE,
+                3,
+                "test_collection",
+                "test_namespace",
+                {},
+                5
+            );
+
+            const mockFetch = vi.mocked(fetch);
+            mockFetch
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        result: [
+                            { id: "1", score: 0.9, payload: { text: "a" } },
+                            { id: "2", score: 0.8, payload: { text: "b" } },
+                        ],
+                    }),
+                } as Response)
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        result: [
+                            { id: "2", score: 0.85, payload: { text: "b" } },
+                            { id: "3", score: 0.7, payload: { text: "c" } },
+                        ],
+                    }),
+                } as Response);
+
+            const results = await clientWithMultipleEmbeddings.dbQuery();
+
+            expect(results).toHaveLength(3);
+            const result2 = results.find((r: QdrantSearchResult) => r.id === "2");
+            expect(result2?.score).toBe(0.85);
+            expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+        });
+
+        test("should return single result set for single embedding", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    result: [{ id: "1", score: 0.9, payload: { text: "a" } }],
+                }),
+            } as Response);
+
+            const results = await client.dbQuery();
+
+            expect(results).toHaveLength(1);
+            expect(results[0].id).toBe("1");
+        });
+    });
+
+    describe("upsertPoints", () => {
+        test("should upsert points successfully", async () => {
+            const points: QdrantPoint[] = [
+                {
+                    id: "1",
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { text: "hello", namespace: "test_namespace" },
+                },
+                {
+                    id: "2",
+                    vector: [0.4, 0.5, 0.6],
+                    payload: { text: "world", namespace: "test_namespace" },
+                },
+            ];
+
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    result: { operation_id: 1, status: "completed" },
+                    status: "ok",
+                }),
+            } as Response);
+
+            const result = await client.upsertPoints(points);
+
+            expect(result).toBe(true);
+            expect(mockFetch).toHaveBeenCalledWith(
+                `${baseUrl}/collections/test_collection/points?wait=true`,
+                expect.objectContaining({
+                    method: "PUT",
+                    body: JSON.stringify({ points }),
+                })
+            );
+        });
+
+        test("should throw error when upsert fails", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 400,
+                text: async () => "Invalid vector dimension",
+            } as Response);
+
+            await expect(
+                client.upsertPoints([{ id: "1", vector: [0.1, 0.2] }])
+            ).rejects.toThrow("Qdrant upsert failed: 400 - Invalid vector dimension");
+        });
+    });
+
+    describe("deletePoints", () => {
+        test("should delete points by ID", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    result: { operation_id: 2, status: "completed" },
+                    status: "ok",
+                }),
+            } as Response);
+
+            const result = await client.deletePoints(["1", "2"]);
+
+            expect(result).toBe(true);
+            expect(mockFetch).toHaveBeenCalledWith(
+                `${baseUrl}/collections/test_collection/points/delete?wait=true`,
+                expect.objectContaining({
+                    method: "POST",
+                    body: JSON.stringify({ points: ["1", "2"] }),
+                })
+            );
+        });
+    });
+
+    describe("createCollection", () => {
+        test("should create collection with default Cosine distance", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ result: true, status: "ok" }),
+            } as Response);
+
+            const result = await client.createCollection(128);
+
+            expect(result).toBe(true);
+            expect(mockFetch).toHaveBeenCalledWith(
+                `${baseUrl}/collections/test_collection`,
+                expect.objectContaining({
+                    method: "PUT",
+                    body: JSON.stringify({
+                        vectors: {
+                            size: 128,
+                            distance: "Cosine",
+                        },
+                    }),
+                })
+            );
+        });
+
+        test("should create collection with Euclid distance", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ result: true, status: "ok" }),
+            } as Response);
+
+            const result = await client.createCollection(
+                256,
+                QdrantDistanceMetric.EUCLID
+            );
+
+            expect(result).toBe(true);
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    body: expect.stringContaining("Euclid"),
+                })
+            );
+        });
+    });
+
+    describe("getCollectionInfo", () => {
+        test("should return collection info", async () => {
+            const mockInfo = {
+                result: {
+                    status: "green",
+                    vectors_count: 100,
+                    segments_count: 2,
+                    config: {
+                        params: {
+                            vectors: { size: 128, distance: "Cosine" },
+                        },
+                    },
+                },
+                status: "ok",
+            };
+
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockInfo,
+            } as Response);
+
+            const info = await client.getCollectionInfo();
+
+            expect(info).toEqual(mockInfo);
+        });
+    });
+
+    describe("healthCheck", () => {
+        test("should return true when server is healthy", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+            } as Response);
+
+            const result = await client.healthCheck();
+
+            expect(result).toBe(true);
+        });
+
+        test("should return false when server is unreachable", async () => {
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+            const result = await client.healthCheck();
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe("constructor variations", () => {
+        test("should work without apiKey", () => {
+            const clientNoKey = new QdrantClient(
+                baseUrl,
+                [[0.1, 0.2]],
+                QdrantDistanceMetric.DOT,
+                5,
+                "coll",
+                "ns",
+                {},
+                10
+            );
+
+            expect(clientNoKey).toBeDefined();
+        });
+
+        test("should trim trailing slash from baseUrl", async () => {
+            const clientWithSlash = new QdrantClient(
+                "http://localhost:6333/",
+                [[0.1]],
+                QdrantDistanceMetric.COSINE,
+                1,
+                "coll",
+                "ns",
+                {},
+                1
+            );
+
+            const mockFetch = vi.mocked(fetch);
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ result: [], status: "ok" }),
+            } as Response);
+
+            await clientWithSlash.searchVectors([0.1]);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://localhost:6333/collections/coll/points/search",
+                expect.any(Object)
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Adds Qdrant vector database support to the EdgeChains JavaScript SDK using the Qdrant REST API directly (no external SDK package).

## Problem
The JavaScript SDK only supported PostgreSQL/Supabase as the vector database. Issue #273 requested adding Qdrant vector database support.

## Solution
- Created `QdrantClient` class that wraps the Qdrant REST API directly
- Follows the same pattern as the existing `PostgresClient`
- Supports vector search, upsert, delete, collection management
- Implements multiple distance metrics: Cosine, Euclid, Dot
- Adds namespace filtering via Qdrant payload filters
- Implements batch search with result deduplication and ranking
- Includes 14 comprehensive unit tests using vitest

## Changes
- `JS/edgechains/arakoodev/src/db/src/lib/qdrant-client/QdrantClient.ts` - New Qdrant client (279 lines)
- `JS/edgechains/arakoodev/src/db/src/tests/qdrant-client/qdrantClient.test.ts` - 14 unit tests (371 lines)
- `JS/edgechains/arakoodev/src/db/src/index.ts` - Export QdrantClient and QdrantDistanceMetric

## Testing
- All 14 unit tests pass
- Tests cover: search, batch query, upsert, delete, collection creation, collection info, health check, error handling

## Usage
```typescript
import { QdrantClient, QdrantDistanceMetric } from "@arakoodev/edgechains.js/db";

const client = new QdrantClient(
  "http://localhost:6333",
  [[0.1, 0.2, 0.3]],
  QdrantDistanceMetric.COSINE,
  5,
  "my_collection",
  "my_namespace",
  arkRequest,
  10,
  "optional-api-key"
);

// Search vectors
const results = await client.searchVectors([0.1, 0.2, 0.3]);

// Batch query (dbQuery pattern like PostgresClient)
const results = await client.dbQuery();

// Upsert points
await client.upsertPoints([
  { id: "1", vector: [0.1, 0.2], payload: { text: "hello" } }
]);
```

/claim #273