### PR TITLE
Add Qdrant vector database support

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -3,3 +3,48 @@ Installation
 ```
 npm install arakoodev
 ```
+
+## Qdrant vector database
+
+The vector database package supports Qdrant through its HTTP API without requiring
+the Qdrant JavaScript client package.
+
+```ts
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant({
+    url: process.env.QDRANT_URL,
+    apiKey: process.env.QDRANT_API_KEY,
+});
+const client = qdrant.createClient();
+
+await qdrant.createCollection({
+    client,
+    collectionName: "documents",
+    vectors: {
+        size: 1536,
+        distance: "Cosine",
+    },
+});
+
+await qdrant.insertVectorData({
+    client,
+    collectionName: "documents",
+    points: [
+        {
+            id: 1,
+            vector: [0.1, 0.2, 0.3],
+            payload: {
+                content: "hello world",
+            },
+        },
+    ],
+});
+
+const matches = await qdrant.getDataFromQuery({
+    client,
+    collectionName: "documents",
+    vector: [0.1, 0.2, 0.3],
+    limit: 5,
+});
+```

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,10 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+    QdrantClient,
+    QdrantCollectionConfig,
+    QdrantConstructorOptions,
+    QdrantPoint,
+    QdrantSearchArgs,
+    QdrantVector,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,198 @@
+import axios, { AxiosInstance } from "axios";
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+export type QdrantVector = number[] | Record<string, number[]>;
+
+export interface QdrantClient {
+    request: AxiosInstance;
+}
+
+export interface QdrantConstructorOptions {
+    url?: string;
+    apiKey?: string;
+}
+
+export interface QdrantCollectionConfig {
+    collectionName: string;
+    vectors: {
+        size: number;
+        distance: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+    };
+}
+
+export interface QdrantPoint {
+    id: number | string;
+    vector: QdrantVector;
+    payload?: Record<string, any>;
+}
+
+export interface QdrantSearchArgs {
+    client: QdrantClient;
+    collectionName: string;
+    vector: QdrantVector;
+    limit?: number;
+    filter?: Record<string, any>;
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY: string;
+
+    constructor(options: QdrantConstructorOptions = {}) {
+        this.QDRANT_URL = (options.url || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = options.apiKey || process.env.QDRANT_API_KEY || "";
+    }
+
+    createClient(): QdrantClient {
+        if (!this.QDRANT_URL) {
+            throw new Error(
+                "Qdrant URL is missing. Please provide a URL or set QDRANT_URL in your environment."
+            );
+        }
+
+        return {
+            request: axios.create({
+                baseURL: this.QDRANT_URL,
+                headers: this.QDRANT_API_KEY
+                    ? {
+                          "api-key": this.QDRANT_API_KEY,
+                      }
+                    : undefined,
+            }),
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectors,
+    }: QdrantCollectionConfig & { client: QdrantClient }): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.request.put(`/collections/${collectionName}`, {
+                vectors,
+            });
+            return response.data;
+        });
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.request.put(
+                `/collections/${collectionName}/points`,
+                { points },
+                { params: { wait } }
+            );
+            return response.data;
+        });
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        ids,
+        withPayload = true,
+        withVector = false,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        ids: Array<number | string>;
+        withPayload?: boolean | string[];
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.request.post(`/collections/${collectionName}/points`, {
+                ids,
+                with_payload: withPayload,
+                with_vector: withVector,
+            });
+            return response.data;
+        });
+    }
+
+    async getDataFromQuery({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: QdrantSearchArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.request.post(
+                `/collections/${collectionName}/points/search`,
+                {
+                    vector,
+                    limit,
+                    filter,
+                    with_payload: withPayload,
+                    with_vector: withVector,
+                    score_threshold: scoreThreshold,
+                }
+            );
+            return response.data;
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        ids,
+        wait = true,
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        ids: Array<number | string>;
+        wait?: boolean;
+    }): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.request.post(
+                `/collections/${collectionName}/points/delete`,
+                {
+                    points: ids,
+                },
+                { params: { wait } }
+            );
+            return response.data;
+        });
+    }
+
+    private async withRetry<T>(callback: () => Promise<T>): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    resolve(await callback());
+                } catch (error: any) {
+                    if (operation.retry(error)) {
+                        return;
+                    }
+                    reject(error);
+                }
+            });
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,149 @@
+import axios from "axios";
+import { beforeEach, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+const mocks = vi.hoisted(() => ({
+    create: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+    default: {
+        create: mocks.create,
+    },
+}));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.create.mockReturnValue({ put: mocks.put, post: mocks.post });
+    mocks.put.mockResolvedValue({ data: { status: "ok" } });
+    mocks.post.mockResolvedValue({ data: { result: [] } });
+});
+
+it("creates a REST client with an api key header", () => {
+    const qdrant = new Qdrant({
+        url: "http://localhost:6333/",
+        apiKey: "test-key",
+    });
+
+    qdrant.createClient();
+
+    expect(axios.create).toHaveBeenCalledWith({
+        baseURL: "http://localhost:6333",
+        headers: {
+            "api-key": "test-key",
+        },
+    });
+});
+
+it("creates collections with vector configuration", async () => {
+    const qdrant = new Qdrant({ url: "http://localhost:6333" });
+    const client = qdrant.createClient();
+
+    await qdrant.createCollection({
+        client,
+        collectionName: "documents",
+        vectors: {
+            size: 1536,
+            distance: "Cosine",
+        },
+    });
+
+    expect(mocks.put).toHaveBeenCalledWith("/collections/documents", {
+        vectors: {
+            size: 1536,
+            distance: "Cosine",
+        },
+    });
+});
+
+it("upserts points through the Qdrant REST API", async () => {
+    const qdrant = new Qdrant({ url: "http://localhost:6333" });
+    const client = qdrant.createClient();
+    const points = [
+        {
+            id: 1,
+            vector: [0.1, 0.2, 0.3],
+            payload: { content: "hello" },
+        },
+    ];
+
+    await qdrant.insertVectorData({
+        client,
+        collectionName: "documents",
+        points,
+    });
+
+    expect(mocks.put).toHaveBeenCalledWith(
+        "/collections/documents/points",
+        { points },
+        { params: { wait: true } }
+    );
+});
+
+it("searches points using the provided vector and filter", async () => {
+    const qdrant = new Qdrant({ url: "http://localhost:6333" });
+    const client = qdrant.createClient();
+
+    await qdrant.getDataFromQuery({
+        client,
+        collectionName: "documents",
+        vector: [0.1, 0.2, 0.3],
+        filter: {
+            must: [
+                {
+                    key: "source",
+                    match: { value: "docs" },
+                },
+            ],
+        },
+        limit: 3,
+    });
+
+    expect(mocks.post).toHaveBeenCalledWith("/collections/documents/points/search", {
+        vector: [0.1, 0.2, 0.3],
+        limit: 3,
+        filter: {
+            must: [
+                {
+                    key: "source",
+                    match: { value: "docs" },
+                },
+            ],
+        },
+        with_payload: true,
+        with_vector: false,
+        score_threshold: undefined,
+    });
+});
+
+it("retrieves and deletes points by id", async () => {
+    const qdrant = new Qdrant({ url: "http://localhost:6333" });
+    const client = qdrant.createClient();
+
+    await qdrant.getDataById({
+        client,
+        collectionName: "documents",
+        ids: [1, "external-id"],
+    });
+    await qdrant.deleteById({
+        client,
+        collectionName: "documents",
+        ids: [1, "external-id"],
+    });
+
+    expect(mocks.post).toHaveBeenNthCalledWith(1, "/collections/documents/points", {
+        ids: [1, "external-id"],
+        with_payload: true,
+        with_vector: false,
+    });
+    expect(mocks.post).toHaveBeenNthCalledWith(
+        2,
+        "/collections/documents/points/delete",
+        {
+            points: [1, "external-id"],
+        },
+        { params: { wait: true } }
+    );
+});


### PR DESCRIPTION
## Summary
- add a Qdrant REST wrapper to the JavaScript SDK vector-db package without introducing a Qdrant client dependency
- support collection creation, point upsert, vector search, point lookup, and delete-by-id operations
- export Qdrant types from the vector-db entrypoint
- document basic Qdrant usage in the package README

## Verification
- `npm run build`
- `npx vitest src/vector-db/src/tests/qdrant/qdrant.test.ts --run`

/claim #273