### PR TITLE
feat(js): add Google PaLM2 API client

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,17 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
+export type {
+    Palm2Candidate,
+    Palm2ChatOptions,
+    Palm2ConstructionOptions,
+    Palm2Content,
+    Palm2ContentPart,
+    Palm2EmbeddingOptions,
+    Palm2EmbeddingResponse,
+    Palm2GenerateResponse,
+    Palm2TextOptions,
+} from "./lib/palm2/palm2.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,176 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+
+const defaultBaseUrl = "https://generativelanguage.googleapis.com/v1beta";
+
+export interface Palm2ConstructionOptions {
+    apiKey?: string;
+    baseUrl?: string;
+}
+
+export interface Palm2ContentPart {
+    text: string;
+}
+
+export interface Palm2Content {
+    role?: "user" | "model";
+    parts: Palm2ContentPart[];
+}
+
+export interface Palm2ChatOptions {
+    model?: string;
+    prompt?: string;
+    contents?: Palm2Content[];
+    temperature?: number;
+    topP?: number;
+    topK?: number;
+    maxOutputTokens?: number;
+    candidateCount?: number;
+    stopSequences?: string[];
+    maxRetries?: number;
+    delay?: number;
+}
+
+export interface Palm2TextOptions {
+    model?: string;
+    prompt: string;
+    temperature?: number;
+    topP?: number;
+    topK?: number;
+    maxOutputTokens?: number;
+    candidateCount?: number;
+    stopSequences?: string[];
+    maxRetries?: number;
+    delay?: number;
+}
+
+export interface Palm2EmbeddingOptions {
+    model?: string;
+    text: string;
+    maxRetries?: number;
+    delay?: number;
+}
+
+export interface Palm2Candidate {
+    content?: Palm2Content;
+    output?: string;
+    finishReason?: string;
+    index?: number;
+}
+
+export interface Palm2GenerateResponse {
+    candidates: Palm2Candidate[];
+    usageMetadata?: {
+        promptTokenCount?: number;
+        candidatesTokenCount?: number;
+        totalTokenCount?: number;
+    };
+}
+
+export interface Palm2EmbeddingResponse {
+    embedding: {
+        values: number[];
+    };
+}
+
+export class Palm2AI {
+    private readonly apiKey: string;
+    private readonly baseUrl: string;
+
+    constructor(options: Palm2ConstructionOptions = {}) {
+        this.apiKey = options.apiKey || process.env.GOOGLE_API_KEY || process.env.PALM2_API_KEY || "";
+        this.baseUrl = options.baseUrl || defaultBaseUrl;
+    }
+
+    async chat(options: Palm2ChatOptions): Promise<Palm2GenerateResponse> {
+        const model = options.model || "gemini-pro";
+        const contents = options.contents ?? [
+            {
+                role: "user" as const,
+                parts: [{ text: options.prompt || "" }],
+            },
+        ];
+
+        return this.request<Palm2GenerateResponse>({
+            endpoint: `models/${model}:generateContent`,
+            data: {
+                contents,
+                generationConfig: this.generationConfig(options),
+            },
+            maxRetries: options.maxRetries,
+            delay: options.delay,
+        });
+    }
+
+    async generateText(options: Palm2TextOptions): Promise<Palm2GenerateResponse> {
+        const model = options.model || "text-bison-001";
+        return this.request<Palm2GenerateResponse>({
+            endpoint: `models/${model}:generateText`,
+            data: {
+                prompt: {
+                    text: options.prompt,
+                },
+                temperature: options.temperature,
+                topP: options.topP,
+                topK: options.topK,
+                maxOutputTokens: options.maxOutputTokens,
+                candidateCount: options.candidateCount,
+                stopSequences: options.stopSequences,
+            },
+            maxRetries: options.maxRetries,
+            delay: options.delay,
+        });
+    }
+
+    async generateEmbedding(options: Palm2EmbeddingOptions): Promise<Palm2EmbeddingResponse> {
+        const model = options.model || "embedding-gecko-001";
+        return this.request<Palm2EmbeddingResponse>({
+            endpoint: `models/${model}:embedText`,
+            data: {
+                text: options.text,
+            },
+            maxRetries: options.maxRetries,
+            delay: options.delay,
+        });
+    }
+
+    private async request<T>({
+        endpoint,
+        data,
+        maxRetries,
+        delay,
+    }: {
+        endpoint: string;
+        data: object;
+        maxRetries?: number;
+        delay?: number;
+    }): Promise<T> {
+        if (!this.apiKey) {
+            throw new Error("Google Generative Language API key is required");
+        }
+
+        return retry(
+            async () => {
+                const response = await axios.post<T>(`${this.baseUrl}/${endpoint}`, data, {
+                    headers: {
+                        "Content-Type": "application/json",
+                        "x-goog-api-key": this.apiKey,
+                    },
+                });
+                return response.data;
+            },
+            { maxAttempts: maxRetries || 3, delay: delay || 200 }
+        );
+    }
+
+    private generationConfig(options: Palm2ChatOptions) {
+        return {
+            temperature: options.temperature,
+            topP: options.topP,
+            topK: options.topK,
+            maxOutputTokens: options.maxOutputTokens,
+            candidateCount: options.candidateCount,
+            stopSequences: options.stopSequences,
+        };
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, mock } from "bun:test";
+import axios from "axios";
+import { Palm2AI } from "../../lib/palm2/palm2";
+
+describe("Palm2AI", () => {
+    test("calls generateContent with a chat prompt", async () => {
+        const post = mock(async () => ({
+            data: {
+                candidates: [{ content: { parts: [{ text: "Hello" }] } }],
+            },
+        }));
+        axios.post = post as any;
+
+        const palm2 = new Palm2AI({ apiKey: "test-key", baseUrl: "https://example.test" });
+        const response = await palm2.chat({ prompt: "Say hello", maxRetries: 1 });
+
+        expect(response.candidates[0].content?.parts[0].text).toBe("Hello");
+        expect(post.mock.calls[0][0]).toBe("https://example.test/models/gemini-pro:generateContent");
+        expect(post.mock.calls[0][1]).toEqual({
+            contents: [{ role: "user", parts: [{ text: "Say hello" }] }],
+            generationConfig: {
+                temperature: undefined,
+                topP: undefined,
+                topK: undefined,
+                maxOutputTokens: undefined,
+                candidateCount: undefined,
+                stopSequences: undefined,
+            },
+        });
+    });
+
+    test("supports PaLM text generation endpoint", async () => {
+        const post = mock(async () => ({
+            data: {
+                candidates: [{ output: "Generated text" }],
+            },
+        }));
+        axios.post = post as any;
+
+        const palm2 = new Palm2AI({ apiKey: "test-key", baseUrl: "https://example.test" });
+        const response = await palm2.generateText({
+            prompt: "Write a tagline",
+            temperature: 0.2,
+            maxRetries: 1,
+        });
+
+        expect(response.candidates[0].output).toBe("Generated text");
+        expect(post.mock.calls[0][0]).toBe("https://example.test/models/text-bison-001:generateText");
+        expect(post.mock.calls[0][1]).toMatchObject({
+            prompt: { text: "Write a tagline" },
+            temperature: 0.2,
+        });
+    });
+
+    test("supports embedding endpoint", async () => {
+        const post = mock(async () => ({
+            data: {
+                embedding: {
+                    values: [0.1, 0.2, 0.3],
+                },
+            },
+        }));
+        axios.post = post as any;
+
+        const palm2 = new Palm2AI({ apiKey: "test-key", baseUrl: "https://example.test" });
+        const response = await palm2.generateEmbedding({ text: "embed me", maxRetries: 1 });
+
+        expect(response.embedding.values).toEqual([0.1, 0.2, 0.3]);
+        expect(post.mock.calls[0][0]).toBe("https://example.test/models/embedding-gecko-001:embedText");
+        expect(post.mock.calls[0][1]).toEqual({ text: "embed me" });
+    });
+
+    test("throws a helpful error when no API key is configured", async () => {
+        const palm2 = new Palm2AI({ apiKey: "" });
+
+        await expect(palm2.chat({ prompt: "hello", maxRetries: 1 })).rejects.toThrow(
+            "Google Generative Language API key is required"
+        );
+    });
+});

--- a/JS/edgechains/examples/palm2-chat/README.md
+++ b/JS/edgechains/examples/palm2-chat/README.md
@@ -1,0 +1,18 @@
+# PaLM2/Gemini chat example
+
+This example keeps the prompt and model configuration in `jsonnet/main.jsonnet`
+and calls the Google Generative Language API through `Palm2AI`.
+
+## Run
+
+```sh
+export GOOGLE_API_KEY=...
+bun install
+bun run start
+```
+
+Change the prompt topic without editing TypeScript:
+
+```sh
+TOPIC="agentic workflows" bun run start
+```

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,8 @@
+local topic = std.extVar('topic');
+
+{
+  model: 'gemini-pro',
+  prompt: 'Explain ' + topic + ' in two short paragraphs for a developer audience.',
+  temperature: 0.2,
+  maxOutputTokens: 512,
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "palm2-chat-example",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "ts-node src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.1.7",
+        "ts-node": "^10.9.2"
+    },
+    "devDependencies": {
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,15 @@
+import { Palm2AI } from "@arakoodev/edgechains.js/ai";
+import Jsonnet from "@arakoodev/jsonnet";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+jsonnet.extString("topic", process.env.TOPIC ?? "retrieval augmented generation");
+
+const config = JSON.parse(jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet")));
+const palm2 = new Palm2AI({ apiKey: process.env.GOOGLE_API_KEY });
+const response = await palm2.chat(config);
+
+console.log(JSON.stringify(response, null, 2));


### PR DESCRIPTION
Fixes #279

## Summary
- add a direct `Palm2AI` client for Google Generative Language endpoints without using a Google SDK
- support chat/generateContent, PaLM text generation, and embeddings with TypeScript request/response types
- export the client from the JS AI package
- add mocked unit tests under `src/ai/src/tests/palm2`
- add a jsonnet-driven `examples/palm2-chat` example with prompts/config outside TypeScript

## Verification
- `bun test src/ai/src/tests/palm2/palm2.test.ts`
- `bun run build`

/claim #279