### PR TITLE
Add QdrantClient to vector-db module

### DIFF
--- a/JS/edgechains/arakoodev/.gitignore
+++ b/JS/edgechains/arakoodev/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 dist
+*.tsbuildinfo

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { QdrantClient } from "./lib/qdrant/QdrantClient.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/QdrantClient.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/QdrantClient.ts
@@ -1,0 +1,131 @@
+import axios, { AxiosInstance } from "axios";
+import { config } from "dotenv";
+
+config();
+
+export type QdrantDistance = "Cosine" | "Euclid" | "Dot" | "Manhattan";
+
+export type QdrantPointId = number | string;
+
+export type QdrantFilter = Record<string, unknown>;
+
+export interface QdrantPoint<Payload = Record<string, unknown>> {
+    id: QdrantPointId;
+    vector: number[] | Record<string, number[]>;
+    payload?: Payload;
+}
+
+export interface QdrantSearchResult<Payload = Record<string, unknown>> {
+    id: QdrantPointId;
+    version?: number;
+    score: number;
+    payload?: Payload;
+    vector?: number[] | Record<string, number[]>;
+}
+
+export interface QdrantClientOptions {
+    url?: string;
+    apiKey?: string;
+    timeoutMs?: number;
+}
+
+export interface CreateCollectionArgs {
+    collectionName: string;
+    vectorSize: number;
+    distance: QdrantDistance;
+    onDiskPayload?: boolean;
+}
+
+export interface UpsertPointsArgs<Payload = Record<string, unknown>> {
+    collectionName: string;
+    points: Array<QdrantPoint<Payload>>;
+    wait?: boolean;
+}
+
+export interface SearchPointsArgs {
+    collectionName: string;
+    vector: number[] | Record<string, number[]>;
+    limit: number;
+    filter?: QdrantFilter;
+    withPayload?: boolean | string[] | Record<string, unknown>;
+    withVector?: boolean;
+    scoreThreshold?: number;
+}
+
+export class QdrantClient {
+    private client: AxiosInstance;
+
+    constructor(options: QdrantClientOptions = {}) {
+        const url = options.url || process.env.QDRANT_URL;
+        if (!url) {
+            throw new Error(
+                "QdrantClient requires `url` option or env var `QDRANT_URL` (e.g. http://localhost:6333)"
+            );
+        }
+
+        const apiKey = options.apiKey || process.env.QDRANT_API_KEY;
+
+        this.client = axios.create({
+            baseURL: url.replace(/\/+$/, ""),
+            timeout: options.timeoutMs ?? 30_000,
+            headers: apiKey ? { "api-key": apiKey } : undefined,
+        });
+    }
+
+    async healthz() {
+        const res = await this.client.get("/healthz");
+        return res.data;
+    }
+
+    async createCollection({
+        collectionName,
+        vectorSize,
+        distance,
+        onDiskPayload,
+    }: CreateCollectionArgs) {
+        const res = await this.client.put(`/collections/${encodeURIComponent(collectionName)}`, {
+            vectors: {
+                size: vectorSize,
+                distance,
+            },
+            ...(onDiskPayload === undefined ? {} : { on_disk_payload: onDiskPayload }),
+        });
+        return res.data;
+    }
+
+    async upsertPoints<Payload = Record<string, unknown>>({
+        collectionName,
+        points,
+        wait,
+    }: UpsertPointsArgs<Payload>) {
+        const res = await this.client.put(
+            `/collections/${encodeURIComponent(collectionName)}/points`,
+            { points },
+            { params: wait === undefined ? undefined : { wait } }
+        );
+        return res.data;
+    }
+
+    async searchPoints<Payload = Record<string, unknown>>({
+        collectionName,
+        vector,
+        limit,
+        filter,
+        withPayload,
+        withVector,
+        scoreThreshold,
+    }: SearchPointsArgs): Promise<QdrantSearchResult<Payload>[]> {
+        const res = await this.client.post(
+            `/collections/${encodeURIComponent(collectionName)}/points/search`,
+            {
+                vector,
+                limit,
+                ...(filter ? { filter } : {}),
+                ...(withPayload === undefined ? {} : { with_payload: withPayload }),
+                ...(withVector === undefined ? {} : { with_vector: withVector }),
+                ...(scoreThreshold === undefined ? {} : { score_threshold: scoreThreshold }),
+            }
+        );
+        return res.data?.result ?? [];
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrantClient.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrantClient.test.ts
@@ -1,0 +1,70 @@
+import { QdrantClient } from "../../../../../dist/vector-db/src/lib/qdrant/QdrantClient.js";
+
+const mockGet = jest.fn();
+const mockPut = jest.fn();
+const mockPost = jest.fn();
+const mockAxiosCreate: jest.Mock = jest.fn(() => ({
+    get: mockGet,
+    put: mockPut,
+    post: mockPost,
+}));
+
+jest.mock("axios", () => ({
+    __esModule: true,
+    default: {
+        create: (config: any) => mockAxiosCreate(config),
+    },
+}));
+
+describe("QdrantClient", () => {
+    beforeEach(() => {
+        mockGet.mockReset();
+        mockPut.mockReset();
+        mockPost.mockReset();
+        mockAxiosCreate.mockClear();
+    });
+
+    test("constructor should set baseURL and api-key header when provided", () => {
+        new QdrantClient({
+            url: "http://localhost:6333/",
+            apiKey: "secret",
+            timeoutMs: 1234,
+        });
+
+        expect(mockAxiosCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                baseURL: "http://localhost:6333",
+                timeout: 1234,
+                headers: { "api-key": "secret" },
+            })
+        );
+    });
+
+    test("searchPoints should call Qdrant search endpoint and return result list", async () => {
+        mockPost.mockResolvedValueOnce({
+            data: {
+                result: [{ id: 1, score: 0.99, payload: { foo: "bar" } }],
+            },
+        });
+
+        const client = new QdrantClient({ url: "http://localhost:6333" });
+        const res = await client.searchPoints({
+            collectionName: "my_collection",
+            vector: [0.1, 0.2],
+            limit: 3,
+            withPayload: true,
+            withVector: false,
+        });
+
+        expect(mockPost).toHaveBeenCalledWith(
+            "/collections/my_collection/points/search",
+            expect.objectContaining({
+                vector: [0.1, 0.2],
+                limit: 3,
+                with_payload: true,
+                with_vector: false,
+            })
+        );
+        expect(res).toEqual([{ id: 1, score: 0.99, payload: { foo: "bar" } }]);
+    });
+});


### PR DESCRIPTION
Closes #273.

What's included
- Adds `QdrantClient` in `vector-db` as a lightweight REST wrapper (no qdrant npm deps).
- Exposes it via `@arakoodev/edgechains.js/vector-db`.
- Adds unit tests for constructor config + search request/response shaping.

Verification
- `npm run build` (in `JS/edgechains/arakoodev`)
- `npx jest src/vector-db/src/tests --runInBand` (in `JS/edgechains/arakoodev`)
