### PR TITLE
Add AWS Comprehend prompt redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,4 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AwsComprehendRedactor } from "./lib/aws-comprehend/awsComprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
@@ -1,0 +1,207 @@
+import axios from "axios";
+import { createHash, createHmac } from "crypto";
+
+type AwsCredentials = {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+};
+
+type AwsComprehendRedactorOptions = {
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    region?: string;
+    languageCode?: string;
+    replacement?: string;
+    endpoint?: string;
+};
+
+type PiiEntity = {
+    Type: string;
+    Score: number;
+    BeginOffset: number;
+    EndOffset: number;
+};
+
+type MessageOption = {
+    role: string;
+    content: string;
+    name?: string;
+};
+
+type PromptOptions = {
+    prompt?: string;
+    messages?: MessageOption[];
+    [key: string]: unknown;
+};
+
+type SignedHeaders = {
+    Authorization: string;
+    "Content-Type": string;
+    Host: string;
+    "X-Amz-Date": string;
+    "X-Amz-Target": string;
+    "X-Amz-Security-Token"?: string;
+};
+
+const SERVICE = "comprehend";
+const ALGORITHM = "AWS4-HMAC-SHA256";
+
+export class AwsComprehendRedactor {
+    private credentials: AwsCredentials;
+    private region: string;
+    private languageCode: string;
+    private replacement: string;
+    private endpoint: string;
+
+    constructor(options: AwsComprehendRedactorOptions = {}) {
+        this.region = options.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || "us-east-1";
+        this.languageCode = options.languageCode || "en";
+        this.replacement = options.replacement || "[REDACTED]";
+        this.endpoint = options.endpoint || `https://comprehend.${this.region}.amazonaws.com`;
+        this.credentials = {
+            accessKeyId: options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "",
+            secretAccessKey: options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "",
+            sessionToken: options.sessionToken || process.env.AWS_SESSION_TOKEN,
+        };
+
+        if (!this.credentials.accessKeyId || !this.credentials.secretAccessKey) {
+            console.error(
+                "AWS credentials are missing. Provide accessKeyId and secretAccessKey or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+            );
+        }
+    }
+
+    async detectPiiEntities(text: string): Promise<PiiEntity[]> {
+        if (!text) return [];
+
+        const body = JSON.stringify({
+            LanguageCode: this.languageCode,
+            Text: text,
+        });
+        const headers = this.createSignedHeaders(body, "Comprehend_20171127.DetectPiiEntities");
+
+        const response = await axios.post(this.endpoint, body, {
+            headers,
+        });
+
+        return response.data.Entities || [];
+    }
+
+    async redactText(text: string): Promise<string> {
+        const entities = await this.detectPiiEntities(text);
+        return this.applyRedactions(text, entities);
+    }
+
+    async redactPrompt(prompt: string): Promise<string> {
+        return this.redactText(prompt);
+    }
+
+    async redactChatOptions<T extends PromptOptions>(chatOptions: T): Promise<T> {
+        const redactedOptions = { ...chatOptions };
+
+        if (typeof redactedOptions.prompt === "string") {
+            redactedOptions.prompt = await this.redactText(redactedOptions.prompt);
+        }
+
+        if (Array.isArray(redactedOptions.messages)) {
+            redactedOptions.messages = await Promise.all(
+                redactedOptions.messages.map(async (message) => ({
+                    ...message,
+                    content: await this.redactText(message.content),
+                }))
+            );
+        }
+
+        return redactedOptions;
+    }
+
+    private applyRedactions(text: string, entities: PiiEntity[]): string {
+        const sortedEntities = [...entities].sort((a, b) => b.BeginOffset - a.BeginOffset);
+
+        return sortedEntities.reduce((redactedText, entity) => {
+            if (entity.BeginOffset < 0 || entity.EndOffset > redactedText.length) {
+                return redactedText;
+            }
+
+            return (
+                redactedText.slice(0, entity.BeginOffset) +
+                this.replacement +
+                redactedText.slice(entity.EndOffset)
+            );
+        }, text);
+    }
+
+    private createSignedHeaders(body: string, target: string): SignedHeaders {
+        const now = new Date();
+        const amzDate = this.toAmzDate(now);
+        const dateStamp = amzDate.slice(0, 8);
+        const host = new URL(this.endpoint).host;
+        const payloadHash = this.sha256(body);
+        const canonicalHeaderEntries = [
+            ["content-type", "application/x-amz-json-1.1"],
+            ["host", host],
+            ["x-amz-date", amzDate],
+        ];
+
+        if (this.credentials.sessionToken) {
+            canonicalHeaderEntries.push(["x-amz-security-token", this.credentials.sessionToken]);
+        }
+
+        canonicalHeaderEntries.push(["x-amz-target", target]);
+
+        const canonicalHeaders = canonicalHeaderEntries
+            .map(([name, value]) => `${name}:${value}\n`)
+            .join("");
+        const signedHeaders = canonicalHeaderEntries.map(([name]) => name).join(";");
+        const canonicalRequest = [
+            "POST",
+            "/",
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            payloadHash,
+        ].join("\n");
+        const credentialScope = `${dateStamp}/${this.region}/${SERVICE}/aws4_request`;
+        const stringToSign = [
+            ALGORITHM,
+            amzDate,
+            credentialScope,
+            this.sha256(canonicalRequest),
+        ].join("\n");
+        const signingKey = this.getSignatureKey(dateStamp);
+        const signature = createHmac("sha256", signingKey).update(stringToSign).digest("hex");
+        const authorizationHeader = `${ALGORITHM} Credential=${this.credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+        const headers: SignedHeaders = {
+            Authorization: authorizationHeader,
+            "Content-Type": "application/x-amz-json-1.1",
+            Host: host,
+            "X-Amz-Date": amzDate,
+            "X-Amz-Target": target,
+        };
+
+        if (this.credentials.sessionToken) {
+            headers["X-Amz-Security-Token"] = this.credentials.sessionToken;
+        }
+
+        return headers;
+    }
+
+    private getSignatureKey(dateStamp: string): Buffer {
+        const kDate = createHmac("sha256", `AWS4${this.credentials.secretAccessKey}`)
+            .update(dateStamp)
+            .digest();
+        const kRegion = createHmac("sha256", kDate).update(this.region).digest();
+        const kService = createHmac("sha256", kRegion).update(SERVICE).digest();
+        return createHmac("sha256", kService).update("aws4_request").digest();
+    }
+
+    private sha256(value: string): string {
+        return createHash("sha256").update(value, "utf8").digest("hex");
+    }
+
+    private toAmzDate(date: Date): string {
+        return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
@@ -1,0 +1,135 @@
+import axios from "axios";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AwsComprehendRedactor } from "../lib/aws-comprehend/awsComprehendRedactor";
+
+vi.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("AwsComprehendRedactor", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test("redacts PII entities returned by AWS Comprehend", async () => {
+        mockedAxios.post.mockResolvedValueOnce({
+            data: {
+                Entities: [
+                    {
+                        Type: "EMAIL",
+                        Score: 0.99,
+                        BeginOffset: 14,
+                        EndOffset: 27,
+                    },
+                    {
+                        Type: "PHONE",
+                        Score: 0.98,
+                        BeginOffset: 36,
+                        EndOffset: 44,
+                    },
+                ],
+            },
+        });
+
+        const redactor = new AwsComprehendRedactor({
+            accessKeyId: "test-access-key",
+            secretAccessKey: "test-secret-key",
+            region: "us-east-1",
+        });
+
+        const result = await redactor.redactText("Contact me at a@example.com or call 555-1234.");
+
+        expect(result).toBe("Contact me at [REDACTED] or call [REDACTED].");
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            "https://comprehend.us-east-1.amazonaws.com",
+            JSON.stringify({
+                LanguageCode: "en",
+                Text: "Contact me at a@example.com or call 555-1234.",
+            }),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: expect.stringContaining("AWS4-HMAC-SHA256"),
+                    "Content-Type": "application/x-amz-json-1.1",
+                    "X-Amz-Target": "Comprehend_20171127.DetectPiiEntities",
+                }),
+            })
+        );
+    });
+
+    test("redacts prompt and messages for chaining with chat endpoints", async () => {
+        mockedAxios.post
+            .mockResolvedValueOnce({
+                data: {
+                    Entities: [
+                        {
+                            Type: "EMAIL",
+                            Score: 0.99,
+                            BeginOffset: 6,
+                            EndOffset: 19,
+                        },
+                    ],
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    Entities: [
+                        {
+                            Type: "PHONE",
+                            Score: 0.98,
+                            BeginOffset: 5,
+                            EndOffset: 13,
+                        },
+                    ],
+                },
+            });
+
+        const redactor = new AwsComprehendRedactor({
+            accessKeyId: "test-access-key",
+            secretAccessKey: "test-secret-key",
+            replacement: "[PII]",
+        });
+
+        const result = await redactor.redactChatOptions({
+            prompt: "Email a@example.com",
+            messages: [{ role: "user", content: "Call 555-1234" }],
+            temperature: 0.2,
+        });
+
+        expect(result).toEqual({
+            prompt: "Email [PII]",
+            messages: [{ role: "user", content: "Call [PII]" }],
+            temperature: 0.2,
+        });
+    });
+
+    test("includes session token in SigV4 signed headers", async () => {
+        mockedAxios.post.mockResolvedValueOnce({
+            data: {
+                Entities: [],
+            },
+        });
+
+        const redactor = new AwsComprehendRedactor({
+            accessKeyId: "test-access-key",
+            secretAccessKey: "test-secret-key",
+            sessionToken: "test-session-token",
+            region: "us-east-1",
+        });
+
+        await redactor.detectPiiEntities("No PII here.");
+
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            "https://comprehend.us-east-1.amazonaws.com",
+            expect.any(String),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: expect.stringContaining(
+                        "SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target"
+                    ),
+                    "X-Amz-Security-Token": "test-session-token",
+                    "X-Amz-Target": "Comprehend_20171127.DetectPiiEntities",
+                }),
+            })
+        );
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,14 @@
+local key = std.extVar('openai_api_key');
+local input = std.extVar('input');
+
+local promptTemplate = |||
+  Summarize this support request after removing sensitive personal data:
+  {input}
+|||;
+
+local prompt = std.strReplace(promptTemplate, '{input}', input);
+
+local main() =
+  arakoo.native('redactedOpenAICall')({ prompt: prompt, openAIApiKey: key });
+
+main()

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "aws-comprehend-redaction",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "build": "tsc",
+        "start": "node dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.2.7",
+        "file-uri-to-path": "^2.0.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/readme.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/readme.md
@@ -1,0 +1,19 @@
+# AWS Comprehend Redaction
+
+This example redacts PII from a Jsonnet-managed prompt with `AwsComprehendRedactor`
+before sending the sanitized prompt to an `OpenAI` endpoint.
+
+Required environment variables:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `OPENAI_API_KEY`
+
+Run the example server:
+
+```sh
+npm install
+npm run build
+npm start
+```

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,25 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const redactedOpenAICall = createSyncRPC(path.join(__dirname, "./lib/redactedOpenAICall.cjs"));
+
+app.post("/redact-and-chat", async (c: any) => {
+    const { input } = await c.req.json();
+    const key = process.env.OPENAI_API_KEY || "";
+
+    jsonnet.extString("openai_api_key", key);
+    jsonnet.extString("input", input || "");
+    jsonnet.javascriptCallback("redactedOpenAICall", redactedOpenAICall);
+
+    const response = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+    return c.json(JSON.parse(response));
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/lib/redactedOpenAICall.cts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/lib/redactedOpenAICall.cts
@@ -1,0 +1,15 @@
+const { AwsComprehendRedactor, OpenAI } = require("@arakoodev/edgechains.js/ai");
+
+async function redactedOpenAICall({ prompt, openAIApiKey }: { prompt: string; openAIApiKey: string }) {
+    const redactor = new AwsComprehendRedactor({
+        region: process.env.AWS_REGION || "us-east-1",
+    });
+    const openai = new OpenAI({ apiKey: openAIApiKey });
+    const redactedPrompt = await redactor.redactPrompt(prompt);
+
+    return openai.chat({
+        prompt: redactedPrompt,
+    });
+}
+
+module.exports = redactedOpenAICall;

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary\n- add AwsComprehendRedactor for AWS Comprehend DetectPiiEntities without adding AWS SDK dependencies\n- expose helpers to redact raw prompts and chat options before chaining into existing AI endpoint calls\n- add unit coverage with mocked Comprehend responses\n- add a Jsonnet-based example showing PII redaction before an OpenAI call\n\n/claim #290\n\nCloses #290\n\n## Demo\n- https://raw.githubusercontent.com/josemariano-hub/edgechains-demo-assets/main/edgechains-aws-comprehend-demo.mp4\n\n## Verification\n- npx vitest run awsComprehendRedactor.test.ts\n- npm run build