### PR TITLE
feat(js): add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -1,5 +1,55 @@
-Installation
+# @arakoodev/edgechains.js
 
+## Installation
+
+```sh
+npm install @arakoodev/edgechains.js
 ```
-npm install arakoodev
+
+## Vector databases
+
+The JavaScript SDK exports vector database clients from `@arakoodev/edgechains.js/vector-db`.
+
+### Supabase
+
+```ts
+import { Supabase } from "@arakoodev/edgechains.js/vector-db";
 ```
+
+### Qdrant
+
+Qdrant support uses the Qdrant HTTP API directly; no Qdrant npm package is required.
+
+```ts
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY);
+const client = qdrant.createClient();
+
+await qdrant.createCollection({
+    client,
+    collectionName: "documents",
+    size: 1536,
+    distance: "Cosine",
+});
+
+await qdrant.insertVectorData({
+    client,
+    collectionName: "documents",
+    id: "doc-1",
+    vector: embedding,
+    payload: {
+        content: "Document text",
+        source: "example",
+    },
+});
+
+const matches = await qdrant.search({
+    client,
+    collectionName: "documents",
+    vector: queryEmbedding,
+    limit: 5,
+});
+```
+
+`Qdrant` also includes `getCollection`, `deleteCollection`, `upsertPoints`, `getData`, `getDataById`, `updateById`, and `deleteById` helpers. `insertVectorData` accepts Supabase-style aliases (`tableName` and `embedding`) to make migration from existing EdgeChains vector database examples straightforward.

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,11 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+    QdrantClient,
+    QdrantDistance,
+    QdrantInsertVectorDataArgs,
+    QdrantPoint,
+    QdrantPointId,
+    QdrantSearchArgs,
+    QdrantVectorConfig,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,447 @@
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+export type QdrantPointId = string | number;
+export type QdrantDistance = "Cosine" | "Euclid" | "Dot" | "Manhattan";
+
+export interface QdrantClient {
+    url: string;
+    apiKey?: string;
+    timeoutMs: number;
+}
+
+export interface QdrantPoint {
+    id: QdrantPointId;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+export interface QdrantVectorConfig {
+    size: number;
+    distance?: QdrantDistance;
+    [key: string]: any;
+}
+
+export interface QdrantSearchArgs {
+    client?: QdrantClient;
+    collectionName: string;
+    vector: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, any>;
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+    [key: string]: any;
+}
+
+export interface QdrantInsertVectorDataArgs {
+    client?: QdrantClient;
+    collectionName?: string;
+    tableName?: string;
+    id: QdrantPointId;
+    vector?: number[] | Record<string, number[]>;
+    embedding?: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+    wait?: boolean;
+    [key: string]: any;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+    timeoutMs: number;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string, timeoutMs = 30000) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "http://localhost:6333").replace(
+            /\/$/,
+            ""
+        );
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+        this.timeoutMs = timeoutMs;
+    }
+
+    createClient(): QdrantClient {
+        return {
+            url: this.QDRANT_URL,
+            apiKey: this.QDRANT_API_KEY,
+            timeoutMs: this.timeoutMs,
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectors,
+        size,
+        distance = "Cosine",
+        ...args
+    }: {
+        client?: QdrantClient;
+        collectionName: string;
+        vectors?: QdrantVectorConfig | Record<string, QdrantVectorConfig>;
+        size?: number;
+        distance?: QdrantDistance;
+        [key: string]: any;
+    }): Promise<any> {
+        const vectorConfig = vectors || { size, distance };
+        if (!vectors && !size) {
+            throw new Error("Qdrant collection creation requires either vectors or size");
+        }
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collectionName)}`,
+            body: {
+                vectors: vectorConfig,
+                ...args,
+            },
+        });
+    }
+
+    async getCollection({
+        client,
+        collectionName,
+    }: {
+        client?: QdrantClient;
+        collectionName: string;
+    }): Promise<any> {
+        return this.request({
+            client,
+            method: "GET",
+            path: `/collections/${encodeURIComponent(collectionName)}`,
+        });
+    }
+
+    async deleteCollection({
+        client,
+        collectionName,
+        timeout,
+    }: {
+        client?: QdrantClient;
+        collectionName: string;
+        timeout?: number;
+    }): Promise<any> {
+        return this.request({
+            client,
+            method: "DELETE",
+            path: `/collections/${encodeURIComponent(collectionName)}${
+                timeout ? `?timeout=${timeout}` : ""
+            }`,
+        });
+    }
+
+    async upsertPoints({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        client?: QdrantClient;
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collectionName)}/points?wait=${wait}`,
+            body: { points },
+        });
+    }
+
+    /**
+     * Insert one vector point into Qdrant. Accepts EdgeChains/Supabase-style
+     * `tableName` + `embedding` as aliases for `collectionName` + `vector`.
+     */
+    async insertVectorData({
+        client,
+        collectionName,
+        tableName,
+        id,
+        vector,
+        embedding,
+        payload,
+        wait = true,
+        ...args
+    }: QdrantInsertVectorDataArgs): Promise<any> {
+        const targetCollection = collectionName || tableName;
+        const targetVector = vector || embedding;
+        if (!targetCollection) {
+            throw new Error("Qdrant insertVectorData requires collectionName or tableName");
+        }
+        if (!targetVector) {
+            throw new Error("Qdrant insertVectorData requires vector or embedding");
+        }
+
+        const pointPayload = payload || args;
+        return this.upsertPoints({
+            client,
+            collectionName: targetCollection,
+            wait,
+            points: [
+                {
+                    id,
+                    vector: targetVector,
+                    payload: pointPayload,
+                },
+            ],
+        });
+    }
+
+    async search({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+        ...args
+    }: QdrantSearchArgs): Promise<any> {
+        const response = await this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collectionName)}/points/search`,
+            body: {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+                ...args,
+            },
+        });
+
+        return response.result ?? response;
+    }
+
+    async getData({
+        client,
+        collectionName,
+        tableName,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        offset,
+    }: {
+        client?: QdrantClient;
+        collectionName?: string;
+        tableName?: string;
+        limit?: number;
+        filter?: Record<string, any>;
+        withPayload?: boolean | string[] | Record<string, any>;
+        withVector?: boolean | string[];
+        offset?: QdrantPointId | Record<string, any>;
+    }): Promise<any> {
+        const targetCollection = collectionName || tableName;
+        if (!targetCollection) {
+            throw new Error("Qdrant getData requires collectionName or tableName");
+        }
+
+        const response = await this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(targetCollection)}/points/scroll`,
+            body: {
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                offset,
+            },
+        });
+
+        return response.result ?? response;
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: {
+        client?: QdrantClient;
+        collectionName?: string;
+        tableName?: string;
+        id: QdrantPointId;
+        withPayload?: boolean | string[] | Record<string, any>;
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        const targetCollection = collectionName || tableName;
+        if (!targetCollection) {
+            throw new Error("Qdrant getDataById requires collectionName or tableName");
+        }
+
+        const query = new URLSearchParams({
+            with_payload: String(Boolean(withPayload)),
+            with_vector: String(Boolean(withVector)),
+        });
+
+        const response = await this.request({
+            client,
+            method: "GET",
+            path: `/collections/${encodeURIComponent(targetCollection)}/points/${encodeURIComponent(
+                String(id)
+            )}?${query.toString()}`,
+        });
+
+        return response.result ?? response;
+    }
+
+    async updateById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        updatedContent,
+        wait = true,
+    }: {
+        client?: QdrantClient;
+        collectionName?: string;
+        tableName?: string;
+        id: QdrantPointId;
+        updatedContent: Record<string, any>;
+        wait?: boolean;
+    }): Promise<any> {
+        const targetCollection = collectionName || tableName;
+        if (!targetCollection) {
+            throw new Error("Qdrant updateById requires collectionName or tableName");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(targetCollection)}/points/payload?wait=${wait}`,
+            body: {
+                payload: updatedContent,
+                points: [id],
+            },
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        wait = true,
+    }: {
+        client?: QdrantClient;
+        collectionName?: string;
+        tableName?: string;
+        id: QdrantPointId;
+        wait?: boolean;
+    }): Promise<any> {
+        const targetCollection = collectionName || tableName;
+        if (!targetCollection) {
+            throw new Error("Qdrant deleteById requires collectionName or tableName");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(targetCollection)}/points/delete?wait=${wait}`,
+            body: {
+                points: [id],
+            },
+        });
+    }
+
+    private async request({
+        client,
+        method,
+        path,
+        body,
+    }: {
+        client?: QdrantClient;
+        method: string;
+        path: string;
+        body?: Record<string, any>;
+    }): Promise<any> {
+        const activeClient = client || this.createClient();
+
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), activeClient.timeoutMs);
+
+                try {
+                    const response = await fetch(`${activeClient.url}${path}`, {
+                        method,
+                        headers: this.headers(activeClient),
+                        body: body ? JSON.stringify(this.cleanUndefined(body)) : undefined,
+                        signal: controller.signal,
+                    });
+                    const responseBody = await this.parseResponse(response);
+
+                    if (!response.ok) {
+                        const message = responseBody?.status?.error || responseBody?.message || response.statusText;
+                        const error = new Error(
+                            `Qdrant ${method} ${path} failed with ${response.status}: ${message}`
+                        );
+                        const retryableStatus = response.status === 429 || response.status >= 500;
+                        if (retryableStatus && operation.retry(error)) return;
+                        reject(error);
+                        return;
+                    }
+
+                    resolve(responseBody);
+                } catch (error: any) {
+                    if (operation.retry(error)) return;
+                    reject(error);
+                } finally {
+                    clearTimeout(timeout);
+                }
+            });
+        });
+    }
+
+    private headers(client: QdrantClient): Record<string, string> {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (client.apiKey) {
+            headers["api-key"] = client.apiKey;
+        }
+        return headers;
+    }
+
+    private async parseResponse(response: Response): Promise<any> {
+        const text = await response.text();
+        if (!text) return {};
+        try {
+            return JSON.parse(text);
+        } catch (error) {
+            return text;
+        }
+    }
+
+    private cleanUndefined<T>(value: T): T {
+        if (Array.isArray(value)) {
+            return value.map((item) => this.cleanUndefined(item)) as T;
+        }
+        if (value && typeof value === "object") {
+            return Object.fromEntries(
+                Object.entries(value as Record<string, any>)
+                    .filter(([, entryValue]) => entryValue !== undefined)
+                    .map(([key, entryValue]) => [key, this.cleanUndefined(entryValue)])
+            ) as T;
+        }
+        return value;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+const jsonResponse = (body: Record<string, any>, init?: ResponseInit) =>
+    new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        statusText: init?.statusText,
+        headers: { "Content-Type": "application/json" },
+    });
+
+describe("Qdrant", () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        vi.stubGlobal("fetch", fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("creates collections through the Qdrant REST API without a qdrant package", async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ result: true, status: "ok" }));
+
+        const qdrant = new Qdrant("https://qdrant.example", "test-key");
+        const client = qdrant.createClient();
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            size: 1536,
+            distance: "Cosine",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents",
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                    "api-key": "test-key",
+                }),
+                body: JSON.stringify({ vectors: { size: 1536, distance: "Cosine" } }),
+            })
+        );
+    });
+
+    it("inserts EdgeChains-style vector data by upserting a Qdrant point", async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ result: { operation_id: 1 }, status: "ok" }));
+
+        const qdrant = new Qdrant("https://qdrant.example");
+        await qdrant.insertVectorData({
+            tableName: "documents",
+            id: "doc-1",
+            embedding: [0.1, 0.2, 0.3],
+            content: "hello world",
+            source: "unit-test",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: "doc-1",
+                            vector: [0.1, 0.2, 0.3],
+                            payload: { content: "hello world", source: "unit-test" },
+                        },
+                    ],
+                }),
+            })
+        );
+    });
+
+    it("searches points and returns the Qdrant result payload", async () => {
+        const qdrantResults = [{ id: "doc-1", score: 0.92, payload: { content: "hello" } }];
+        fetchMock.mockResolvedValueOnce(jsonResponse({ result: qdrantResults, status: "ok" }));
+
+        const qdrant = new Qdrant("https://qdrant.example");
+        const result = await qdrant.search({
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "unit-test" } }] },
+        });
+
+        expect(result).toEqual(qdrantResults);
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents/points/search",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    vector: [0.1, 0.2, 0.3],
+                    limit: 3,
+                    filter: { must: [{ key: "source", match: { value: "unit-test" } }] },
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            })
+        );
+    });
+
+    it("throws helpful errors for non-2xx Qdrant responses", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({ status: { error: "collection not found" } }, { status: 404 }));
+
+        const qdrant = new Qdrant("https://qdrant.example");
+        await expect(qdrant.getCollection({ collectionName: "missing" })).rejects.toThrow(
+            "Qdrant GET /collections/missing failed with 404: collection not found"
+        );
+    });
+});


### PR DESCRIPTION
/claim #273

## Summary
- Added a `Qdrant` vector database client to the JavaScript SDK under `@arakoodev/edgechains.js/vector-db`.
- Uses Qdrant's REST API directly via `fetch`; no Qdrant npm package dependency is added.
- Supports collection creation/deletion/inspection, point upsert, EdgeChains-style `insertVectorData`, vector search, scroll reads, get/update/delete by id, API key headers, retries, and env defaults (`QDRANT_URL`, `QDRANT_API_KEY`).
- Exported Qdrant types and documented usage in the package README.

## Validation
- `npm run build` ✅
- `npx vitest --run src/vector-db/src/tests/qdrant/qdrant.test.ts` ✅ (4 Qdrant REST wrapper tests)
- `npm test -- --run` ⚠️ attempted, but the pre-existing full suite is not green in this checkout due unrelated issues: Vitest globals missing for older Jest-style tests, missing Playwright browser install, a scraper 403, and existing dist import path mismatches. The new Qdrant-targeted tests pass after build.
