### PR TITLE
Add Qdrant vector database support

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,238 @@
+import { config } from "dotenv";
+config();
+
+interface ArgsObject {
+    [key: string]: any;
+}
+
+interface QdrantPoint {
+    id: string | number;
+    vector: number[] | Record<string, number[]>;
+    payload?: ArgsObject;
+}
+
+interface QdrantFilter {
+    [key: string]: any;
+}
+
+interface InsertVectorDataArgs {
+    collectionName: string;
+    points: QdrantPoint[];
+    wait?: boolean;
+}
+
+interface SearchVectorDataArgs {
+    collectionName: string;
+    vector: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: QdrantFilter;
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+}
+
+interface GetDataArgs {
+    collectionName: string;
+    ids: Array<string | number>;
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+}
+
+interface DeleteByIdArgs {
+    collectionName: string;
+    ids: Array<string | number>;
+    wait?: boolean;
+}
+
+interface UpdateByIdArgs {
+    collectionName: string;
+    id: string | number;
+    payload: ArgsObject;
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    private async request(path: string, options: RequestInit = {}): Promise<any> {
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required to connect to Qdrant");
+        }
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            ...(options.headers as Record<string, string>),
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        const response = await fetch(`${this.QDRANT_URL}${path}`, {
+            ...options,
+            headers,
+        });
+
+        const text = await response.text();
+        const body = text ? JSON.parse(text) : {};
+
+        if (!response.ok) {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(body)}`
+            );
+        }
+
+        return body.result ?? body;
+    }
+
+    /**
+     * Create a Qdrant collection.
+     * @param collectionName The Qdrant collection name.
+     * @param vectors Qdrant vector configuration, for example { size: 1536, distance: "Cosine" }.
+     * @returns The Qdrant API result.
+     */
+    async createCollection({
+        collectionName,
+        vectors,
+    }: {
+        collectionName: string;
+        vectors: ArgsObject;
+    }): Promise<any> {
+        return this.request(`/collections/${collectionName}`, {
+            method: "PUT",
+            body: JSON.stringify({ vectors }),
+        });
+    }
+
+    /**
+     * Insert or update vector points in a Qdrant collection.
+     * @param collectionName The Qdrant collection name.
+     * @param points Points to upsert with id, vector and optional payload.
+     * @param wait Whether to wait for the operation to complete.
+     * @returns The Qdrant API result.
+     */
+    async insertVectorData({
+        collectionName,
+        points,
+        wait = true,
+    }: InsertVectorDataArgs): Promise<any> {
+        return this.request(`/collections/${collectionName}/points?wait=${wait}`, {
+            method: "PUT",
+            body: JSON.stringify({ points }),
+        });
+    }
+
+    /**
+     * Search vector points in a Qdrant collection.
+     * @param collectionName The Qdrant collection name.
+     * @param vector Query vector.
+     * @param limit Maximum number of matches to return.
+     * @param filter Optional Qdrant filter object.
+     * @param withPayload Include payload in results.
+     * @param withVector Include vectors in results.
+     * @param scoreThreshold Optional minimum similarity score.
+     * @returns Matching Qdrant points.
+     */
+    async getDataFromQuery({
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: SearchVectorDataArgs): Promise<any> {
+        return this.request(`/collections/${collectionName}/points/search`, {
+            method: "POST",
+            body: JSON.stringify({
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+            }),
+        });
+    }
+
+    /**
+     * Fetch points from a Qdrant collection by id.
+     * @param collectionName The Qdrant collection name.
+     * @param ids Point ids to retrieve.
+     * @param withPayload Include payload in results.
+     * @param withVector Include vectors in results.
+     * @returns Requested Qdrant points.
+     */
+    async getData({ collectionName, ids, withPayload = true, withVector = false }: GetDataArgs) {
+        return this.request(`/collections/${collectionName}/points`, {
+            method: "POST",
+            body: JSON.stringify({
+                ids,
+                with_payload: withPayload,
+                with_vector: withVector,
+            }),
+        });
+    }
+
+    /**
+     * Fetch a single Qdrant point by id.
+     * @param collectionName The Qdrant collection name.
+     * @param id Point id.
+     * @returns The requested Qdrant point.
+     */
+    async getDataById({
+        collectionName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: {
+        collectionName: string;
+        id: string | number;
+        withPayload?: boolean | string[];
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        return this.request(
+            `/collections/${collectionName}/points/${id}?with_payload=${withPayload}&with_vector=${withVector}`
+        );
+    }
+
+    /**
+     * Set payload fields for one Qdrant point.
+     * @param collectionName The Qdrant collection name.
+     * @param id Point id.
+     * @param payload Payload fields to set.
+     * @param wait Whether to wait for the operation to complete.
+     * @returns The Qdrant API result.
+     */
+    async updateById({ collectionName, id, payload, wait = true }: UpdateByIdArgs): Promise<any> {
+        return this.request(`/collections/${collectionName}/points/payload?wait=${wait}`, {
+            method: "POST",
+            body: JSON.stringify({
+                payload,
+                points: [id],
+            }),
+        });
+    }
+
+    /**
+     * Delete points from a Qdrant collection by id.
+     * @param collectionName The Qdrant collection name.
+     * @param ids Point ids to delete.
+     * @param wait Whether to wait for the operation to complete.
+     * @returns The Qdrant API result.
+     */
+    async deleteById({ collectionName, ids, wait = true }: DeleteByIdArgs): Promise<any> {
+        return this.request(`/collections/${collectionName}/points/delete?wait=${wait}`, {
+            method: "POST",
+            body: JSON.stringify({
+                points: ids,
+            }),
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,97 @@
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+const MOCK_QDRANT_URL = "https://mock-qdrant.test";
+const MOCK_QDRANT_API_KEY = "mock-api-key";
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch;
+
+beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ result: { status: "ok" } }),
+    });
+});
+
+describe("Qdrant", () => {
+    it("should upsert vector points using the Qdrant API directly", async () => {
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+
+        const result = await qdrant.insertVectorData({
+            collectionName: "documents",
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+        });
+
+        expect(result).toEqual({ status: "ok" });
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${MOCK_QDRANT_URL}/collections/documents/points?wait=true`,
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                    "api-key": MOCK_QDRANT_API_KEY,
+                }),
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: 1,
+                            vector: [0.1, 0.2, 0.3],
+                            payload: { content: "hello" },
+                        },
+                    ],
+                }),
+            })
+        );
+    });
+
+    it("should search vector points with payload and vector options", async () => {
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+
+        await qdrant.getDataFromQuery({
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+            withPayload: true,
+            withVector: false,
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${MOCK_QDRANT_URL}/collections/documents/points/search`,
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    vector: [0.1, 0.2, 0.3],
+                    limit: 3,
+                    filter: { must: [{ key: "source", match: { value: "docs" } }] },
+                    with_payload: true,
+                    with_vector: false,
+                    score_threshold: undefined,
+                }),
+            })
+        );
+    });
+
+    it("should throw a helpful error when Qdrant returns an error response", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            text: async () => JSON.stringify({ status: { error: "Not found" } }),
+        });
+
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+
+        await expect(
+            qdrant.getDataById({ collectionName: "documents", id: 404 })
+        ).rejects.toThrow("Qdrant request failed with status 404");
+    });
+});


### PR DESCRIPTION
## Summary
- add a Qdrant vector database wrapper that talks directly to the Qdrant HTTP API, without adding a Qdrant SDK dependency
- export `Qdrant` from the vector-db package entrypoint
- cover upsert, search, and error handling with mocked API tests

## Tests
- `npm run build`
- `npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand`
- `npx jest src/vector-db/src/tests --runInBand`

Closes #273

/claim #273 