### PR TITLE
Add AWS Comprehend PII redactor

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,16 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+  AWSComprehendPIIRedactor,
+  ComprehendRedactionMiddleware,
+} from "./lib/aws-comprehend/aws-comprehend.js";
+export type {
+  AWSComprehendPIIRedactorOptions,
+  ComprehendPiiEntity,
+  ComprehendPiiEntityType,
+  DetectPiiEntitiesResponse,
+  ObservableLike,
+  ObserverLike,
+  RedactTextOptions,
+} from "./lib/aws-comprehend/aws-comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/aws-comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/aws-comprehend.ts
@@ -1,0 +1,364 @@
+import { createHash, createHmac } from "crypto";
+
+type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export type ComprehendPiiEntityType =
+  | "BANK_ACCOUNT_NUMBER"
+  | "BANK_ROUTING"
+  | "CREDIT_DEBIT_NUMBER"
+  | "CREDIT_DEBIT_CVV"
+  | "CREDIT_DEBIT_EXPIRY"
+  | "PIN"
+  | "EMAIL"
+  | "ADDRESS"
+  | "NAME"
+  | "PHONE"
+  | "SSN"
+  | "DATE_TIME"
+  | "PASSPORT_NUMBER"
+  | "DRIVER_ID"
+  | "URL"
+  | "AGE"
+  | "USERNAME"
+  | "PASSWORD"
+  | "AWS_ACCESS_KEY"
+  | "AWS_SECRET_KEY"
+  | "IP_ADDRESS"
+  | "MAC_ADDRESS"
+  | "ALL";
+
+export interface ComprehendPiiEntity {
+  Score: number;
+  Type: ComprehendPiiEntityType;
+  BeginOffset: number;
+  EndOffset: number;
+}
+
+export interface DetectPiiEntitiesResponse {
+  Entities: ComprehendPiiEntity[];
+}
+
+export interface AWSComprehendPIIRedactorOptions {
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  endpoint?: string;
+  languageCode?: string;
+  minScore?: number;
+  entityTypes?: ComprehendPiiEntityType[];
+  replacement?: string;
+  fetch?: FetchLike;
+  now?: () => Date;
+}
+
+export interface RedactTextOptions {
+  languageCode?: string;
+  minScore?: number;
+  entityTypes?: ComprehendPiiEntityType[];
+  replacement?: string;
+}
+
+export interface ObserverLike<T> {
+  next: (value: T) => void;
+  error?: (error: unknown) => void;
+  complete?: () => void;
+}
+
+export interface ObservableLike<T> {
+  subscribe: (
+    observer: ObserverLike<T> | ((value: T) => void),
+  ) => { unsubscribe?: () => void } | void;
+}
+
+interface MessageLike {
+  content?: string;
+  [key: string]: any;
+}
+
+interface ChatOptionsLike {
+  prompt?: string;
+  messages?: MessageLike[];
+  [key: string]: any;
+}
+
+const SERVICE = "comprehend";
+const TARGET = "Comprehend_20171127.DetectPiiEntities";
+const CONTENT_TYPE = "application/x-amz-json-1.1";
+
+export class AWSComprehendPIIRedactor {
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  endpoint: string;
+  languageCode: string;
+  minScore: number;
+  entityTypes?: ComprehendPiiEntityType[];
+  replacement: string;
+  fetch: FetchLike;
+  now: () => Date;
+
+  constructor(options: AWSComprehendPIIRedactorOptions = {}) {
+    this.region = options.region || process.env.AWS_REGION || "us-east-1";
+    this.accessKeyId =
+      options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+    this.secretAccessKey =
+      options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "";
+    this.sessionToken = options.sessionToken || process.env.AWS_SESSION_TOKEN;
+    this.endpoint =
+      options.endpoint || `https://${SERVICE}.${this.region}.amazonaws.com`;
+    this.languageCode = options.languageCode || "en";
+    this.minScore = options.minScore ?? 0;
+    this.entityTypes = options.entityTypes;
+    this.replacement = options.replacement || "[REDACTED_{type}]";
+    this.fetch = options.fetch || globalThis.fetch.bind(globalThis);
+    this.now = options.now || (() => new Date());
+  }
+
+  async detectPiiEntities(
+    text: string,
+    options: Pick<RedactTextOptions, "languageCode"> = {},
+  ): Promise<DetectPiiEntitiesResponse> {
+    if (!this.accessKeyId || !this.secretAccessKey) {
+      throw new Error(
+        "AWS credentials are required for Comprehend PII redaction",
+      );
+    }
+
+    const body = JSON.stringify({
+      Text: text,
+      LanguageCode: options.languageCode || this.languageCode,
+    });
+    const headers = this.createSignedHeaders(body);
+    const response = await this.fetch(this.endpoint, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(
+        `AWS Comprehend request failed: ${response.status} ${message}`,
+      );
+    }
+
+    return (await response.json()) as DetectPiiEntitiesResponse;
+  }
+
+  async redactText(
+    text: string,
+    options: RedactTextOptions = {},
+  ): Promise<string> {
+    const response = await this.detectPiiEntities(text, options);
+    const minScore = options.minScore ?? this.minScore;
+    const entityTypes = options.entityTypes || this.entityTypes;
+    const entities = response.Entities.filter((entity) => {
+      const passesScore = entity.Score >= minScore;
+      const passesType =
+        !entityTypes ||
+        entityTypes.includes("ALL") ||
+        entityTypes.includes(entity.Type);
+      return passesScore && passesType;
+    }).sort((a, b) => b.BeginOffset - a.BeginOffset);
+
+    let redacted = text;
+    for (const entity of entities) {
+      const replacement = this.formatReplacement(
+        entity,
+        options.replacement || this.replacement,
+      );
+      redacted =
+        redacted.slice(0, entity.BeginOffset) +
+        replacement +
+        redacted.slice(entity.EndOffset);
+    }
+    return redacted;
+  }
+
+  async chain<T>(
+    prompt: string,
+    next: (redactedPrompt: string) => Promise<T> | T,
+    options: RedactTextOptions = {},
+  ): Promise<T> {
+    const redactedPrompt = await this.redactText(prompt, options);
+    return next(redactedPrompt);
+  }
+
+  redactObservable(
+    source: ObservableLike<string>,
+    options: RedactTextOptions = {},
+  ): ObservableLike<string> {
+    return {
+      subscribe: (observerOrNext) => {
+        const observer = toObserver(observerOrNext);
+        let pending = 0;
+        let completed = false;
+        const maybeComplete = () => {
+          if (completed && pending === 0) {
+            observer.complete?.();
+          }
+        };
+
+        return source.subscribe({
+          next: (value) => {
+            pending += 1;
+            this.redactText(value, options)
+              .then((redacted) => observer.next(redacted))
+              .catch((error) => observer.error?.(error))
+              .finally(() => {
+                pending -= 1;
+                maybeComplete();
+              });
+          },
+          error: (error) => observer.error?.(error),
+          complete: () => {
+            completed = true;
+            maybeComplete();
+          },
+        });
+      },
+    };
+  }
+
+  private createSignedHeaders(body: string): Record<string, string> {
+    const date = this.now();
+    const amzDate = toAmzDate(date);
+    const dateStamp = amzDate.slice(0, 8);
+    const host = new URL(this.endpoint).host;
+    const payloadHash = sha256Hex(body);
+    const headers: Record<string, string> = {
+      "content-type": CONTENT_TYPE,
+      host,
+      "x-amz-date": amzDate,
+      "x-amz-target": TARGET,
+    };
+
+    if (this.sessionToken) {
+      headers["x-amz-security-token"] = this.sessionToken;
+    }
+
+    const signedHeaderNames = Object.keys(headers).sort();
+    const canonicalHeaders = signedHeaderNames
+      .map((name) => `${name}:${headers[name]}`)
+      .join("\n");
+    const signedHeaders = signedHeaderNames.join(";");
+    const canonicalRequest = [
+      "POST",
+      "/",
+      "",
+      `${canonicalHeaders}\n`,
+      signedHeaders,
+      payloadHash,
+    ].join("\n");
+    const credentialScope = `${dateStamp}/${this.region}/${SERVICE}/aws4_request`;
+    const stringToSign = [
+      "AWS4-HMAC-SHA256",
+      amzDate,
+      credentialScope,
+      sha256Hex(canonicalRequest),
+    ].join("\n");
+    const signature = getSignatureKey(
+      this.secretAccessKey,
+      dateStamp,
+      this.region,
+      SERVICE,
+    )
+      .update(stringToSign)
+      .digest("hex");
+
+    return {
+      ...headers,
+      Authorization: `AWS4-HMAC-SHA256 Credential=${this.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    };
+  }
+
+  private formatReplacement(
+    entity: ComprehendPiiEntity,
+    replacement: string,
+  ): string {
+    return replacement.replace("{type}", entity.Type);
+  }
+}
+
+export class ComprehendRedactionMiddleware {
+  redactor: AWSComprehendPIIRedactor;
+
+  constructor(redactor: AWSComprehendPIIRedactor) {
+    this.redactor = redactor;
+  }
+
+  async redactChatOptions<T extends ChatOptionsLike>(
+    options: T,
+    redactOptions: RedactTextOptions = {},
+  ): Promise<T> {
+    const nextOptions = { ...options };
+    if (nextOptions.prompt) {
+      nextOptions.prompt = await this.redactor.redactText(
+        nextOptions.prompt,
+        redactOptions,
+      );
+    }
+    if (nextOptions.messages) {
+      nextOptions.messages = await Promise.all(
+        nextOptions.messages.map(async (message) => ({
+          ...message,
+          content: message.content
+            ? await this.redactor.redactText(message.content, redactOptions)
+            : message.content,
+        })),
+      );
+    }
+    return nextOptions;
+  }
+
+  wrapEndpoint<T extends { chat: (options: ChatOptionsLike) => Promise<any> }>(
+    endpoint: T,
+    redactOptions: RedactTextOptions = {},
+  ): T {
+    return {
+      ...endpoint,
+      chat: async (options: ChatOptionsLike) => {
+        const redactedOptions = await this.redactChatOptions(
+          options,
+          redactOptions,
+        );
+        return endpoint.chat(redactedOptions);
+      },
+    };
+  }
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function hmac(key: string | Buffer, value: string): Buffer {
+  return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function toObserver<T>(
+  observerOrNext: ObserverLike<T> | ((value: T) => void),
+): ObserverLike<T> {
+  if (typeof observerOrNext === "function") {
+    return { next: observerOrNext };
+  }
+  return observerOrNext;
+}
+
+function getSignatureKey(
+  secretAccessKey: string,
+  dateStamp: string,
+  region: string,
+  service: string,
+) {
+  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const regionKey = hmac(dateKey, region);
+  const serviceKey = hmac(regionKey, service);
+  return createHmac("sha256", hmac(serviceKey, "aws4_request"));
+}
+
+function toAmzDate(date: Date): string {
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/aws-comprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/aws-comprehend.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AWSComprehendPIIRedactor,
+  ComprehendRedactionMiddleware,
+} from "../../lib/aws-comprehend/aws-comprehend";
+
+const mockDate = new Date("2026-05-13T08:30:00.000Z");
+
+function createJsonResponse(body: object): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe("AWSComprehendPIIRedactor", () => {
+  it("calls AWS Comprehend DetectPiiEntities with signed REST headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        Entities: [
+          {
+            Score: 0.99,
+            Type: "EMAIL",
+            BeginOffset: 14,
+            EndOffset: 30,
+          },
+        ],
+      }),
+    );
+    const redactor = new AWSComprehendPIIRedactor({
+      region: "us-east-1",
+      accessKeyId: "AKIA_TEST",
+      secretAccessKey: "secret",
+      endpoint: "https://comprehend.us-east-1.amazonaws.com",
+      fetch: fetchMock,
+      now: () => mockDate,
+    });
+
+    const response = await redactor.detectPiiEntities(
+      "Email Rahul at rahul@example.com",
+    );
+
+    expect(response.Entities).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://comprehend.us-east-1.amazonaws.com");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({
+      "content-type": "application/x-amz-json-1.1",
+      "x-amz-date": "20260513T083000Z",
+      "x-amz-target": "Comprehend_20171127.DetectPiiEntities",
+    });
+    expect(String(init.headers.Authorization)).toContain("AWS4-HMAC-SHA256");
+    expect(init.body).toBe(
+      JSON.stringify({
+        Text: "Email Rahul at rahul@example.com",
+        LanguageCode: "en",
+      }),
+    );
+  });
+
+  it("redacts matching PII entities with type-specific placeholders", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        Entities: [
+          {
+            Score: 0.99,
+            Type: "NAME",
+            BeginOffset: 6,
+            EndOffset: 11,
+          },
+          {
+            Score: 0.98,
+            Type: "EMAIL",
+            BeginOffset: 15,
+            EndOffset: 32,
+          },
+        ],
+      }),
+    );
+    const redactor = new AWSComprehendPIIRedactor({
+      accessKeyId: "AKIA_TEST",
+      secretAccessKey: "secret",
+      fetch: fetchMock,
+      now: () => mockDate,
+    });
+
+    await expect(
+      redactor.redactText("Email Rahul at rahul@example.com"),
+    ).resolves.toBe("Email [REDACTED_NAME] at [REDACTED_EMAIL]");
+  });
+
+  it("supports redacting prompt options before calling an endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        Entities: [
+          {
+            Score: 0.99,
+            Type: "PHONE",
+            BeginOffset: 8,
+            EndOffset: 20,
+          },
+        ],
+      }),
+    );
+    const endpoint = {
+      chat: vi.fn().mockResolvedValue({ content: "ok" }),
+    };
+    const redactor = new AWSComprehendPIIRedactor({
+      accessKeyId: "AKIA_TEST",
+      secretAccessKey: "secret",
+      fetch: fetchMock,
+      now: () => mockDate,
+    });
+    const middleware = new ComprehendRedactionMiddleware(redactor);
+    const wrappedEndpoint = middleware.wrapEndpoint(endpoint);
+
+    await wrappedEndpoint.chat({ prompt: "Call me 555-867-5309" });
+
+    expect(endpoint.chat).toHaveBeenCalledWith({
+      prompt: "Call me [REDACTED_PHONE]",
+    });
+  });
+
+  it("supports observable-like prompt redaction", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        Entities: [
+          {
+            Score: 0.99,
+            Type: "EMAIL",
+            BeginOffset: 15,
+            EndOffset: 32,
+          },
+        ],
+      }),
+    );
+    const redactor = new AWSComprehendPIIRedactor({
+      accessKeyId: "AKIA_TEST",
+      secretAccessKey: "secret",
+      fetch: fetchMock,
+      now: () => mockDate,
+    });
+    const source = {
+      subscribe: (observer: {
+        next: (value: string) => void;
+        complete?: () => void;
+      }) => {
+        observer.next("Email Rahul at rahul@example.com");
+        observer.complete?.();
+      },
+    };
+    const values: string[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      redactor.redactObservable(source).subscribe({
+        next: (value) => values.push(value),
+        error: reject,
+        complete: resolve,
+      });
+    });
+
+    expect(values).toEqual(["Email Rahul at [REDACTED_EMAIL]"]);
+  });
+});

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,16 @@
+local inputPrompt = std.extVar("input_prompt");
+
+local redactPrompt(prompt) =
+  std.parseJson(arakoo.native("redactPrompt")({
+    prompt: prompt,
+    languageCode: "en",
+    replacement: "[REDACTED_{type}]",
+  }));
+
+local main() =
+  {
+    originalPrompt: inputPrompt,
+    redactedPrompt: redactPrompt(inputPrompt),
+  };
+
+main()

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "aws-comprehend-pii-redaction",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsc && node ./dist/index.js"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "@arakoodev/jsonnet": "^0.24.0",
+    "file-uri-to-path": "^2.0.0",
+    "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "typescript": "^5.7.0-dev.20241007"
+  }
+}

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/readme.md
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/readme.md
@@ -1,0 +1,36 @@
+# AWS Comprehend PII Redaction Example
+
+This example uses Jsonnet to define a prompt and then calls the JavaScript SDK's AWS Comprehend PII redactor before the prompt is sent to another endpoint. The redactor calls AWS Comprehend directly through its REST API and replaces detected sensitive spans with typed placeholders.
+
+## Setup
+
+Set AWS credentials for an account that can call `comprehend:DetectPiiEntities`.
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+## Run
+
+```bash
+cd ../../arakoodev
+npm install
+npm run build
+cd ../examples/aws-comprehend-pii-redaction
+npm install
+npm run start
+```
+
+You can override the sample prompt:
+
+```bash
+INPUT_PROMPT="Email Rahul at rahul@example.com" npm run start
+```
+
+For a local demo without AWS credentials, run the mocked flow:
+
+```bash
+MOCK_AWS_COMPREHEND=true npm run start
+```

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/src/edgechains.d.ts
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/src/edgechains.d.ts
@@ -1,0 +1,3 @@
+declare module "@arakoodev/edgechains.js/sync-rpc" {
+  export function createSyncRPC(filename: string): (args: unknown) => string;
+}

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/src/index.ts
@@ -1,0 +1,38 @@
+import Jsonnet from "@arakoodev/jsonnet";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const redactPrompt = createSyncRPC(
+  path.join(__dirname, "./lib/redactPrompt.cjs"),
+);
+
+async function main(): Promise<void> {
+  const inputPrompt =
+    process.env.INPUT_PROMPT ||
+    "Please email Rahul at rahul@example.com about account 1234.";
+  const mockMode = process.env.MOCK_AWS_COMPREHEND === "true";
+
+  jsonnet.extString("input_prompt", inputPrompt);
+  jsonnet.javascriptCallback("redactPrompt", (request: any) => {
+    return redactPrompt({
+      ...request,
+      awsRegion: process.env.AWS_REGION || "us-east-1",
+      awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      mockMode,
+    });
+  });
+
+  const response = jsonnet.evaluateFile(
+    path.join(__dirname, "../jsonnet/main.jsonnet"),
+  );
+  console.log(response);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/src/lib/redactPrompt.cts
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/src/lib/redactPrompt.cts
@@ -1,0 +1,64 @@
+const { AWSComprehendPIIRedactor } = require("@arakoodev/edgechains.js/ai");
+
+type RedactPromptRequest = {
+  prompt: string;
+  languageCode?: string;
+  replacement?: string;
+  awsRegion?: string;
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
+  mockMode?: boolean;
+};
+
+async function redactPrompt({
+  prompt,
+  languageCode,
+  replacement,
+  awsRegion,
+  awsAccessKeyId,
+  awsSecretAccessKey,
+  mockMode,
+}: RedactPromptRequest): Promise<string> {
+  const redactor = new AWSComprehendPIIRedactor({
+    region: awsRegion,
+    accessKeyId: mockMode ? "mock-access-key" : awsAccessKeyId,
+    secretAccessKey: mockMode ? "mock-secret-key" : awsSecretAccessKey,
+    languageCode,
+    replacement,
+    fetch: mockMode ? createMockComprehendFetch(prompt) : undefined,
+  });
+  return redactor.redactText(prompt);
+}
+
+function createMockComprehendFetch(prompt: string) {
+  return async () => {
+    const entities = [
+      createEntity(prompt, "Rahul", "NAME"),
+      createEntity(prompt, "rahul@example.com", "EMAIL"),
+      createEntity(prompt, "1234", "BANK_ACCOUNT_NUMBER"),
+    ].filter(Boolean);
+
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ Entities: entities }),
+      text: async () => JSON.stringify({ Entities: entities }),
+    } as Response;
+  };
+}
+
+function createEntity(prompt: string, value: string, type: string) {
+  const start = prompt.indexOf(value);
+  if (start === -1) {
+    return null;
+  }
+
+  return {
+    Score: 0.99,
+    Type: type,
+    BeginOffset: start,
+    EndOffset: start + value.length,
+  };
+}
+
+module.exports = redactPrompt;

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
/claim #290

## Summary

- Added `AWSComprehendPIIRedactor` to the JavaScript AI package with direct AWS Comprehend `DetectPiiEntities` REST calls and SigV4 signing.
- Added direct prompt redaction, endpoint wrapping, and observable-like redaction support for prompt pipelines.
- Exported the new redactor and types from the AI package.
- Added a Jsonnet-based runnable example with a mocked AWS Comprehend mode for local verification.

## Validation

- `npm test -- --run src/ai/src/tests/aws-comprehend/aws-comprehend.test.ts`
- `npm run build`
- `MOCK_AWS_COMPREHEND=true npm run start`

Mock example output:

```json
{
  "originalPrompt": "Please email Rahul at rahul@example.com about account 1234.",
  "redactedPrompt": "Please email [REDACTED_NAME] at [REDACTED_EMAIL] about account [REDACTED_BANK_ACCOUNT_NUMBER]."
}
```
