### PR TITLE
Add AWS Comprehend prompt redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -22,6 +22,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.1046.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",
@@ -48,6 +49,7 @@
         "retell-client-js-sdk": "^2.0.4",
         "retell-sdk": "^4.9.0",
         "retry": "^0.13.1",
+        "rxjs": "^7.8.2",
         "ts-node": "^10.9.2",
         "typeorm": "^0.3.20",
         "vitest": "^2.0.3",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,8 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { ComprehendRedactor } from "./lib/comprehend/comprehendRedactor.js";
+export type {
+    RedactedPiiEntity,
+    RedactedPrompt,
+} from "./lib/comprehend/comprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehendRedactor.ts
@@ -1,0 +1,169 @@
+import {
+    ComprehendClient,
+    DetectPiiEntitiesCommand,
+    DetectPiiEntitiesCommandInput,
+    PiiEntity,
+} from "@aws-sdk/client-comprehend";
+import { from, isObservable, Observable, ObservableInput, of } from "rxjs";
+import { mergeMap } from "rxjs/operators";
+
+type ComprehendPiiClient = {
+    send(
+        command: DetectPiiEntitiesCommand,
+    ): Promise<{ Entities?: PiiEntity[] }>;
+};
+
+interface ComprehendRedactorOptions {
+    client?: ComprehendPiiClient;
+    region?: string;
+}
+
+interface RedactPromptOptions {
+    text: string;
+    languageCode?: DetectPiiEntitiesCommandInput["LanguageCode"];
+    replacement?: string;
+    minScore?: number;
+    entityTypes?: string[];
+    includeEntityType?: boolean;
+}
+
+type RedactPromptStreamOptions = Omit<RedactPromptOptions, "text">;
+
+export interface RedactedPiiEntity {
+    type: string;
+    score?: number;
+    beginOffset: number;
+    endOffset: number;
+    text: string;
+}
+
+export interface RedactedPrompt {
+    redactedText: string;
+    entities: RedactedPiiEntity[];
+}
+
+export class ComprehendRedactor {
+    private client: ComprehendPiiClient;
+
+    constructor(options: ComprehendRedactorOptions = {}) {
+        this.client =
+            options.client ||
+            new ComprehendClient({
+                region: options.region || process.env.AWS_REGION || "us-east-1",
+            });
+    }
+
+    async redactPrompt({
+        text,
+        languageCode = "en",
+        replacement = "[REDACTED]",
+        minScore = 0,
+        entityTypes,
+        includeEntityType = true,
+    }: RedactPromptOptions): Promise<RedactedPrompt> {
+        const response = await this.client.send(
+            new DetectPiiEntitiesCommand({
+                Text: text,
+                LanguageCode: languageCode,
+            }),
+        );
+
+        const allowedTypes = entityTypes ? new Set(entityTypes) : null;
+        const entities = (response.Entities || [])
+            .filter((entity) =>
+                this.isUsableEntity(entity, minScore, allowedTypes),
+            )
+            .map((entity) => this.toRedactedEntity(text, entity))
+            .sort((a, b) => a.beginOffset - b.beginOffset);
+
+        return {
+            redactedText: this.replaceEntities(
+                text,
+                entities,
+                replacement,
+                includeEntityType,
+            ),
+            entities,
+        };
+    }
+
+    redactPrompt$(
+        text: string | Promise<string> | ObservableInput<string>,
+        options: RedactPromptStreamOptions = {},
+    ): Observable<RedactedPrompt> {
+        const source = isObservable(text)
+            ? text
+            : typeof text === "string"
+              ? of(text)
+              : from(text);
+
+        return source.pipe(
+            mergeMap((promptText) =>
+                from(
+                    this.redactPrompt({
+                        ...options,
+                        text: promptText,
+                    }),
+                ),
+            ),
+        );
+    }
+
+    private isUsableEntity(
+        entity: PiiEntity,
+        minScore: number,
+        allowedTypes: Set<string> | null,
+    ): boolean {
+        if (
+            entity.BeginOffset === undefined ||
+            entity.EndOffset === undefined ||
+            !entity.Type
+        ) {
+            return false;
+        }
+        if ((entity.Score || 0) < minScore) {
+            return false;
+        }
+        return !allowedTypes || allowedTypes.has(entity.Type);
+    }
+
+    private toRedactedEntity(
+        text: string,
+        entity: PiiEntity,
+    ): RedactedPiiEntity {
+        const beginOffset = entity.BeginOffset || 0;
+        const endOffset = entity.EndOffset || beginOffset;
+
+        return {
+            type: entity.Type || "UNKNOWN",
+            score: entity.Score,
+            beginOffset,
+            endOffset,
+            text: text.slice(beginOffset, endOffset),
+        };
+    }
+
+    private replaceEntities(
+        text: string,
+        entities: RedactedPiiEntity[],
+        replacement: string,
+        includeEntityType: boolean,
+    ): string {
+        return entities
+            .filter((entity, index, sorted) => {
+                const previous = sorted[index - 1];
+                return !previous || entity.beginOffset >= previous.endOffset;
+            })
+            .sort((a, b) => b.beginOffset - a.beginOffset)
+            .reduce((redactedText, entity) => {
+                const label = includeEntityType
+                    ? `[${entity.type}]`
+                    : replacement;
+                return (
+                    redactedText.slice(0, entity.beginOffset) +
+                    label +
+                    redactedText.slice(entity.endOffset)
+                );
+            }, text);
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehend/comprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehend/comprehendRedactor.test.ts
@@ -1,0 +1,115 @@
+import { ComprehendRedactor } from "../../../../../dist/ai/src/lib/comprehend/comprehendRedactor.js";
+import { firstValueFrom, of } from "rxjs";
+
+describe("ComprehendRedactor", () => {
+    it("redacts PII entities detected by AWS Comprehend", async () => {
+        const client = {
+            send: jest.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "NAME",
+                        Score: 0.99,
+                        BeginOffset: 3,
+                        EndOffset: 13,
+                    },
+                    {
+                        Type: "EMAIL",
+                        Score: 0.98,
+                        BeginOffset: 28,
+                        EndOffset: 44,
+                    },
+                ],
+            }),
+        };
+        const redactor = new ComprehendRedactor({ client });
+
+        const result = await redactor.redactPrompt({
+            text: "Hi Jane Smith, please email jane@example.com today.",
+        });
+
+        expect(client.send).toHaveBeenCalledTimes(1);
+        expect(result.redactedText).toBe(
+            "Hi [NAME], please email [EMAIL] today.",
+        );
+        expect(result.entities).toEqual([
+            {
+                type: "NAME",
+                score: 0.99,
+                beginOffset: 3,
+                endOffset: 13,
+                text: "Jane Smith",
+            },
+            {
+                type: "EMAIL",
+                score: 0.98,
+                beginOffset: 28,
+                endOffset: 44,
+                text: "jane@example.com",
+            },
+        ]);
+    });
+
+    it("supports score and entity-type filters", async () => {
+        const client = {
+            send: jest.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "NAME",
+                        Score: 0.55,
+                        BeginOffset: 0,
+                        EndOffset: 4,
+                    },
+                    {
+                        Type: "PHONE",
+                        Score: 0.99,
+                        BeginOffset: 13,
+                        EndOffset: 23,
+                    },
+                    {
+                        Type: "EMAIL",
+                        Score: 0.99,
+                        BeginOffset: 26,
+                        EndOffset: 42,
+                    },
+                ],
+            }),
+        };
+        const redactor = new ComprehendRedactor({ client });
+
+        const result = await redactor.redactPrompt({
+            text: "Jane called 5551234567 or jane@example.com.",
+            minScore: 0.9,
+            entityTypes: ["EMAIL"],
+            includeEntityType: false,
+            replacement: "[PRIVATE]",
+        });
+
+        expect(result.redactedText).toBe(
+            "Jane called 5551234567 or [PRIVATE].",
+        );
+        expect(result.entities).toHaveLength(1);
+        expect(result.entities[0].type).toBe("EMAIL");
+    });
+
+    it("can be chained as an observable redaction step", async () => {
+        const client = {
+            send: jest.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "EMAIL",
+                        Score: 0.99,
+                        BeginOffset: 6,
+                        EndOffset: 22,
+                    },
+                ],
+            }),
+        };
+        const redactor = new ComprehendRedactor({ client });
+
+        const result = await firstValueFrom(
+            redactor.redactPrompt$(of("Email jane@example.com")),
+        );
+
+        expect(result.redactedText).toBe("Email [EMAIL]");
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/.gitignore
+++ b/JS/edgechains/examples/aws-comprehend-redaction/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.env

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,13 @@
+local promptTemplate = |||
+  Write a concise account-risk summary for this customer conversation.
+  Do not expose personal data in the output.
+
+  Conversation:
+  {redacted_prompt}
+|||;
+
+local redactedPrompt = std.extVar('redacted_prompt');
+
+{
+  prompt: std.strReplace(promptTemplate, '{redacted_prompt}', redactedPrompt),
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/secrets.jsonnet.sample
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/secrets.jsonnet.sample
@@ -1,0 +1,3 @@
+{
+  aws_region: 'us-east-1',
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "aws-comprehend-redaction",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "build": "tsc -b",
+        "start": "tsc && node dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "^0.23.6",
+        "@arakoodev/jsonnet": "^0.23.6",
+        "dotenv": "^16.4.5",
+        "file-uri-to-path": "^2.0.0",
+        "path": "^0.12.7",
+        "rxjs": "^7.8.2"
+    },
+    "devDependencies": {
+        "@types/node": "^20.14.1",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/readme.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/readme.md
@@ -1,0 +1,12 @@
+# AWS Comprehend Redaction Example
+
+This example redacts PII from a prompt with AWS Comprehend before the prompt is passed into a Jsonnet prompt template.
+
+## Setup
+
+```bash
+npm install
+AWS_REGION=us-east-1 npm start
+```
+
+AWS credentials should be configured through the normal AWS SDK provider chain, such as environment variables, an AWS profile, or an attached role.

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,48 @@
+import "dotenv/config";
+import Jsonnet from "@arakoodev/jsonnet";
+import { ComprehendRedactor } from "@arakoodev/edgechains.js/ai";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+import { firstValueFrom, of } from "rxjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const prompt =
+    process.argv.slice(2).join(" ") ||
+    "Customer Jane Smith emailed jane@example.com and asked about invoice 12345.";
+
+const redactor = new ComprehendRedactor({
+    region: process.env.AWS_REGION || "us-east-1",
+});
+
+const result = await firstValueFrom(
+    redactor.redactPrompt$(of(prompt), {
+        minScore: 0.75,
+    }),
+);
+
+const jsonnet = new Jsonnet();
+jsonnet.extString("redacted_prompt", result.redactedText);
+
+const compiledPrompt = JSON.parse(
+    jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet")),
+);
+
+console.log(
+    JSON.stringify(
+        {
+            redactedPrompt: result.redactedText,
+            entities: result.entities.map(
+                ({ type, score, beginOffset, endOffset }) => ({
+                    type,
+                    score,
+                    beginOffset,
+                    endOffset,
+                }),
+            ),
+            compiledPrompt: compiledPrompt.prompt,
+        },
+        null,
+        2,
+    ),
+);

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `ComprehendRedactor` for AWS Comprehend PII detection/redaction in prompts
- expose both Promise and Observable APIs so redaction can be chained before endpoint/LLM calls
- export redaction types from the AI package
- add a full `aws-comprehend-redaction` Jsonnet example

## Tests
- npm run build
- npx jest src/ai/src/tests/comprehend/comprehendRedactor.test.ts --runInBand

Closes #290