### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,191 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+interface QdrantClientOptions {
+    url?: string;
+    apiKey?: string;
+    axiosConfig?: AxiosRequestConfig;
+}
+
+interface QdrantCreateCollectionArgs {
+    client: AxiosInstance;
+    collectionName: string;
+    vectorSize: number;
+    distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+}
+
+interface QdrantUpsertPointsArgs {
+    client: AxiosInstance;
+    collectionName: string;
+    points: Array<{
+        id: string | number;
+        vector: number[];
+        payload?: Record<string, any>;
+    }>;
+    wait?: boolean;
+}
+
+interface QdrantSearchPointsArgs {
+    client: AxiosInstance;
+    collectionName: string;
+    vector: number[];
+    limit?: number;
+    filter?: Record<string, any>;
+    withPayload?: boolean | Record<string, any>;
+    scoreThreshold?: number;
+}
+
+interface QdrantGetPointArgs {
+    client: AxiosInstance;
+    collectionName: string;
+    id: string | number;
+    withPayload?: boolean | Record<string, any>;
+    withVector?: boolean;
+}
+
+interface QdrantDeletePointsArgs {
+    client: AxiosInstance;
+    collectionName: string;
+    points: Array<string | number>;
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(options: QdrantClientOptions = {}) {
+        this.QDRANT_URL = (options.url || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = options.apiKey || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(options: QdrantClientOptions = {}) {
+        const url = (options.url || this.QDRANT_URL || process.env.QDRANT_URL || "").replace(
+            /\/$/,
+            ""
+        );
+        const apiKey = options.apiKey || this.QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+
+        if (!url) {
+            throw new Error("Qdrant URL is required. Pass url or set QDRANT_URL.");
+        }
+
+        return axios.create({
+            baseURL: url,
+            headers: {
+                ...(apiKey ? { "api-key": apiKey } : {}),
+                "Content-Type": "application/json",
+            },
+            ...options.axiosConfig,
+        });
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: QdrantCreateCollectionArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const res = await client.put(`/collections/${collectionName}`, {
+                vectors: {
+                    size: vectorSize,
+                    distance,
+                },
+            });
+            return res.data;
+        });
+    }
+
+    async upsertPoints({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: QdrantUpsertPointsArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const res = await client.put(`/collections/${collectionName}/points`, {
+                points,
+                wait,
+            });
+            return res.data;
+        });
+    }
+
+    async searchPoints({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        scoreThreshold,
+    }: QdrantSearchPointsArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const res = await client.post(`/collections/${collectionName}/points/search`, {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                score_threshold: scoreThreshold,
+            });
+            return res.data;
+        });
+    }
+
+    async getPoint({
+        client,
+        collectionName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: QdrantGetPointArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const res = await client.get(`/collections/${collectionName}/points/${id}`, {
+                params: {
+                    with_payload: withPayload,
+                    with_vector: withVector,
+                },
+            });
+            return res.data;
+        });
+    }
+
+    async deletePoints({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: QdrantDeletePointsArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const res = await client.post(`/collections/${collectionName}/points/delete`, {
+                points,
+                wait,
+            });
+            return res.data;
+        });
+    }
+
+    private async withRetry<T>(handler: () => Promise<T>): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    resolve(await handler());
+                } catch (error: any) {
+                    if (operation.retry(error)) return;
+                    reject(error);
+                }
+            });
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,135 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+describe("Qdrant vector database client", () => {
+    const qdrant = new Qdrant({ url: "https://mock-qdrant.local", apiKey: "mock-api-key" });
+
+    it("creates a configured axios client", () => {
+        const client = qdrant.createClient();
+
+        expect(client.defaults.baseURL).toBe("https://mock-qdrant.local");
+        expect(client.defaults.headers["api-key"]).toBe("mock-api-key");
+    });
+
+    it("creates a collection through the Qdrant REST API", async () => {
+        const client = {
+            put: jest.fn().mockResolvedValue({
+                data: {
+                    result: true,
+                    status: "ok",
+                },
+            }),
+        } as any;
+
+        const result = await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+        });
+
+        expect(client.put).toHaveBeenCalledWith("/collections/documents", {
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
+        expect(result).toEqual({ result: true, status: "ok" });
+    });
+
+    it("upserts vector points directly through the REST API", async () => {
+        const client = {
+            put: jest.fn().mockResolvedValue({
+                data: {
+                    result: { operation_id: 42 },
+                    status: "ok",
+                },
+            }),
+        } as any;
+
+        const points = [
+            {
+                id: 1,
+                vector: [0.1, 0.2, 0.3],
+                payload: { content: "Sample document" },
+            },
+        ];
+
+        const result = await qdrant.upsertPoints({
+            client,
+            collectionName: "documents",
+            points,
+        });
+
+        expect(client.put).toHaveBeenCalledWith("/collections/documents/points", {
+            points,
+            wait: true,
+        });
+        expect(result.status).toBe("ok");
+    });
+
+    it("searches vector points with optional filter arguments", async () => {
+        const client = {
+            post: jest.fn().mockResolvedValue({
+                data: {
+                    result: [{ id: 1, score: 0.98, payload: { content: "Sample document" } }],
+                    status: "ok",
+                },
+            }),
+        } as any;
+
+        const result = await qdrant.searchPoints({
+            client,
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: {
+                must: [{ key: "category", match: { value: "docs" } }],
+            },
+        });
+
+        expect(client.post).toHaveBeenCalledWith("/collections/documents/points/search", {
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: {
+                must: [{ key: "category", match: { value: "docs" } }],
+            },
+            with_payload: true,
+            score_threshold: undefined,
+        });
+        expect(result.result[0].score).toBe(0.98);
+    });
+
+    it("fetches and deletes points", async () => {
+        const client = {
+            get: jest.fn().mockResolvedValue({
+                data: { result: { id: 1, payload: { content: "Sample document" } } },
+            }),
+            post: jest.fn().mockResolvedValue({
+                data: { result: { operation_id: 7 }, status: "ok" },
+            }),
+        } as any;
+
+        const point = await qdrant.getPoint({
+            client,
+            collectionName: "documents",
+            id: 1,
+        });
+        const deleted = await qdrant.deletePoints({
+            client,
+            collectionName: "documents",
+            points: [1],
+        });
+
+        expect(client.get).toHaveBeenCalledWith("/collections/documents/points/1", {
+            params: {
+                with_payload: true,
+                with_vector: false,
+            },
+        });
+        expect(client.post).toHaveBeenCalledWith("/collections/documents/points/delete", {
+            points: [1],
+            wait: true,
+        });
+        expect(point.result.id).toBe(1);
+        expect(deleted.status).toBe("ok");
+    });
+});


### PR DESCRIPTION
## Summary
- add a Qdrant vector database client that uses Qdrant REST endpoints directly, without the Qdrant package
- support collection creation, point upsert, search, point fetch, and point deletion
- export the Qdrant client from the vector-db package

## Tests
- npm run build
- npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand

Closes #273