### PR TITLE
Add Qdrant support to vector-db package

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,255 @@
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+interface QdrantClient {
+    url: string;
+    apiKey?: string;
+    headers: Record<string, string>;
+}
+
+interface QdrantPoint {
+    id: string | number;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+interface QdrantRequestOptions {
+    method?: string;
+    body?: unknown;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(): QdrantClient {
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required");
+        }
+
+        return {
+            url: this.QDRANT_URL,
+            apiKey: this.QDRANT_API_KEY,
+            headers: {
+                "Content-Type": "application/json",
+                ...(this.QDRANT_API_KEY ? { "api-key": this.QDRANT_API_KEY } : {}),
+            },
+        };
+    }
+
+    private async request<T>(
+        client: QdrantClient,
+        path: string,
+        { method = "GET", body }: QdrantRequestOptions = {}
+    ): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    const response = await fetch(`${client.url}${path}`, {
+                        method,
+                        headers: client.headers,
+                        body: body === undefined ? undefined : JSON.stringify(body),
+                    });
+                    const payload = await response.json().catch(() => ({}));
+
+                    if (!response.ok) {
+                        const message =
+                            payload?.status?.error ||
+                            payload?.message ||
+                            response.statusText ||
+                            "Qdrant request failed";
+                        if (operation.retry(new Error(message))) return;
+                        reject(new Error(message));
+                        return;
+                    }
+
+                    resolve(payload as T);
+                } catch (error: any) {
+                    if (operation.retry(error)) return;
+                    reject(error);
+                }
+            });
+        });
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+        vectors,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        vectorSize?: number;
+        distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+        vectors?: Record<string, any>;
+    }): Promise<any> {
+        if (!vectors && !vectorSize) {
+            throw new Error("Either vectorSize or vectors is required to create a Qdrant collection");
+        }
+
+        const body = { vectors: vectors || { size: vectorSize, distance } };
+        return this.request(client, `/collections/${collectionName}`, {
+            method: "PUT",
+            body,
+        });
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        return this.request(client, `/collections/${collectionName}/points?wait=${wait}`, {
+            method: "PUT",
+            body: { points },
+        });
+    }
+
+    async search({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        vector: number[] | Record<string, number[]>;
+        limit?: number;
+        filter?: Record<string, any>;
+        withPayload?: boolean;
+        withVector?: boolean;
+        scoreThreshold?: number;
+    }): Promise<any> {
+        const response: any = await this.request(client, `/collections/${collectionName}/points/search`, {
+            method: "POST",
+            body: {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+            },
+        });
+
+        return response.result;
+    }
+
+    async getData({
+        client,
+        collectionName,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        limit?: number;
+        filter?: Record<string, any>;
+        withPayload?: boolean;
+        withVector?: boolean;
+    }): Promise<any> {
+        const response: any = await this.request(client, `/collections/${collectionName}/points/scroll`, {
+            method: "POST",
+            body: {
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+            },
+        });
+
+        return response.result?.points || [];
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        ids,
+        withPayload = true,
+        withVector = false,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        ids: Array<string | number>;
+        withPayload?: boolean;
+        withVector?: boolean;
+    }): Promise<any> {
+        const response: any = await this.request(client, `/collections/${collectionName}/points`, {
+            method: "POST",
+            body: {
+                ids,
+                with_payload: withPayload,
+                with_vector: withVector,
+            },
+        });
+
+        return response.result;
+    }
+
+    async updateById({
+        client,
+        collectionName,
+        ids,
+        payload,
+        wait = true,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        ids: Array<string | number>;
+        payload: Record<string, any>;
+        wait?: boolean;
+    }): Promise<any> {
+        return this.request(client, `/collections/${collectionName}/points/payload?wait=${wait}`, {
+            method: "POST",
+            body: {
+                points: ids,
+                payload,
+            },
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        ids,
+        wait = true,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        ids: Array<string | number>;
+        wait?: boolean;
+    }): Promise<any> {
+        return this.request(client, `/collections/${collectionName}/points/delete?wait=${wait}`, {
+            method: "POST",
+            body: { points: ids },
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,130 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+const MOCK_QDRANT_URL = "https://mock-qdrant.local";
+const MOCK_QDRANT_API_KEY = "mock-api-key";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+function mockQdrantResponse(result: any = { status: "ok" }) {
+    mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ result }),
+    });
+}
+
+describe("Qdrant vector database", () => {
+    it("should create a Qdrant client", () => {
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        expect(client).toEqual({
+            url: MOCK_QDRANT_URL,
+            apiKey: MOCK_QDRANT_API_KEY,
+            headers: {
+                "Content-Type": "application/json",
+                "api-key": MOCK_QDRANT_API_KEY,
+            },
+        });
+    });
+
+    it("should create a collection", async () => {
+        mockQdrantResponse(true);
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(`${MOCK_QDRANT_URL}/collections/documents`, {
+            method: "PUT",
+            headers: client.headers,
+            body: JSON.stringify({ vectors: { size: 1536, distance: "Cosine" } }),
+        });
+    });
+
+    it("should upsert vector points", async () => {
+        mockQdrantResponse({ operation_id: 1, status: "completed" });
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+        const points = [
+            {
+                id: 1,
+                vector: [0.1, 0.2, 0.3],
+                payload: { content: "hello" },
+            },
+        ];
+
+        await qdrant.insertVectorData({
+            client,
+            collectionName: "documents",
+            points,
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${MOCK_QDRANT_URL}/collections/documents/points?wait=true`,
+            {
+                method: "PUT",
+                headers: client.headers,
+                body: JSON.stringify({ points }),
+            }
+        );
+    });
+
+    it("should search vector points", async () => {
+        const result = [{ id: 1, score: 0.99, payload: { content: "hello" } }];
+        mockQdrantResponse(result);
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        const response = await qdrant.search({
+            client,
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 5,
+        });
+
+        expect(response).toEqual(result);
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${MOCK_QDRANT_URL}/collections/documents/points/search`,
+            {
+                method: "POST",
+                headers: client.headers,
+                body: JSON.stringify({
+                    vector: [0.1, 0.2, 0.3],
+                    limit: 5,
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            }
+        );
+    });
+
+    it("should delete vector points", async () => {
+        mockQdrantResponse({ operation_id: 2, status: "completed" });
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        await qdrant.deleteById({
+            client,
+            collectionName: "documents",
+            ids: [1, 2],
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${MOCK_QDRANT_URL}/collections/documents/points/delete?wait=true`,
+            {
+                method: "POST",
+                headers: client.headers,
+                body: JSON.stringify({ points: [1, 2] }),
+            }
+        );
+    });
+});


### PR DESCRIPTION
/claim #273

# PR: Add Qdrant support to vector-db package

## Summary

Adds a Qdrant vector database provider to the JS SDK vector-db package.

Closes / addresses: arakoodev/EdgeChains#273

## Changes

- Add `Qdrant` provider under `src/vector-db/src/lib/qdrant/qdrant.ts`.
- Export `Qdrant` from `src/vector-db/src/index.ts`.
- Support creating a client from explicit values or `QDRANT_URL` / `QDRANT_API_KEY`.
- Support common Qdrant REST operations:
  - create collection
  - upsert vector points
  - search vector points
  - scroll points
  - retrieve by id
  - update payload by id
  - delete by id
- Add Jest tests for client creation, collection creation, upsert, search, and delete request construction.

## Validation

- `git diff --check` passes.
- `npm run build` passes.
- `npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand` passes.

## Notes

The implementation uses Qdrant's REST API directly instead of adding a new package dependency.
