### PR TITLE
feat: add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,10 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+  CreateCollectionArgs,
+  InsertVectorDataArgs,
+  QdrantDistanceMetric,
+  QdrantPoint,
+  QdrantPointPayload,
+  SearchVectorDataArgs,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,155 @@
+import { config } from "dotenv";
+config();
+
+export type QdrantDistanceMetric = "Cosine" | "Euclid" | "Dot";
+
+export interface QdrantPointPayload {
+  [key: string]: any;
+}
+
+export interface QdrantPoint {
+  id: string | number;
+  vector: number[];
+  payload?: QdrantPointPayload;
+}
+
+export interface CreateCollectionArgs {
+  collectionName: string;
+  vectorSize: number;
+  distance?: QdrantDistanceMetric;
+}
+
+export interface InsertVectorDataArgs {
+  collectionName: string;
+  points: QdrantPoint[];
+  wait?: boolean;
+}
+
+export interface SearchVectorDataArgs {
+  collectionName: string;
+  vector: number[];
+  limit?: number;
+  filter?: Record<string, any>;
+  withPayload?: boolean;
+  scoreThreshold?: number;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+
+  constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+    this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(
+      /\/$/,
+      "",
+    );
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+  }
+
+  private getHeaders() {
+    return {
+      "Content-Type": "application/json",
+      ...(this.QDRANT_API_KEY ? { "api-key": this.QDRANT_API_KEY } : {}),
+    };
+  }
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required");
+    }
+
+    const response = await fetch(`${this.QDRANT_URL}${path}`, {
+      ...init,
+      headers: {
+        ...this.getHeaders(),
+        ...(init.headers ?? {}),
+      },
+    });
+    const body = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      throw new Error(
+        `Qdrant request failed with ${response.status}: ${JSON.stringify(body)}`,
+      );
+    }
+
+    return body as T;
+  }
+
+  async createCollection({
+    collectionName,
+    vectorSize,
+    distance = "Cosine",
+  }: CreateCollectionArgs): Promise<any> {
+    return this.request(`/collections/${collectionName}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        vectors: {
+          size: vectorSize,
+          distance,
+        },
+      }),
+    });
+  }
+
+  async insertVectorData({
+    collectionName,
+    points,
+    wait = true,
+  }: InsertVectorDataArgs): Promise<any> {
+    return this.request(`/collections/${collectionName}/points?wait=${wait}`, {
+      method: "PUT",
+      body: JSON.stringify({ points }),
+    });
+  }
+
+  async searchVectorData({
+    collectionName,
+    vector,
+    limit = 10,
+    filter,
+    withPayload = true,
+    scoreThreshold,
+  }: SearchVectorDataArgs): Promise<any> {
+    return this.request(`/collections/${collectionName}/points/search`, {
+      method: "POST",
+      body: JSON.stringify({
+        vector,
+        limit,
+        filter,
+        with_payload: withPayload,
+        score_threshold: scoreThreshold,
+      }),
+    });
+  }
+
+  async getDataById({
+    collectionName,
+    id,
+  }: {
+    collectionName: string;
+    id: string | number;
+  }): Promise<any> {
+    return this.request(`/collections/${collectionName}/points/${id}`);
+  }
+
+  async deleteById({
+    collectionName,
+    id,
+    wait = true,
+  }: {
+    collectionName: string;
+    id: string | number;
+    wait?: boolean;
+  }): Promise<any> {
+    return this.request(
+      `/collections/${collectionName}/points/delete?wait=${wait}`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          points: [id],
+        }),
+      },
+    );
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,100 @@
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+describe("Qdrant", () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ result: "ok" }),
+    });
+    global.fetch = fetchMock as any;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("creates a collection using the Qdrant REST API", async () => {
+    const qdrant = new Qdrant("https://qdrant.example.com", "api-key");
+
+    await qdrant.createCollection({
+      collectionName: "documents",
+      vectorSize: 1536,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/documents",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({ "api-key": "api-key" }),
+        body: JSON.stringify({
+          vectors: {
+            size: 1536,
+            distance: "Cosine",
+          },
+        }),
+      }),
+    );
+  });
+
+  test("inserts points without using the qdrant package", async () => {
+    const qdrant = new Qdrant("https://qdrant.example.com");
+
+    await qdrant.insertVectorData({
+      collectionName: "documents",
+      points: [
+        {
+          id: 1,
+          vector: [0.1, 0.2],
+          payload: { raw_text: "hello" },
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/documents/points?wait=true",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          points: [
+            {
+              id: 1,
+              vector: [0.1, 0.2],
+              payload: { raw_text: "hello" },
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  test("searches points using vector and filter payload", async () => {
+    const qdrant = new Qdrant("https://qdrant.example.com");
+
+    await qdrant.searchVectorData({
+      collectionName: "documents",
+      vector: [0.1, 0.2],
+      limit: 3,
+      filter: {
+        must: [{ key: "namespace", match: { value: "docs" } }],
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/documents/points/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          vector: [0.1, 0.2],
+          limit: 3,
+          filter: {
+            must: [{ key: "namespace", match: { value: "docs" } }],
+          },
+          with_payload: true,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a Qdrant vector database client that calls the REST API directly without the qdrant package
- support collection creation, point upsert, vector search, point lookup, and point deletion
- export Qdrant and its public types from the vector-db package
- add Jest coverage for create, insert, and search request construction

Closes #273

## Test plan
- npx.cmd tsc -b
- npx.cmd jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand

Note: npm.cmd run build is Unix-shell dependent on Windows because it starts with m -rf dist; direct 	sc -b passes.
