### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,160 @@
+import { config } from "dotenv";
+config();
+
+type FetchLike = typeof fetch;
+type QdrantPointId = string | number;
+
+interface QdrantOptions {
+    fetch?: FetchLike;
+}
+
+interface QdrantRequestOptions {
+    method?: string;
+    body?: unknown;
+    query?: Record<string, string | number | boolean | undefined>;
+}
+
+interface UpsertPointsArgs {
+    collectionName: string;
+    points: Array<{
+        id: QdrantPointId;
+        vector: number[] | Record<string, number[]>;
+        payload?: Record<string, unknown>;
+    }>;
+    wait?: boolean;
+}
+
+interface SearchArgs {
+    collectionName: string;
+    vector: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, unknown>;
+    withPayload?: boolean | string[] | Record<string, unknown>;
+    withVector?: boolean | string[];
+}
+
+interface GetPointByIdArgs {
+    collectionName: string;
+    id: QdrantPointId;
+}
+
+interface DeleteByIdArgs {
+    collectionName: string;
+    id: QdrantPointId;
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+    private readonly fetcher: FetchLike;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string, options: QdrantOptions = {}) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/+$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+        this.fetcher = options.fetch || fetch;
+
+        if (!this.QDRANT_URL) {
+            throw new Error("Qdrant URL is required. Pass QDRANT_URL or set process.env.QDRANT_URL.");
+        }
+    }
+
+    /**
+     * Insert or update points in a Qdrant collection using the REST API directly.
+     * @param collectionName The Qdrant collection name.
+     * @param points Points with id, vector, and optional payload.
+     * @param wait Whether Qdrant should wait for the operation to be applied.
+     */
+    async upsertPoints({ collectionName, points, wait = true }: UpsertPointsArgs): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points`, {
+            method: "PUT",
+            query: { wait },
+            body: { points },
+        });
+    }
+
+    /**
+     * Search for nearest points in a Qdrant collection.
+     * @param collectionName The Qdrant collection name.
+     * @param vector Query vector or named vector map.
+     * @param limit Maximum number of matches to return.
+     */
+    async search({
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: SearchArgs): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points/search`, {
+            method: "POST",
+            body: {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+            },
+        });
+    }
+
+    /**
+     * Fetch a point by id.
+     * @param collectionName The Qdrant collection name.
+     * @param id Point id.
+     */
+    async getPointById({ collectionName, id }: GetPointByIdArgs): Promise<any> {
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points/${encodeURIComponent(String(id))}`
+        );
+    }
+
+    /**
+     * Delete a point by id.
+     * @param collectionName The Qdrant collection name.
+     * @param id Point id.
+     * @param wait Whether Qdrant should wait for the operation to be applied.
+     */
+    async deleteById({ collectionName, id, wait = true }: DeleteByIdArgs): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points/delete`, {
+            method: "POST",
+            query: { wait },
+            body: { points: [id] },
+        });
+    }
+
+    private async request(path: string, options: QdrantRequestOptions = {}): Promise<any> {
+        const query = new URLSearchParams();
+        for (const [key, value] of Object.entries(options.query || {})) {
+            if (value !== undefined) query.set(key, String(value));
+        }
+
+        const queryString = query.toString();
+        const url = `${this.QDRANT_URL}${path}${queryString ? `?${queryString}` : ""}`;
+        const headers: Record<string, string> = {
+            "content-type": "application/json",
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        const response = await this.fetcher(url, {
+            method: options.method || "GET",
+            headers,
+            body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        });
+
+        const text = await response.text();
+        const data = text ? JSON.parse(text) : undefined;
+
+        if (!response.ok) {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(data)}`
+            );
+        }
+
+        return data;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,91 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+const MOCK_QDRANT_URL = "https://mock-qdrant.local";
+const MOCK_QDRANT_API_KEY = "mock-api-key";
+
+const createJsonResponse = (body: unknown, init: { status?: number } = {}) => {
+    const status = init.status ?? 200;
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+    } as any;
+};
+
+it("should upsert points using the Qdrant REST API", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(createJsonResponse({ result: { status: "ok" } }));
+    const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY, { fetch: fetchMock });
+
+    await qdrant.upsertPoints({
+        collectionName: "documents",
+        points: [
+            {
+                id: 1,
+                vector: [0.1, 0.2, 0.3],
+                payload: { content: "hello" },
+            },
+        ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+        `${MOCK_QDRANT_URL}/collections/documents/points?wait=true`,
+        expect.objectContaining({
+            method: "PUT",
+            headers: expect.objectContaining({
+                "api-key": MOCK_QDRANT_API_KEY,
+                "content-type": "application/json",
+            }),
+            body: JSON.stringify({
+                points: [
+                    {
+                        id: 1,
+                        vector: [0.1, 0.2, 0.3],
+                        payload: { content: "hello" },
+                    },
+                ],
+            }),
+        })
+    );
+});
+
+it("should search points using the Qdrant REST API", async () => {
+    const searchResult = [{ id: 1, score: 0.9, payload: { content: "hello" } }];
+    const fetchMock = jest.fn().mockResolvedValue(createJsonResponse({ result: searchResult }));
+    const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY, { fetch: fetchMock });
+
+    const result = await qdrant.search({
+        collectionName: "documents",
+        vector: [0.1, 0.2, 0.3],
+        limit: 3,
+        filter: { must: [{ key: "source", match: { value: "docs" } }] },
+    });
+
+    expect(result).toEqual({ result: searchResult });
+    expect(fetchMock).toHaveBeenCalledWith(
+        `${MOCK_QDRANT_URL}/collections/documents/points/search`,
+        expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({
+                vector: [0.1, 0.2, 0.3],
+                limit: 3,
+                filter: { must: [{ key: "source", match: { value: "docs" } }] },
+                with_payload: true,
+                with_vector: false,
+            }),
+        })
+    );
+});
+
+it("should throw when Qdrant returns an error", async () => {
+    const fetchMock = jest
+        .fn()
+        .mockResolvedValue(createJsonResponse({ status: { error: "missing collection" } }, { status: 404 }));
+    const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY, { fetch: fetchMock });
+
+    await expect(
+        qdrant.getPointById({
+            collectionName: "missing",
+            id: "abc",
+        })
+    ).rejects.toThrow("Qdrant request failed with status 404");
+});


### PR DESCRIPTION
# Add Qdrant vector database client

Closes arakoodev/EdgeChains#273.
/claim #273

## Summary

- Adds a `Qdrant` vector database client implemented against Qdrant's REST API directly.
- Exports `Qdrant` from `@arakoodev/edgechains.js/vector-db`.
- Adds mocked tests for point upsert, vector search, and error handling.

## Verification

```text
npx tsc -b
npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --config jest.config.cjs
npx jest src/vector-db/src/tests --config jest.config.cjs
```

The vector-db test suite passed locally: 7 suites, 10 tests.
