### PR TITLE
Add dependency-free AWS Comprehend PII redactor

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,5 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AwsComprehendClient, AwsComprehendRedactor, fromPrompts } from "./lib/aws-comprehend/awsComprehendRedactor.js";
+export type { ComprehendClient, ComprehendPiiEntity, ObservableLike, RedactionResult } from "./lib/aws-comprehend/awsComprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
@@ -1,0 +1,329 @@
+import { createHash, createHmac } from "crypto";
+
+export type PiiEntityType =
+    | "BANK_ACCOUNT_NUMBER"
+    | "BANK_ROUTING"
+    | "CREDIT_DEBIT_NUMBER"
+    | "CREDIT_DEBIT_CVV"
+    | "CREDIT_DEBIT_EXPIRY"
+    | "PIN"
+    | "EMAIL"
+    | "ADDRESS"
+    | "NAME"
+    | "PHONE"
+    | "SSN"
+    | "DATE_TIME"
+    | "PASSPORT_NUMBER"
+    | "DRIVER_ID"
+    | "URL"
+    | "AGE"
+    | "USERNAME"
+    | "PASSWORD"
+    | "AWS_ACCESS_KEY"
+    | "AWS_SECRET_KEY"
+    | "IP_ADDRESS"
+    | "MAC_ADDRESS"
+    | "ALL";
+
+export interface ComprehendPiiEntity {
+    Type: PiiEntityType;
+    Score: number;
+    BeginOffset: number;
+    EndOffset: number;
+}
+
+export interface ComprehendClient {
+    detectPiiEntities(input: {
+        Text: string;
+        LanguageCode: string;
+    }): Promise<{ Entities?: ComprehendPiiEntity[] }>;
+}
+
+export interface AwsComprehendClientOptions {
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    region?: string;
+}
+
+export interface AwsComprehendRedactorOptions extends AwsComprehendClientOptions {
+    client?: ComprehendClient;
+    languageCode?: string;
+    minScore?: number;
+    entityTypes?: PiiEntityType[];
+    placeholder?: string;
+}
+
+export interface RedactOptions {
+    languageCode?: string;
+    minScore?: number;
+    entityTypes?: PiiEntityType[];
+    placeholder?: string;
+}
+
+export interface RedactionResult {
+    originalText: string;
+    redactedText: string;
+    entities: ComprehendPiiEntity[];
+}
+
+export interface Observer<T> {
+    next(value: T): void;
+    error?(error: unknown): void;
+    complete?(): void;
+}
+
+export interface ObservableLike<T> {
+    subscribe(observer: Observer<T> | ((value: T) => void)): { unsubscribe(): void };
+}
+
+type Endpoint<T> = (redactedPrompt: string, result: RedactionResult) => Promise<T> | T;
+
+const SERVICE = "comprehend";
+const AWS_TARGET = "Comprehend_20171127.DetectPiiEntities";
+
+export class AwsComprehendClient implements ComprehendClient {
+    private accessKeyId: string;
+    private secretAccessKey: string;
+    private sessionToken?: string;
+    private region: string;
+
+    constructor(options: AwsComprehendClientOptions = {}) {
+        this.accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+        this.secretAccessKey = options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "";
+        this.sessionToken = options.sessionToken || process.env.AWS_SESSION_TOKEN;
+        this.region = options.region || process.env.AWS_REGION || "us-east-1";
+    }
+
+    async detectPiiEntities(input: {
+        Text: string;
+        LanguageCode: string;
+    }): Promise<{ Entities?: ComprehendPiiEntity[] }> {
+        this.assertCredentials();
+
+        const endpoint = `https://comprehend.${this.region}.amazonaws.com/`;
+        const body = JSON.stringify(input);
+        const now = new Date();
+        const amzDate = toAmzDate(now);
+        const dateStamp = amzDate.slice(0, 8);
+        const payloadHash = sha256(body);
+        const headers: Record<string, string> = {
+            "content-type": "application/x-amz-json-1.1",
+            host: `comprehend.${this.region}.amazonaws.com`,
+            "x-amz-date": amzDate,
+            "x-amz-target": AWS_TARGET,
+        };
+
+        if (this.sessionToken) headers["x-amz-security-token"] = this.sessionToken;
+
+        const authorization = sign({
+            accessKeyId: this.accessKeyId,
+            secretAccessKey: this.secretAccessKey,
+            region: this.region,
+            dateStamp,
+            amzDate,
+            headers,
+            payloadHash,
+        });
+
+        const response = await fetch(endpoint, {
+            method: "POST",
+            headers: { ...headers, authorization },
+            body,
+        });
+
+        if (!response.ok) {
+            throw new Error(`AWS Comprehend request failed with status ${response.status}`);
+        }
+
+        return (await response.json()) as { Entities?: ComprehendPiiEntity[] };
+    }
+
+    private assertCredentials(): void {
+        if (!this.accessKeyId || !this.secretAccessKey) {
+            throw new Error(
+                "AWS credentials are required. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or pass them to AwsComprehendClient."
+            );
+        }
+    }
+}
+
+export class AwsComprehendRedactor {
+    private client: ComprehendClient;
+    private languageCode: string;
+    private minScore: number;
+    private entityTypes: PiiEntityType[];
+    private placeholder: string;
+
+    constructor(options: AwsComprehendRedactorOptions = {}) {
+        this.client = options.client || new AwsComprehendClient(options);
+        this.languageCode = options.languageCode || "en";
+        this.minScore = options.minScore ?? 0.5;
+        this.entityTypes = options.entityTypes || ["ALL"];
+        this.placeholder = options.placeholder || "[REDACTED_${TYPE}]";
+    }
+
+    async detect(text: string, options: RedactOptions = {}): Promise<ComprehendPiiEntity[]> {
+        const languageCode = options.languageCode || this.languageCode;
+        const minScore = options.minScore ?? this.minScore;
+        const entityTypes = options.entityTypes || this.entityTypes;
+        const response = await this.client.detectPiiEntities({ Text: text, LanguageCode: languageCode });
+
+        return (response.Entities || [])
+            .filter((entity) => entity.Score >= minScore)
+            .filter((entity) => entityTypes.includes("ALL") || entityTypes.includes(entity.Type))
+            .sort((a, b) => a.BeginOffset - b.BeginOffset);
+    }
+
+    async redact(text: string, options: RedactOptions = {}): Promise<RedactionResult> {
+        const entities = await this.detect(text, options);
+        const placeholder = options.placeholder || this.placeholder;
+        let redactedText = "";
+        let cursor = 0;
+
+        for (const entity of entities) {
+            if (entity.BeginOffset < cursor) continue;
+            redactedText += text.slice(cursor, entity.BeginOffset);
+            redactedText += placeholder.replace("${TYPE}", entity.Type);
+            cursor = entity.EndOffset;
+        }
+
+        redactedText += text.slice(cursor);
+        return { originalText: text, redactedText, entities };
+    }
+
+    async chain<T>(text: string, endpoint: Endpoint<T>, options: RedactOptions = {}): Promise<T> {
+        const result = await this.redact(text, options);
+        return endpoint(result.redactedText, result);
+    }
+
+    redactObservable(source: ObservableLike<string>, options: RedactOptions = {}): ObservableLike<RedactionResult> {
+        return createObservable<RedactionResult>((observer) => {
+            let pending = 0;
+            let sourceComplete = false;
+            const completeIfIdle = () => {
+                if (sourceComplete && pending === 0) observer.complete?.();
+            };
+            const subscription = source.subscribe({
+                next: (value) => {
+                    pending += 1;
+                    this.redact(value, options)
+                        .then((result) => observer.next(result))
+                        .catch((error) => observer.error?.(error))
+                        .finally(() => {
+                            pending -= 1;
+                            completeIfIdle();
+                        });
+                },
+                error: (error) => observer.error?.(error),
+                complete: () => {
+                    sourceComplete = true;
+                    completeIfIdle();
+                },
+            });
+
+            return () => subscription.unsubscribe();
+        });
+    }
+}
+
+export function fromPrompts(prompts: string[]): ObservableLike<string> {
+    return createObservable<string>((observer) => {
+        for (const prompt of prompts) observer.next(prompt);
+        observer.complete?.();
+        return () => undefined;
+    });
+}
+
+function createObservable<T>(
+    producer: (observer: Observer<T>) => () => void
+): ObservableLike<T> {
+    return {
+        subscribe(observerOrNext: Observer<T> | ((value: T) => void)) {
+            const observer =
+                typeof observerOrNext === "function" ? { next: observerOrNext } : observerOrNext;
+            let closed = false;
+            const unsubscribe = producer({
+                next: (value) => {
+                    if (!closed) observer.next(value);
+                },
+                error: (error) => {
+                    if (!closed) observer.error?.(error);
+                },
+                complete: () => {
+                    if (!closed) observer.complete?.();
+                },
+            });
+
+            return {
+                unsubscribe() {
+                    closed = true;
+                    unsubscribe();
+                },
+            };
+        },
+    };
+}
+
+function sign(input: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    region: string;
+    dateStamp: string;
+    amzDate: string;
+    headers: Record<string, string>;
+    payloadHash: string;
+}): string {
+    const signedHeaders = Object.keys(input.headers).sort().join(";");
+    const canonicalHeaders = Object.keys(input.headers)
+        .sort()
+        .map((key) => `${key}:${input.headers[key].trim()}\n`)
+        .join("");
+    const canonicalRequest = [
+        "POST",
+        "/",
+        "",
+        canonicalHeaders,
+        signedHeaders,
+        input.payloadHash,
+    ].join("\n");
+    const credentialScope = `${input.dateStamp}/${input.region}/${SERVICE}/aws4_request`;
+    const stringToSign = [
+        "AWS4-HMAC-SHA256",
+        input.amzDate,
+        credentialScope,
+        sha256(canonicalRequest),
+    ].join("\n");
+    const signingKey = getSigningKey(input.secretAccessKey, input.dateStamp, input.region);
+    const signature = hmacHex(signingKey, stringToSign);
+
+    return [
+        "AWS4-HMAC-SHA256",
+        `Credential=${input.accessKeyId}/${credentialScope}`,
+        `SignedHeaders=${signedHeaders}`,
+        `Signature=${signature}`,
+    ].join(", ");
+}
+
+function getSigningKey(secretAccessKey: string, dateStamp: string, region: string): Buffer {
+    const dateKey = hmac(Buffer.from(`AWS4${secretAccessKey}`, "utf8"), dateStamp);
+    const dateRegionKey = hmac(dateKey, region);
+    const dateRegionServiceKey = hmac(dateRegionKey, SERVICE);
+    return hmac(dateRegionServiceKey, "aws4_request");
+}
+
+function toAmzDate(date: Date): string {
+    return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}
+
+function sha256(value: string): string {
+    return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function hmac(key: Buffer, value: string): Buffer {
+    return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function hmacHex(key: Buffer, value: string): string {
+    return createHmac("sha256", key).update(value, "utf8").digest("hex");
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import {
+    AwsComprehendRedactor,
+    ComprehendClient,
+    fromPrompts,
+} from "../lib/aws-comprehend/awsComprehendRedactor";
+
+const client: ComprehendClient = {
+    async detectPiiEntities() {
+        return {
+            Entities: [
+                { Type: "NAME", Score: 0.99, BeginOffset: 6, EndOffset: 16 },
+                { Type: "EMAIL", Score: 0.98, BeginOffset: 20, EndOffset: 36 },
+                { Type: "PHONE", Score: 0.2, BeginOffset: 40, EndOffset: 52 },
+            ],
+        };
+    },
+};
+
+describe("AwsComprehendRedactor", () => {
+    test("redacts supported PII using typed placeholders", async () => {
+        const redactor = new AwsComprehendRedactor({ client });
+
+        const result = await redactor.redact("Hello Jane Smith at jane@example.com or 415-555-1212");
+
+        expect(result.redactedText).toBe("Hello [REDACTED_NAME] at [REDACTED_EMAIL] or 415-555-1212");
+        expect(result.entities.map((entity) => entity.Type)).toEqual(["NAME", "EMAIL"]);
+    });
+
+    test("filters by entity type", async () => {
+        const redactor = new AwsComprehendRedactor({ client });
+
+        const result = await redactor.redact("Hello Jane Smith at jane@example.com", {
+            entityTypes: ["EMAIL"],
+        });
+
+        expect(result.redactedText).toBe("Hello Jane Smith at [REDACTED_EMAIL]");
+    });
+
+    test("chains redacted prompt into endpoint calls", async () => {
+        const redactor = new AwsComprehendRedactor({ client });
+
+        const response = await redactor.chain("Hello Jane Smith at jane@example.com", async (prompt) => {
+            return `endpoint saw: ${prompt}`;
+        });
+
+        expect(response).toBe("endpoint saw: Hello [REDACTED_NAME] at [REDACTED_EMAIL]");
+    });
+
+    test("redacts an observable prompt stream without rxjs", async () => {
+        const redactor = new AwsComprehendRedactor({ client });
+        const results: string[] = [];
+
+        await new Promise<void>((resolve, reject) => {
+            redactor.redactObservable(fromPrompts(["Hello Jane Smith at jane@example.com"])).subscribe({
+                next: (result) => results.push(result.redactedText),
+                error: reject,
+                complete: resolve,
+            });
+        });
+
+        expect(results).toEqual(["Hello [REDACTED_NAME] at [REDACTED_EMAIL]"]);
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,15 @@
+# AWS Comprehend redaction
+
+This example redacts PII from a prompt before it is sent to an AI endpoint.
+
+It runs in mock mode by default, so reviewers can verify the chaining behavior without AWS credentials. Set `USE_REAL_AWS=1` with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` to call Amazon Comprehend.
+
+```bash
+npm install
+npm start
+```
+
+The example demonstrates both supported surfaces:
+
+- `chain(prompt, endpoint)` for existing Promise-based endpoint classes.
+- `redactObservable(source)` for Observable-compatible prompt streams.

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,9 @@
+{
+  name: 'aws-comprehend-redaction',
+  description: 'Redact PII before passing prompts to an AI endpoint',
+  steps: [
+    'Create an AwsComprehendRedactor',
+    'Redact a prompt with chain(prompt, endpoint)',
+    'Redact a prompt stream with redactObservable(source)',
+  ],
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "aws-comprehend-redaction-example",
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "ts-node src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,45 @@
+import {
+    AwsComprehendClient,
+    AwsComprehendRedactor,
+    ComprehendClient,
+    fromPrompts,
+} from "@arakoodev/edgechains.js/ai";
+
+const samplePrompt = "Please summarize this request from Jane Smith at jane@example.com.";
+
+const mockClient: ComprehendClient = {
+    async detectPiiEntities() {
+        return {
+            Entities: [
+                { Type: "NAME", Score: 0.99, BeginOffset: 35, EndOffset: 45 },
+                { Type: "EMAIL", Score: 0.99, BeginOffset: 49, EndOffset: 65 },
+            ],
+        };
+    },
+};
+
+const client =
+    process.env.USE_REAL_AWS === "1"
+        ? new AwsComprehendClient({ region: process.env.AWS_REGION || "us-east-1" })
+        : mockClient;
+
+const redactor = new AwsComprehendRedactor({ client });
+
+const endpointResponse = await redactor.chain(samplePrompt, async (safePrompt) => {
+    return {
+        endpoint: "OpenAI-compatible endpoint",
+        promptReceived: safePrompt,
+    };
+});
+
+console.log("Promise chain result:");
+console.log(endpointResponse);
+
+console.log("Observable chain result:");
+await new Promise<void>((resolve, reject) => {
+    redactor.redactObservable(fromPrompts([samplePrompt])).subscribe({
+        next: (result) => console.log(result.redactedText),
+        error: reject,
+        complete: resolve,
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "types": ["node"],
+        "typeRoots": ["../../arakoodev/node_modules/@types"],
+        "baseUrl": ".",
+        "paths": {
+            "@arakoodev/edgechains.js/ai": ["../../arakoodev/dist/ai/src/index.d.ts"]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AwsComprehendRedactor and AwsComprehendClient to the JS AI package
- redact PII with Amazon Comprehend before prompts are passed into existing endpoint calls
- provide a small Observable-compatible prompt stream helper without adding RxJS or AWS SDK runtime dependencies
- add focused tests with a mock Comprehend client
- add a runnable example under JS/edgechains/examples/aws-comprehend-redaction

## Why this approach
This keeps the SDK surface small and repo-aligned: no new runtime dependencies, no package-lock churn, and tests can run without AWS credentials. Real AWS calls are still supported through a SigV4-signed Comprehend JSON API client using Node built-in crypto/fetch.

## Validation
- npx.cmd vitest run src/ai/src/tests/awsComprehendRedactor.test.ts
- npx.cmd tsc -b
- ..\\..\\arakoodev\\node_modules\\.bin\\tsc.cmd -p tsconfig.json --noEmit from JS/edgechains/examples/aws-comprehend-redaction
- git diff --check

Note: npm run build currently calls rm -rf dist, which does not run under Windows PowerShell. I validated the underlying TypeScript build step directly with npx.cmd tsc -b.

/claim #290
