### PR TITLE
feat: add Palm2 AI client

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,7 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
+export type { Palm2GenerateTextResponse, Palm2EmbedTextResponse } from "./lib/palm2/palm2.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,112 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+
+const palm2BaseUrl = "https://generativelanguage.googleapis.com/v1beta2/models";
+
+interface Palm2AIConstructionOptions {
+    apiKey?: string;
+}
+
+interface Palm2AIChatOptions {
+    model?: string;
+    prompt: string;
+    temperature?: number;
+    max_output_tokens?: number;
+    max_retry?: number;
+    delay?: number;
+}
+
+interface Palm2AIEmbeddingOptions {
+    model?: string;
+    text: string;
+    max_retry?: number;
+    delay?: number;
+}
+
+type SafetyRating = {
+    category: string;
+    probability: string;
+};
+
+type TextCompletion = {
+    output: string;
+    safetyRatings?: SafetyRating[];
+};
+
+export type Palm2GenerateTextResponse = {
+    candidates: TextCompletion[];
+    filters?: Array<{
+        reason: string;
+        message?: string;
+    }>;
+};
+
+export type Palm2EmbedTextResponse = {
+    embedding: {
+        value: number[];
+    };
+};
+
+export class Palm2AI {
+    apiKey: string;
+
+    constructor(options: Palm2AIConstructionOptions = {}) {
+        this.apiKey = options.apiKey || process.env.PALM2_API_KEY || process.env.GOOGLE_API_KEY || "";
+    }
+
+    async chat(chatOptions: Palm2AIChatOptions): Promise<Palm2GenerateTextResponse> {
+        const model = chatOptions.model || "text-bison-001";
+        const config = {
+            method: "post",
+            maxBodyLength: Infinity,
+            url: `${palm2BaseUrl}/${model}:generateText`,
+            params: {
+                key: this.apiKey,
+            },
+            headers: {
+                "Content-Type": "application/json",
+            },
+            data: {
+                prompt: {
+                    text: chatOptions.prompt,
+                },
+                temperature: chatOptions.temperature || 0.7,
+                maxOutputTokens: chatOptions.max_output_tokens || 1024,
+            },
+        };
+
+        return await retry(
+            async () => {
+                return (await axios.request(config)).data;
+            },
+            { maxAttempts: chatOptions.max_retry || 3, delay: chatOptions.delay || 200 }
+        );
+    }
+
+    async generateEmbeddings(
+        embeddingOptions: Palm2AIEmbeddingOptions
+    ): Promise<Palm2EmbedTextResponse> {
+        const model = embeddingOptions.model || "embedding-gecko-001";
+        const config = {
+            method: "post",
+            maxBodyLength: Infinity,
+            url: `${palm2BaseUrl}/${model}:embedText`,
+            params: {
+                key: this.apiKey,
+            },
+            headers: {
+                "Content-Type": "application/json",
+            },
+            data: {
+                text: embeddingOptions.text,
+            },
+        };
+
+        return await retry(
+            async () => {
+                return (await axios.request(config)).data;
+            },
+            { maxAttempts: embeddingOptions.max_retry || 3, delay: embeddingOptions.delay || 200 }
+        );
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
@@ -1,0 +1,59 @@
+import axios from "axios";
+import { Palm2AI } from "../../lib/palm2/palm2";
+
+jest.mock("axios");
+
+describe("Palm2AI", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("should generate text with PaLM2", async () => {
+        const mockResponse = {
+            candidates: [
+                {
+                    output: "Test response",
+                },
+            ],
+        };
+        axios.request = jest.fn().mockResolvedValue({ data: mockResponse });
+
+        const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+        const response = await palm2.chat({ prompt: "test prompt" });
+
+        expect(response).toEqual(mockResponse);
+        expect(axios.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "post",
+                url: "https://generativelanguage.googleapis.com/v1beta2/models/text-bison-001:generateText",
+                params: { key: "test_api_key" },
+                data: expect.objectContaining({
+                    prompt: { text: "test prompt" },
+                    maxOutputTokens: 1024,
+                }),
+            })
+        );
+    });
+
+    test("should generate embeddings with PaLM2", async () => {
+        const mockResponse = {
+            embedding: {
+                value: [0.1, 0.2, 0.3],
+            },
+        };
+        axios.request = jest.fn().mockResolvedValue({ data: mockResponse });
+
+        const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+        const response = await palm2.generateEmbeddings({ text: "test text" });
+
+        expect(response).toEqual(mockResponse);
+        expect(axios.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "post",
+                url: "https://generativelanguage.googleapis.com/v1beta2/models/embedding-gecko-001:embedText",
+                params: { key: "test_api_key" },
+                data: { text: "test text" },
+            })
+        );
+    });
+});

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,14 @@
+local promptTemplate = |||
+  You are a helpful assistant that answers clearly and concisely.
+  Answer the following question: {question}
+|||;
+
+local key = std.extVar('palm2_api_key');
+local question = std.extVar('question');
+
+local prompt = std.strReplace(promptTemplate, '{question}', question + '\n');
+
+local main() =
+  arakoo.native('palm2Call')({ prompt: prompt, palm2ApiKey: key });
+
+main()

--- a/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
@@ -1,0 +1,5 @@
+local PALM2_API_KEY = "your google generative language api key here";
+
+{
+    "palm2_api_key": PALM2_API_KEY,
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "palm2-chat",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "build": "tsc",
+        "dev": "ts-node src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "latest",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/palm2-chat/readme.md
+++ b/JS/edgechains/examples/palm2-chat/readme.md
@@ -1,0 +1,26 @@
+# PaLM2 Chat Example
+
+This example shows how to call the PaLM2 client through an EdgeChains JSONNet workflow.
+
+## Setup
+
+1. Add your Google Generative Language API key in `jsonnet/secrets.jsonnet`.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Start the example:
+
+```bash
+npm run dev
+```
+
+4. Send a request:
+
+```bash
+curl -X POST http://localhost:3000/palm2-chat \
+  -H "Content-Type: application/json" \
+  -d "{\"question\":\"Explain edge computing in one sentence.\"}"
+```

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,31 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import Jsonnet from "@arakoodev/jsonnet";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const palm2Call = createSyncRPC(path.join(__dirname, "./lib/generateResponse.cjs"));
+
+app.post("/palm2-chat", async (c: any) => {
+    try {
+        const { question } = await c.req.json();
+        const key = JSON.parse(
+            jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet"))
+        ).palm2_api_key;
+        jsonnet.extString("palm2_api_key", key);
+        jsonnet.extString("question", question || "");
+        jsonnet.javascriptCallback("palm2Call", palm2Call);
+        const response = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+        return c.json(JSON.parse(response));
+    } catch (error) {
+        console.log("error occured", error);
+        return c.json({ error: "Failed to generate PaLM2 response" }, 500);
+    }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
+++ b/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
@@ -1,0 +1,15 @@
+const { Palm2AI } = require("@arakoodev/edgechains.js/ai");
+
+async function palm2Call({ prompt, palm2ApiKey }: any) {
+    try {
+        const palm2 = new Palm2AI({ apiKey: palm2ApiKey });
+        const response = await palm2.chat({ prompt });
+        return JSON.stringify({
+            answer: response.candidates?.[0]?.output || "",
+        });
+    } catch (error) {
+        return JSON.stringify({ error });
+    }
+}
+
+module.exports = palm2Call;

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "strict": false,
+        "outDir": "dist"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["jsonnet"]
+}


### PR DESCRIPTION
Fixes #279

Summary:
- Adds a PaLM2 REST client with typed text generation and embedding responses.
- Exports Palm2AI from the AI package entrypoint.
- Adds unit tests under src/ai/src/tests/palm2.
- Adds a palm2-chat example that keeps the prompt in Jsonnet instead of hardcoding it in TypeScript.

Verification:
- npx.cmd tsc -b
- npx.cmd jest --runTestsByPath src\ai\src\tests\palm2\palm2.test.ts --runInBand

Note:
- The standalone example package still needs its local dependencies installed before its own tsconfig can be typechecked directly.