### PR TITLE
Add PaLM2 API support

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,28 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
+export type {
+  Palm2ConstructionOptions,
+  Palm2CountMessageTokensOptions,
+  Palm2CountMessageTokensResponse,
+  Palm2EmbedTextOptions,
+  Palm2EmbedTextResponse,
+  Palm2GenerateMessageOptions,
+  Palm2GenerateMessageResponse,
+  Palm2GenerateTextOptions,
+  Palm2GenerateTextResponse,
+  Palm2ListModelsResponse,
+  Palm2Message,
+  Palm2MessagePrompt,
+  Palm2Model,
+  Palm2SafetyCategory,
+  Palm2SafetyProbability,
+  Palm2SafetyRating,
+  Palm2SafetySetting,
+  Palm2SafetyThreshold,
+  Palm2TextCompletion,
+  Palm2TextPrompt,
+} from "./lib/palm2/palm2.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,301 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+
+const DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta2";
+
+export type Palm2SafetyCategory =
+  | "HARM_CATEGORY_UNSPECIFIED"
+  | "HARM_CATEGORY_DEROGATORY"
+  | "HARM_CATEGORY_TOXICITY"
+  | "HARM_CATEGORY_VIOLENCE"
+  | "HARM_CATEGORY_SEXUAL"
+  | "HARM_CATEGORY_MEDICAL"
+  | "HARM_CATEGORY_DANGEROUS";
+
+export type Palm2SafetyThreshold =
+  | "HARM_BLOCK_THRESHOLD_UNSPECIFIED"
+  | "BLOCK_LOW_AND_ABOVE"
+  | "BLOCK_MEDIUM_AND_ABOVE"
+  | "BLOCK_ONLY_HIGH"
+  | "BLOCK_NONE";
+
+export type Palm2SafetyProbability =
+  | "HARM_PROBABILITY_UNSPECIFIED"
+  | "NEGLIGIBLE"
+  | "LOW"
+  | "MEDIUM"
+  | "HIGH";
+
+export interface Palm2ConstructionOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface Palm2SafetySetting {
+  category: Palm2SafetyCategory;
+  threshold: Palm2SafetyThreshold;
+}
+
+export interface Palm2SafetyRating {
+  category: Palm2SafetyCategory;
+  probability: Palm2SafetyProbability;
+}
+
+export interface Palm2TextPrompt {
+  text: string;
+}
+
+export interface Palm2GenerateTextOptions {
+  prompt: string | Palm2TextPrompt;
+  model?: string;
+  temperature?: number;
+  candidateCount?: number;
+  maxOutputTokens?: number;
+  topP?: number;
+  topK?: number;
+  stopSequences?: string[];
+  safetySettings?: Palm2SafetySetting[];
+  maxRetry?: number;
+  delay?: number;
+}
+
+export interface Palm2TextCompletion {
+  output: string;
+  safetyRatings?: Palm2SafetyRating[];
+  citationMetadata?: Record<string, unknown>;
+}
+
+export interface Palm2GenerateTextResponse {
+  candidates: Palm2TextCompletion[];
+  filters?: unknown[];
+  safetyFeedback?: unknown[];
+}
+
+export interface Palm2Message {
+  content: string;
+  author?: string;
+  citationMetadata?: Record<string, unknown>;
+}
+
+export interface Palm2MessagePrompt {
+  context?: string;
+  examples?: Array<{
+    input: Palm2Message;
+    output: Palm2Message;
+  }>;
+  messages: Palm2Message[];
+}
+
+export interface Palm2GenerateMessageOptions {
+  prompt: string | Palm2MessagePrompt | Palm2Message[];
+  model?: string;
+  temperature?: number;
+  candidateCount?: number;
+  topP?: number;
+  topK?: number;
+  maxRetry?: number;
+  delay?: number;
+}
+
+export interface Palm2GenerateMessageResponse {
+  candidates: Palm2Message[];
+  messages?: Palm2Message[];
+  filters?: unknown[];
+}
+
+export interface Palm2EmbedTextOptions {
+  text: string;
+  model?: string;
+  maxRetry?: number;
+  delay?: number;
+}
+
+export interface Palm2EmbedTextResponse {
+  embedding: {
+    value: number[];
+  };
+}
+
+export interface Palm2CountMessageTokensOptions {
+  prompt: string | Palm2MessagePrompt | Palm2Message[];
+  model?: string;
+  maxRetry?: number;
+  delay?: number;
+}
+
+export interface Palm2CountMessageTokensResponse {
+  tokenCount: number;
+}
+
+export interface Palm2Model {
+  name: string;
+  version?: string;
+  displayName?: string;
+  description?: string;
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
+  supportedGenerationMethods?: string[];
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+}
+
+export interface Palm2ListModelsResponse {
+  models: Palm2Model[];
+}
+
+type RetryOptions = {
+  maxRetry?: number;
+  delay?: number;
+};
+
+export class Palm2AI {
+  apiKey: string;
+  baseUrl: string;
+
+  constructor(options: Palm2ConstructionOptions = {}) {
+    this.apiKey =
+      options.apiKey ||
+      process.env.PALM_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      "";
+    this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
+  }
+
+  async generateText(
+    options: Palm2GenerateTextOptions,
+  ): Promise<Palm2GenerateTextResponse> {
+    const {
+      model = "text-bison-001",
+      maxRetry,
+      delay,
+      ...bodyOptions
+    } = options;
+    const prompt =
+      typeof bodyOptions.prompt === "string"
+        ? { text: bodyOptions.prompt }
+        : bodyOptions.prompt;
+
+    return this.request<Palm2GenerateTextResponse>(
+      model,
+      "generateText",
+      {
+        ...bodyOptions,
+        prompt,
+      },
+      { maxRetry, delay },
+    );
+  }
+
+  async chat(
+    options: Palm2GenerateMessageOptions,
+  ): Promise<Palm2GenerateMessageResponse> {
+    return this.generateMessage(options);
+  }
+
+  async generateMessage(
+    options: Palm2GenerateMessageOptions,
+  ): Promise<Palm2GenerateMessageResponse> {
+    const {
+      model = "chat-bison-001",
+      maxRetry,
+      delay,
+      ...bodyOptions
+    } = options;
+
+    return this.request<Palm2GenerateMessageResponse>(
+      model,
+      "generateMessage",
+      {
+        ...bodyOptions,
+        prompt: this.normalizeMessagePrompt(bodyOptions.prompt),
+      },
+      { maxRetry, delay },
+    );
+  }
+
+  async embedText(
+    options: Palm2EmbedTextOptions,
+  ): Promise<Palm2EmbedTextResponse> {
+    const { model = "embedding-gecko-001", maxRetry, delay, ...body } = options;
+
+    return this.request<Palm2EmbedTextResponse>(model, "embedText", body, {
+      maxRetry,
+      delay,
+    });
+  }
+
+  async countMessageTokens(
+    options: Palm2CountMessageTokensOptions,
+  ): Promise<Palm2CountMessageTokensResponse> {
+    const { model = "chat-bison-001", maxRetry, delay, prompt } = options;
+
+    return this.request<Palm2CountMessageTokensResponse>(
+      model,
+      "countMessageTokens",
+      { prompt: this.normalizeMessagePrompt(prompt) },
+      { maxRetry, delay },
+    );
+  }
+
+  async getModel(model = "text-bison-001"): Promise<Palm2Model> {
+    return (await axios.get(this.modelUrl(model), this.authConfig())).data;
+  }
+
+  async listModels(): Promise<Palm2ListModelsResponse> {
+    return (await axios.get(`${this.baseUrl}/models`, this.authConfig())).data;
+  }
+
+  private normalizeMessagePrompt(
+    prompt: string | Palm2MessagePrompt | Palm2Message[],
+  ): Palm2MessagePrompt {
+    if (typeof prompt === "string") {
+      return { messages: [{ content: prompt }] };
+    }
+
+    if (Array.isArray(prompt)) {
+      return { messages: prompt };
+    }
+
+    return prompt;
+  }
+
+  private async request<T>(
+    model: string,
+    method: string,
+    data: Record<string, unknown>,
+    retryOptions: RetryOptions,
+  ): Promise<T> {
+    return retry(
+      async () => {
+        return (
+          await axios.post<T>(this.methodUrl(model, method), data, {
+            headers: { "Content-Type": "application/json" },
+          })
+        ).data;
+      },
+      {
+        maxAttempts: retryOptions.maxRetry || 3,
+        delay: retryOptions.delay || 200,
+      },
+    );
+  }
+
+  private modelUrl(model: string): string {
+    return `${this.baseUrl}/models/${this.cleanModelName(model)}?key=${this.apiKey}`;
+  }
+
+  private methodUrl(model: string, method: string): string {
+    return `${this.baseUrl}/models/${this.cleanModelName(model)}:${method}?key=${this.apiKey}`;
+  }
+
+  private cleanModelName(model: string): string {
+    return model.startsWith("models/") ? model.slice("models/".length) : model;
+  }
+
+  private authConfig() {
+    return {
+      headers: { "Content-Type": "application/json" },
+    };
+  }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
@@ -1,0 +1,90 @@
+import axios from "axios";
+import { Palm2AI } from "../../lib/palm2/palm2";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Palm2AI", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("generateText calls the text-bison endpoint with a text prompt", async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { candidates: [{ output: "Test response" }] },
+    });
+
+    const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+    const response = await palm2.generateText({
+      prompt: "Write a status update",
+      temperature: 0.4,
+      maxOutputTokens: 128,
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta2/models/text-bison-001:generateText?key=test_api_key",
+      {
+        prompt: { text: "Write a status update" },
+        temperature: 0.4,
+        maxOutputTokens: 128,
+      },
+      { headers: { "Content-Type": "application/json" } },
+    );
+    expect(response.candidates[0].output).toBe("Test response");
+  });
+
+  test("generateMessage calls the chat-bison endpoint with normalized messages", async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { candidates: [{ author: "1", content: "Hello" }] },
+    });
+
+    const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+    const response = await palm2.generateMessage({
+      prompt: "hello",
+      candidateCount: 1,
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta2/models/chat-bison-001:generateMessage?key=test_api_key",
+      {
+        prompt: { messages: [{ content: "hello" }] },
+        candidateCount: 1,
+      },
+      { headers: { "Content-Type": "application/json" } },
+    );
+    expect(response.candidates[0].content).toBe("Hello");
+  });
+
+  test("embedText calls the embedding endpoint", async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { embedding: { value: [0.1, 0.2, 0.3] } },
+    });
+
+    const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+    const response = await palm2.embedText({ text: "embed this" });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta2/models/embedding-gecko-001:embedText?key=test_api_key",
+      { text: "embed this" },
+      { headers: { "Content-Type": "application/json" } },
+    );
+    expect(response.embedding.value).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  test("countMessageTokens calls the token endpoint", async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { tokenCount: 7 } });
+
+    const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+    const response = await palm2.countMessageTokens({
+      prompt: [{ content: "How many tokens?" }],
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta2/models/chat-bison-001:countMessageTokens?key=test_api_key",
+      { prompt: { messages: [{ content: "How many tokens?" }] } },
+      { headers: { "Content-Type": "application/json" } },
+    );
+    expect(response.tokenCount).toBe(7);
+  });
+});

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,19 @@
+local promptTemplate = |||
+  You are a concise assistant.
+  Answer the question in two short sentences.
+
+  Question: {question}
+|||;
+
+local palmApiKey = std.extVar('palm_api_key');
+local question = std.extVar('question');
+local prompt = std.strReplace(promptTemplate, '{question}', question);
+
+local main() =
+  local response = arakoo.native('palm2Call')({
+    prompt: prompt,
+    palmApiKey: palmApiKey,
+  });
+  response;
+
+main()

--- a/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
@@ -1,0 +1,5 @@
+local PALM_API_KEY = "your-palm-api-key";
+
+{
+    "palm_api_key": PALM_API_KEY,
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "palm2-chat",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsc && node --experimental-wasm-modules ./dist/index.js"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "@arakoodev/jsonnet": "^0.24.0",
+    "file-uri-to-path": "^2.0.0",
+    "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "typescript": "^5.7.0-dev.20241007"
+  }
+}

--- a/JS/edgechains/examples/palm2-chat/readme.md
+++ b/JS/edgechains/examples/palm2-chat/readme.md
@@ -1,0 +1,18 @@
+# PaLM2 Chat Example
+
+This example calls the PaLM2 text generation API through `@arakoodev/edgechains.js/ai`.
+
+The prompt template lives in `jsonnet/main.jsonnet` so the example can change prompts without recompiling TypeScript.
+
+```bash
+npm install
+npm run start
+```
+
+POST a question to the local server:
+
+```bash
+curl -X POST http://localhost:3000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"question":"What is EdgeChains?"}'
+```

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,35 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const palm2Call = createSyncRPC(
+  path.join(__dirname, "./lib/generateResponse.cjs"),
+);
+
+app.post("/chat", async (c: any) => {
+  try {
+    const { question } = await c.req.json();
+    const key = JSON.parse(
+      jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet")),
+    ).palm_api_key;
+
+    jsonnet.extString("palm_api_key", key);
+    jsonnet.extString("question", question || "");
+    jsonnet.javascriptCallback("palm2Call", palm2Call);
+
+    const response = jsonnet.evaluateFile(
+      path.join(__dirname, "../jsonnet/main.jsonnet"),
+    );
+    return c.json(JSON.parse(response));
+  } catch (error) {
+    console.log("error occured", error);
+  }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
+++ b/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
@@ -1,0 +1,19 @@
+const { Palm2AI } = require("@arakoodev/edgechains.js/ai");
+
+async function palm2Call({
+  prompt,
+  palmApiKey,
+}: {
+  prompt: string;
+  palmApiKey: string;
+}) {
+  try {
+    const palm2 = new Palm2AI({ apiKey: palmApiKey });
+    const response = await palm2.generateText({ prompt });
+    return JSON.stringify(response);
+  } catch (error) {
+    return JSON.stringify({ error });
+  }
+}
+
+module.exports = palm2Call;

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- Adds a `Palm2AI` wrapper for PaLM2 text generation, chat/message generation, embeddings, token counting, model fetch, and model listing.
- Exports PaLM2 classes and types from the AI package entrypoint.
- Adds focused unit tests under `src/ai/src/tests/palm2` and a Jsonnet-based `palm2-chat` example.

## Verification
- `npm run build`
- `npx jest src/ai/src/tests/palm2/palm2.test.ts --runInBand`

Closes #279