### PR TITLE
Add AWS Comprehend PII redaction helper

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -20,5 +20,8 @@ const response = await safeOpenAI.chat({
 });
 ```
 
+For chainable flows, `redactObservable()` and `redactTextObservable()` expose a
+small Observable-style interface with `subscribe()` and `pipe()`.
+
 Credentials are read from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
 `AWS_SESSION_TOKEN`, and `AWS_REGION` or `AWS_DEFAULT_REGION`.

--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -3,3 +3,22 @@ Installation
 ```
 npm install arakoodev
 ```
+
+## AWS Comprehend PII redaction
+
+`ComprehendRedactor` can redact PII before text is passed to an LLM endpoint.
+
+```ts
+import { ComprehendRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+const redactor = new ComprehendRedactor();
+const openAI = new OpenAI({});
+const safeOpenAI = redactor.wrapChat(openAI);
+
+const response = await safeOpenAI.chat({
+  prompt: "Summarize Jane Doe's account notes. Email: jane@example.com",
+});
+```
+
+Credentials are read from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
+`AWS_SESSION_TOKEN`, and `AWS_REGION` or `AWS_DEFAULT_REGION`.

--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -22,6 +22,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.1045.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,10 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+    ComprehendRedactor,
+    type ComprehendDetectionOptions,
+    type ComprehendRedactionResult,
+    type ComprehendRedactOptions,
+    type ComprehendRedactorOptions,
+} from "./lib/comprehend/comprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -4,9 +4,10 @@ export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
 export {
-    ComprehendRedactor,
-    type ComprehendDetectionOptions,
-    type ComprehendRedactionResult,
-    type ComprehendRedactOptions,
-    type ComprehendRedactorOptions,
+  type ComprehendObservable,
+  ComprehendRedactor,
+  type ComprehendDetectionOptions,
+  type ComprehendRedactionResult,
+  type ComprehendRedactOptions,
+  type ComprehendRedactorOptions,
 } from "./lib/comprehend/comprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehendRedactor.ts
@@ -27,6 +27,25 @@ type RedactionReplacement =
   | string
   | ((entity: PiiEntity, value: string) => string);
 
+type Observer<T> = {
+  next?: (value: T) => void;
+  error?: (error: unknown) => void;
+  complete?: () => void;
+};
+
+type Teardown = {
+  unsubscribe(): void;
+};
+
+export type ComprehendObservable<T> = {
+  subscribe(
+    observerOrNext: Observer<T> | ((value: T) => void),
+    error?: (error: unknown) => void,
+    complete?: () => void,
+  ): Teardown;
+  pipe<TNext>(operator: (source: ComprehendObservable<T>) => TNext): TNext;
+};
+
 export interface ComprehendRedactorOptions {
   region?: string;
   accessKeyId?: string;
@@ -105,6 +124,19 @@ export class ComprehendRedactor {
     return result.redactedText;
   }
 
+  redactObservable(
+    options: string | ComprehendRedactOptions,
+  ): ComprehendObservable<ComprehendRedactionResult> {
+    return this.createObservable(() => this.redact(options));
+  }
+
+  redactTextObservable(
+    text: string,
+    options: Omit<ComprehendRedactOptions, "text"> = {},
+  ): ComprehendObservable<string> {
+    return this.createObservable(() => this.redactText(text, options));
+  }
+
   async redactPromptOptions<T extends PromptLike>(
     chatOptions: T,
     options: Omit<ComprehendRedactOptions, "text"> = {},
@@ -149,6 +181,50 @@ export class ComprehendRedactor {
         return endpoint.chat(redactedOptions);
       },
     };
+  }
+
+  private createObservable<T>(
+    producer: () => Promise<T>,
+  ): ComprehendObservable<T> {
+    const observable: ComprehendObservable<T> = {
+      subscribe: (
+        observerOrNext: Observer<T> | ((value: T) => void),
+        error?: (error: unknown) => void,
+        complete?: () => void,
+      ) => {
+        let isSubscribed = true;
+        const observer =
+          typeof observerOrNext === "function"
+            ? { next: observerOrNext, error, complete }
+            : observerOrNext;
+
+        producer()
+          .then((value) => {
+            if (!isSubscribed) {
+              return;
+            }
+
+            observer.next?.(value);
+            observer.complete?.();
+          })
+          .catch((caughtError) => {
+            if (!isSubscribed) {
+              return;
+            }
+
+            observer.error?.(caughtError);
+          });
+
+        return {
+          unsubscribe: () => {
+            isSubscribed = false;
+          },
+        };
+      },
+      pipe: (operator) => operator(observable),
+    };
+
+    return observable;
   }
 
   private createClient(options: ComprehendRedactorOptions): ComprehendClient {

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehendRedactor.ts
@@ -1,0 +1,245 @@
+import {
+  ComprehendClient,
+  DetectPiiEntitiesCommand,
+  type DetectPiiEntitiesCommandOutput,
+  type LanguageCode,
+  type PiiEntity,
+} from "@aws-sdk/client-comprehend";
+
+type ComprehendClientLike = {
+  send(
+    command: DetectPiiEntitiesCommand,
+  ): Promise<DetectPiiEntitiesCommandOutput>;
+};
+
+type PromptMessage = {
+  content?: string;
+  [key: string]: unknown;
+};
+
+type PromptLike = {
+  prompt?: string;
+  messages?: PromptMessage[];
+  [key: string]: unknown;
+};
+
+type RedactionReplacement =
+  | string
+  | ((entity: PiiEntity, value: string) => string);
+
+export interface ComprehendRedactorOptions {
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  client?: ComprehendClientLike;
+  replacement?: RedactionReplacement;
+}
+
+export interface ComprehendDetectionOptions {
+  text: string;
+  languageCode?: LanguageCode;
+}
+
+export interface ComprehendRedactOptions extends ComprehendDetectionOptions {
+  replacement?: RedactionReplacement;
+}
+
+export interface ComprehendRedactionResult {
+  originalText: string;
+  redactedText: string;
+  entities: PiiEntity[];
+}
+
+export class ComprehendRedactor {
+  private client: ComprehendClientLike;
+  private replacement: RedactionReplacement;
+
+  constructor(options: ComprehendRedactorOptions = {}) {
+    this.client = options.client || this.createClient(options);
+    this.replacement =
+      options.replacement || ((entity) => `[${entity.Type || "PII"}]`);
+  }
+
+  async detectPiiEntities(
+    options: string | ComprehendDetectionOptions,
+  ): Promise<PiiEntity[]> {
+    const { text, languageCode } = this.normalizeDetectionOptions(options);
+
+    if (!text.trim()) {
+      return [];
+    }
+
+    const response = await this.client.send(
+      new DetectPiiEntitiesCommand({
+        Text: text,
+        LanguageCode: languageCode,
+      }),
+    );
+
+    return response.Entities || [];
+  }
+
+  async redact(
+    options: string | ComprehendRedactOptions,
+  ): Promise<ComprehendRedactionResult> {
+    const normalizedOptions = this.normalizeRedactOptions(options);
+    const entities = await this.detectPiiEntities(normalizedOptions);
+
+    return {
+      originalText: normalizedOptions.text,
+      redactedText: this.applyRedactions(
+        normalizedOptions.text,
+        entities,
+        normalizedOptions.replacement || this.replacement,
+      ),
+      entities,
+    };
+  }
+
+  async redactText(
+    text: string,
+    options: Omit<ComprehendRedactOptions, "text"> = {},
+  ): Promise<string> {
+    const result = await this.redact({ ...options, text });
+    return result.redactedText;
+  }
+
+  async redactPromptOptions<T extends PromptLike>(
+    chatOptions: T,
+    options: Omit<ComprehendRedactOptions, "text"> = {},
+  ): Promise<T> {
+    const redactedOptions = { ...chatOptions };
+
+    if (typeof redactedOptions.prompt === "string") {
+      redactedOptions.prompt = await this.redactText(
+        redactedOptions.prompt,
+        options,
+      );
+    }
+
+    if (Array.isArray(redactedOptions.messages)) {
+      redactedOptions.messages = await Promise.all(
+        redactedOptions.messages.map(async (message) => {
+          if (typeof message.content !== "string") {
+            return message;
+          }
+
+          return {
+            ...message,
+            content: await this.redactText(message.content, options),
+          };
+        }),
+      );
+    }
+
+    return redactedOptions as T;
+  }
+
+  wrapChat<TOptions extends PromptLike, TResult>(
+    endpoint: { chat(options: TOptions): Promise<TResult> | TResult },
+    options: Omit<ComprehendRedactOptions, "text"> = {},
+  ): { chat(options: TOptions): Promise<TResult> } {
+    return {
+      chat: async (chatOptions: TOptions) => {
+        const redactedOptions = await this.redactPromptOptions(
+          chatOptions,
+          options,
+        );
+        return endpoint.chat(redactedOptions);
+      },
+    };
+  }
+
+  private createClient(options: ComprehendRedactorOptions): ComprehendClient {
+    const accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
+    const secretAccessKey =
+      options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
+    const sessionToken = options.sessionToken || process.env.AWS_SESSION_TOKEN;
+
+    return new ComprehendClient({
+      region:
+        options.region ||
+        process.env.AWS_REGION ||
+        process.env.AWS_DEFAULT_REGION ||
+        "us-east-1",
+      credentials:
+        accessKeyId && secretAccessKey
+          ? {
+              accessKeyId,
+              secretAccessKey,
+              sessionToken,
+            }
+          : undefined,
+    });
+  }
+
+  private normalizeDetectionOptions(
+    options: string | ComprehendDetectionOptions,
+  ): Required<ComprehendDetectionOptions> {
+    if (typeof options === "string") {
+      return { text: options, languageCode: "en" };
+    }
+
+    return {
+      text: options.text,
+      languageCode: options.languageCode || "en",
+    };
+  }
+
+  private normalizeRedactOptions(
+    options: string | ComprehendRedactOptions,
+  ): Required<ComprehendRedactOptions> {
+    if (typeof options === "string") {
+      return {
+        text: options,
+        languageCode: "en",
+        replacement: this.replacement,
+      };
+    }
+
+    return {
+      text: options.text,
+      languageCode: options.languageCode || "en",
+      replacement: options.replacement || this.replacement,
+    };
+  }
+
+  private applyRedactions(
+    text: string,
+    entities: PiiEntity[],
+    replacement: RedactionReplacement,
+  ): string {
+    return entities
+      .filter((entity) => this.isEntityWithOffsets(entity, text))
+      .sort((a, b) => (b.BeginOffset || 0) - (a.BeginOffset || 0))
+      .reduce((redactedText, entity) => {
+        const begin = entity.BeginOffset || 0;
+        const end = entity.EndOffset || begin;
+        const value = redactedText.slice(begin, end);
+        const redactedValue =
+          typeof replacement === "function"
+            ? replacement(entity, value)
+            : replacement;
+
+        return (
+          redactedText.slice(0, begin) + redactedValue + redactedText.slice(end)
+        );
+      }, text);
+  }
+
+  private isEntityWithOffsets(entity: PiiEntity, text: string): boolean {
+    if (
+      typeof entity.BeginOffset !== "number" ||
+      typeof entity.EndOffset !== "number"
+    ) {
+      return false;
+    }
+
+    return (
+      entity.BeginOffset >= 0 &&
+      entity.EndOffset > entity.BeginOffset &&
+      entity.EndOffset <= text.length
+    );
+  }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/testcases/comprehend/comprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/testcases/comprehend/comprehendRedactor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import { ComprehendRedactor } from "../../lib/comprehend/comprehendRedactor.js";
+
+class FakeComprehendClient {
+  commands: any[] = [];
+
+  constructor(private entities: any[]) {}
+
+  async send(command: any): Promise<any> {
+    this.commands.push(command);
+    return { Entities: this.entities };
+  }
+}
+
+describe("ComprehendRedactor", () => {
+  test("detects PII entities with AWS Comprehend", async () => {
+    const client = new FakeComprehendClient([
+      { Type: "EMAIL", BeginOffset: 14, EndOffset: 30, Score: 0.99 },
+    ]);
+    const redactor = new ComprehendRedactor({ client });
+
+    const entities = await redactor.detectPiiEntities(
+      "Jane Doe uses jane@example.com",
+    );
+
+    expect(entities).toEqual([
+      { Type: "EMAIL", BeginOffset: 14, EndOffset: 30, Score: 0.99 },
+    ]);
+    expect(client.commands).toHaveLength(1);
+  });
+
+  test("redacts detected PII entities with entity labels", async () => {
+    const client = new FakeComprehendClient([
+      { Type: "NAME", BeginOffset: 0, EndOffset: 8, Score: 0.99 },
+      { Type: "EMAIL", BeginOffset: 14, EndOffset: 30, Score: 0.99 },
+    ]);
+    const redactor = new ComprehendRedactor({ client });
+
+    const result = await redactor.redact("Jane Doe uses jane@example.com");
+
+    expect(result.redactedText).toBe("[NAME] uses [EMAIL]");
+  });
+
+  test("supports custom replacement strings", async () => {
+    const client = new FakeComprehendClient([
+      { Type: "PHONE", BeginOffset: 8, EndOffset: 20, Score: 0.99 },
+    ]);
+    const redactor = new ComprehendRedactor({
+      client,
+      replacement: "[REDACTED]",
+    });
+
+    const redactedText = await redactor.redactText("Call me 555-123-4567");
+
+    expect(redactedText).toBe("Call me [REDACTED]");
+  });
+
+  test("redacts prompt and message options before they are sent to an endpoint", async () => {
+    const client = new FakeComprehendClient([
+      { Type: "NAME", BeginOffset: 0, EndOffset: 8, Score: 0.99 },
+    ]);
+    const redactor = new ComprehendRedactor({ client });
+
+    const options = await redactor.redactPromptOptions({
+      prompt: "Jane Doe needs help",
+      messages: [{ role: "user", content: "Jane Doe needs help" }],
+    });
+
+    expect(options.prompt).toBe("[NAME] needs help");
+    expect(options.messages?.[0].content).toBe("[NAME] needs help");
+  });
+
+  test("wraps chat endpoints so redaction can be chained with LLM calls", async () => {
+    const client = new FakeComprehendClient([
+      { Type: "NAME", BeginOffset: 0, EndOffset: 8, Score: 0.99 },
+    ]);
+    const redactor = new ComprehendRedactor({ client });
+    const endpoint = {
+      chat: async (options: { prompt: string }) => options.prompt,
+    };
+
+    const safeEndpoint = redactor.wrapChat(endpoint);
+    const response = await safeEndpoint.chat({ prompt: "Jane Doe needs help" });
+
+    expect(response).toBe("[NAME] needs help");
+  });
+});

--- a/JS/edgechains/arakoodev/src/ai/src/testcases/comprehend/comprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/testcases/comprehend/comprehendRedactor.test.ts
@@ -84,4 +84,41 @@ describe("ComprehendRedactor", () => {
 
     expect(response).toBe("[NAME] needs help");
   });
+
+  test("exposes observable-style text redaction for chainable flows", async () => {
+    const client = new FakeComprehendClient([
+      { Type: "NAME", BeginOffset: 0, EndOffset: 8, Score: 0.99 },
+    ]);
+    const redactor = new ComprehendRedactor({ client });
+
+    const redactedText = await new Promise<string>((resolve, reject) => {
+      redactor.redactTextObservable("Jane Doe needs help").subscribe({
+        next: resolve,
+        error: reject,
+      });
+    });
+
+    expect(redactedText).toBe("[NAME] needs help");
+  });
+
+  test("supports observable pipe operators", async () => {
+    const client = new FakeComprehendClient([
+      { Type: "NAME", BeginOffset: 0, EndOffset: 8, Score: 0.99 },
+    ]);
+    const redactor = new ComprehendRedactor({ client });
+
+    const redactedText = await redactor
+      .redactObservable("Jane Doe needs help")
+      .pipe(
+        (source) =>
+          new Promise<string>((resolve, reject) => {
+            source.subscribe({
+              next: (result) => resolve(result.redactedText),
+              error: reject,
+            });
+          }),
+      );
+
+    expect(redactedText).toBe("[NAME] needs help");
+  });
 });

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,23 @@
+# AWS Comprehend Redaction Example
+
+This example redacts personally identifiable information with Amazon Comprehend before sending text to an LLM endpoint.
+
+## Environment
+
+Set AWS credentials with the standard environment variables:
+
+```bash
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_SESSION_TOKEN=...
+```
+
+`AWS_SESSION_TOKEN` is optional. `AWS_DEFAULT_REGION` is also supported when `AWS_REGION` is not set.
+
+## Run
+
+```bash
+npm install
+npm start
+```

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aws-comprehend-redaction-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,26 @@
+import { ComprehendRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+async function main() {
+  const redactor = new ComprehendRedactor();
+  const prompt =
+    "Summarize this customer note: Jane Doe can be reached at jane@example.com.";
+  const redactedPrompt = await redactor.redactText(prompt);
+
+  console.log("Redacted prompt:", redactedPrompt);
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.log("Skipping OpenAI call because OPENAI_API_KEY is not set.");
+    return;
+  }
+
+  const openAI = new OpenAI({});
+  const safeOpenAI = redactor.wrapChat(openAI);
+  const response = await safeOpenAI.chat({ prompt });
+
+  console.log(response);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Summary:
- Adds `ComprehendRedactor` to the JS SDK AI package using `@aws-sdk/client-comprehend`.
- Supports direct PII detection/redaction, `wrapChat()` for existing LLM endpoints, and Observable-style `subscribe()` / `pipe()` helpers for chainable redaction flows.
- Exports the helper and related option/result/observable types from `@arakoodev/edgechains.js/ai`.
- Adds mocked Vitest coverage under `src/ai/src/testcases/comprehend`, including direct redaction, endpoint wrapping, and Observable-style chaining.
- Adds an `aws-comprehend-redaction` example with AWS environment setup notes.

Verification:
- `node node_modules\vitest\vitest.mjs run src/ai/src/testcases/comprehend/comprehendRedactor.test.ts` — 7 tests passed
- `node node_modules\typescript\bin\tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --strict --skipLibCheck --types node src/ai/src/lib/comprehend/comprehendRedactor.ts src/ai/src/testcases/comprehend/comprehendRedactor.test.ts`
- `node node_modules\prettier\bin\prettier.cjs --check src/ai/src/lib/comprehend/comprehendRedactor.ts src/ai/src/testcases/comprehend/comprehendRedactor.test.ts src/ai/src/index.ts README.md ../examples/aws-comprehend-redaction/src/index.ts ../examples/aws-comprehend-redaction/README.md ../examples/aws-comprehend-redaction/package.json ../examples/aws-comprehend-redaction/tsconfig.json`
- `git diff --check`

Note:
- Full project typecheck currently hits pre-existing repo issues unrelated to this change, including `src/document-loader/src/lib/pdf-loader/pdfLoader.ts` missing `pdf-parse/lib/pdf-parse.js` types and existing implicit-any errors in older AI modules.

/claim #290