### PR TITLE
Add SmartRouter for AI deployment routing

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,17 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+    SmartRouter,
+    posthogCallback,
+    sentryCallback,
+} from "./lib/router/smartRouter.js";
+export type {
+    SmartRouterCallback,
+    SmartRouterChatOptions,
+    SmartRouterDeployment,
+    SmartRouterMessage,
+    SmartRouterProvider,
+    SmartRouterResponse,
+    SmartRouterUsage,
+} from "./lib/router/smartRouter.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/smartRouter.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/smartRouter.ts
@@ -1,0 +1,494 @@
+import axios, { AxiosRequestConfig } from "axios";
+
+export type SmartRouterProvider = "openai" | "google_palm" | "cohere";
+
+export interface SmartRouterMessage {
+    role: "user" | "assistant" | "system";
+    content: string;
+}
+
+export interface SmartRouterUsage {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+}
+
+export interface SmartRouterDeployment {
+    id: string;
+    provider: SmartRouterProvider;
+    model: string;
+    apiKey: string;
+    baseUrl?: string;
+    rpmLimit?: number;
+    tpmLimit?: number;
+    timeoutMs?: number;
+    maxRetries?: number;
+}
+
+export interface SmartRouterChatOptions {
+    model?: string;
+    prompt?: string;
+    messages?: SmartRouterMessage[];
+    max_tokens?: number;
+    temperature?: number;
+    stream?: boolean;
+}
+
+export interface SmartRouterResponse {
+    deploymentId: string;
+    provider: SmartRouterProvider;
+    model: string;
+    content: string;
+    usage: SmartRouterUsage;
+    raw: any;
+}
+
+export interface SmartRouterEvent {
+    deployment: SmartRouterDeployment;
+    options: SmartRouterChatOptions;
+    response?: SmartRouterResponse;
+    error?: any;
+    latencyMs: number;
+}
+
+export interface SmartRouterCallback {
+    on_success?: (event: SmartRouterEvent) => void;
+    on_failure?: (event: SmartRouterEvent) => void;
+}
+
+type SmartRouterTransport = (
+    config: AxiosRequestConfig,
+) => Promise<{ data: any; status?: number }>;
+
+interface DeploymentState {
+    minute: number;
+    requests: number;
+    tokens: number;
+    totalTokens: number;
+    cooldownUntil: number;
+}
+
+interface SmartRouterOptions {
+    deployments: SmartRouterDeployment[];
+    transport?: SmartRouterTransport;
+    now?: () => number;
+}
+
+const EMPTY_USAGE: SmartRouterUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+};
+
+export class SmartRouter {
+    private deployments: SmartRouterDeployment[];
+    private states = new Map<string, DeploymentState>();
+    private callbacks: SmartRouterCallback[] = [];
+    private transport: SmartRouterTransport;
+    private now: () => number;
+
+    constructor({
+        deployments,
+        transport,
+        now = () => Date.now(),
+    }: SmartRouterOptions) {
+        if (!deployments.length) {
+            throw new Error("SmartRouter requires at least one deployment.");
+        }
+
+        this.deployments = deployments;
+        this.transport =
+            transport ||
+            ((config) =>
+                axios
+                    .request(config)
+                    .then(({ data, status }) => ({ data, status })));
+        this.now = now;
+
+        deployments.forEach((deployment) => {
+            this.states.set(deployment.id, this.freshState());
+        });
+    }
+
+    addCallback(callback: SmartRouterCallback) {
+        this.callbacks.push(callback);
+    }
+
+    getUsage(deploymentId: string): SmartRouterUsage {
+        const state = this.states.get(deploymentId);
+        return {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: state?.totalTokens || 0,
+        };
+    }
+
+    async chat(
+        options: SmartRouterChatOptions,
+    ): Promise<SmartRouterResponse | AsyncIterable<string>> {
+        const maxAttempts = this.deployments.length;
+        const attempted = new Set<string>();
+        let lastError: any;
+
+        for (
+            let attempt = 0;
+            attempt < maxAttempts && attempted.size < this.deployments.length;
+            attempt++
+        ) {
+            const deployment = this.pickDeployment(options.model, attempted);
+            attempted.add(deployment.id);
+            const startedAt = this.now();
+
+            try {
+                const response = await this.callDeployment(deployment, options);
+                const normalized = this.normalizeResponse(
+                    deployment,
+                    response.data,
+                );
+                const latencyMs = this.now() - startedAt;
+
+                this.recordUsage(deployment.id, normalized.usage);
+                this.emitSuccess({
+                    deployment,
+                    options,
+                    response: normalized,
+                    latencyMs,
+                });
+
+                if (options.stream) {
+                    return this.toAsyncIterable(response.data);
+                }
+
+                return normalized;
+            } catch (error: any) {
+                lastError = error;
+                const latencyMs = this.now() - startedAt;
+
+                if (this.isRateLimited(error)) {
+                    this.cooldown(deployment.id);
+                }
+
+                this.emitFailure({ deployment, options, error, latencyMs });
+
+                if (!this.shouldRetry(error)) {
+                    break;
+                }
+            }
+        }
+
+        throw (
+            lastError ||
+            new Error("No available deployment for SmartRouter request.")
+        );
+    }
+
+    private pickDeployment(model?: string, attempted = new Set<string>()) {
+        this.refreshWindows();
+        const now = this.now();
+        const candidates = this.deployments
+            .filter((deployment) => !attempted.has(deployment.id))
+            .filter((deployment) => !model || deployment.model === model)
+            .filter((deployment) => {
+                const state =
+                    this.states.get(deployment.id) || this.freshState();
+                return (
+                    state.cooldownUntil <= now &&
+                    (!deployment.rpmLimit ||
+                        state.requests < deployment.rpmLimit) &&
+                    (!deployment.tpmLimit || state.tokens < deployment.tpmLimit)
+                );
+            })
+            .sort((a, b) => {
+                const aState = this.states.get(a.id) || this.freshState();
+                const bState = this.states.get(b.id) || this.freshState();
+                return aState.totalTokens - bState.totalTokens;
+            });
+
+        if (!candidates.length) {
+            throw new Error(
+                "No SmartRouter deployments are currently below their limits.",
+            );
+        }
+
+        return candidates[0];
+    }
+
+    private async callDeployment(
+        deployment: SmartRouterDeployment,
+        options: SmartRouterChatOptions,
+    ) {
+        const config = this.toAxiosConfig(deployment, options);
+        const state = this.states.get(deployment.id) || this.freshState();
+        state.requests += 1;
+        this.states.set(deployment.id, state);
+        return this.transport(config);
+    }
+
+    private toAxiosConfig(
+        deployment: SmartRouterDeployment,
+        options: SmartRouterChatOptions,
+    ): AxiosRequestConfig {
+        const messages = options.prompt
+            ? [{ role: "user", content: options.prompt }]
+            : options.messages || [];
+
+        if (deployment.provider === "google_palm") {
+            return {
+                method: "post",
+                url:
+                    deployment.baseUrl ||
+                    `https://generativelanguage.googleapis.com/v1/models/${deployment.model}:generateContent`,
+                timeout: deployment.timeoutMs,
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-goog-api-key": deployment.apiKey,
+                },
+                data: {
+                    contents: messages.map((message) => ({
+                        role: message.role === "assistant" ? "model" : "user",
+                        parts: [{ text: message.content }],
+                    })),
+                    generationConfig: {
+                        temperature: options.temperature,
+                        maxOutputTokens: options.max_tokens,
+                    },
+                },
+            };
+        }
+
+        if (deployment.provider === "cohere") {
+            return {
+                method: "post",
+                url: deployment.baseUrl || "https://api.cohere.ai/v1/chat",
+                timeout: deployment.timeoutMs,
+                headers: {
+                    Authorization: `Bearer ${deployment.apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                data: {
+                    model: deployment.model,
+                    message: messages
+                        .map((message) => message.content)
+                        .join("\n"),
+                    temperature: options.temperature,
+                    max_tokens: options.max_tokens,
+                    stream: options.stream || false,
+                },
+            };
+        }
+
+        return {
+            method: "post",
+            url:
+                deployment.baseUrl ||
+                "https://api.openai.com/v1/chat/completions",
+            timeout: deployment.timeoutMs,
+            headers: {
+                Authorization: `Bearer ${deployment.apiKey}`,
+                "Content-Type": "application/json",
+            },
+            data: {
+                model: deployment.model,
+                messages,
+                max_tokens: options.max_tokens,
+                temperature: options.temperature,
+                stream: options.stream || false,
+            },
+        };
+    }
+
+    private normalizeResponse(
+        deployment: SmartRouterDeployment,
+        raw: any,
+    ): SmartRouterResponse {
+        const content = this.extractContent(deployment.provider, raw);
+        const usage = this.extractUsage(deployment.provider, raw);
+
+        return {
+            deploymentId: deployment.id,
+            provider: deployment.provider,
+            model: deployment.model,
+            content,
+            usage,
+            raw,
+        };
+    }
+
+    private extractContent(provider: SmartRouterProvider, raw: any): string {
+        if (typeof raw === "string") {
+            return raw.includes("data:")
+                ? this.parseSseDeltas(raw).join("")
+                : raw;
+        }
+
+        if (provider === "google_palm") {
+            return (
+                raw?.candidates?.[0]?.content?.parts
+                    ?.map((part) => part.text)
+                    .join("") || ""
+            );
+        }
+
+        if (provider === "cohere") {
+            return raw?.text || raw?.message?.content?.[0]?.text || "";
+        }
+
+        return (
+            raw?.choices?.[0]?.message?.content ||
+            raw?.choices?.[0]?.delta?.content ||
+            ""
+        );
+    }
+
+    private extractUsage(
+        provider: SmartRouterProvider,
+        raw: any,
+    ): SmartRouterUsage {
+        if (raw?.usage) {
+            return {
+                prompt_tokens: raw.usage.prompt_tokens || 0,
+                completion_tokens: raw.usage.completion_tokens || 0,
+                total_tokens: raw.usage.total_tokens || 0,
+            };
+        }
+
+        if (provider === "google_palm" && raw?.usageMetadata) {
+            return {
+                prompt_tokens: raw.usageMetadata.promptTokenCount || 0,
+                completion_tokens: raw.usageMetadata.candidatesTokenCount || 0,
+                total_tokens: raw.usageMetadata.totalTokenCount || 0,
+            };
+        }
+
+        const billedUnits = raw?.meta?.billed_units || raw?.meta?.tokens;
+        if (provider === "cohere" && billedUnits) {
+            const promptTokens = billedUnits.input_tokens || 0;
+            const completionTokens = billedUnits.output_tokens || 0;
+            return {
+                prompt_tokens: promptTokens,
+                completion_tokens: completionTokens,
+                total_tokens: promptTokens + completionTokens,
+            };
+        }
+
+        return EMPTY_USAGE;
+    }
+
+    private recordUsage(deploymentId: string, usage: SmartRouterUsage) {
+        const state = this.states.get(deploymentId) || this.freshState();
+        state.tokens += usage.total_tokens;
+        state.totalTokens += usage.total_tokens;
+        this.states.set(deploymentId, state);
+    }
+
+    private refreshWindows() {
+        const minute = this.currentMinute();
+        this.states.forEach((state) => {
+            if (state.minute !== minute) {
+                state.minute = minute;
+                state.requests = 0;
+                state.tokens = 0;
+            }
+        });
+    }
+
+    private cooldown(deploymentId: string) {
+        const state = this.states.get(deploymentId) || this.freshState();
+        state.cooldownUntil = this.now() + 60 * 1000;
+        this.states.set(deploymentId, state);
+    }
+
+    private shouldRetry(error: any) {
+        const status = error?.response?.status || error?.status;
+        return status === 429 || status >= 500;
+    }
+
+    private isRateLimited(error: any) {
+        return (error?.response?.status || error?.status) === 429;
+    }
+
+    private parseSseDeltas(payload: string) {
+        return payload
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.startsWith("data:"))
+            .map((line) => line.replace(/^data:\s*/, ""))
+            .filter((line) => line && line !== "[DONE]")
+            .map((line) => JSON.parse(line))
+            .map(
+                (event) =>
+                    event?.choices?.[0]?.delta?.content || event?.text || "",
+            )
+            .filter(Boolean);
+    }
+
+    private async *toAsyncIterable(content: string): AsyncIterable<string> {
+        const chunks = content.includes("data:")
+            ? this.parseSseDeltas(content)
+            : [content];
+        for (const chunk of chunks) {
+            yield chunk;
+        }
+    }
+
+    private emitSuccess(event: SmartRouterEvent) {
+        this.callbacks.forEach((callback) => callback.on_success?.(event));
+    }
+
+    private emitFailure(event: SmartRouterEvent) {
+        this.callbacks.forEach((callback) => callback.on_failure?.(event));
+    }
+
+    private freshState(): DeploymentState {
+        return {
+            minute: this.currentMinute(),
+            requests: 0,
+            tokens: 0,
+            totalTokens: 0,
+            cooldownUntil: 0,
+        };
+    }
+
+    private currentMinute() {
+        return Math.floor(this.now() / 60000);
+    }
+}
+
+export function sentryCallback(sentry: {
+    captureException: (error: any, context?: any) => void;
+}) {
+    return {
+        on_failure: (event: SmartRouterEvent) =>
+            sentry.captureException(event.error, {
+                tags: {
+                    provider: event.deployment.provider,
+                    deploymentId: event.deployment.id,
+                },
+            }),
+    };
+}
+
+export function posthogCallback(posthog: { capture: (event: any) => void }) {
+    return {
+        on_success: (event: SmartRouterEvent) =>
+            posthog.capture({
+                event: "smart_router_success",
+                properties: {
+                    provider: event.deployment.provider,
+                    deploymentId: event.deployment.id,
+                    latencyMs: event.latencyMs,
+                    totalTokens: event.response?.usage.total_tokens || 0,
+                },
+            }),
+        on_failure: (event: SmartRouterEvent) =>
+            posthog.capture({
+                event: "smart_router_failure",
+                properties: {
+                    provider: event.deployment.provider,
+                    deploymentId: event.deployment.id,
+                    latencyMs: event.latencyMs,
+                    error: event.error?.message || String(event.error),
+                },
+            }),
+    };
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/router/smartRouter.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/router/smartRouter.test.ts
@@ -1,0 +1,201 @@
+import {
+    posthogCallback,
+    sentryCallback,
+    SmartRouter,
+} from "../../../../../dist/ai/src/lib/router/smartRouter.js";
+
+const deployments = [
+    {
+        id: "openai-primary",
+        provider: "openai" as const,
+        model: "gpt-4o",
+        apiKey: "openai-key",
+        rpmLimit: 10,
+        tpmLimit: 1000,
+    },
+    {
+        id: "openai-secondary",
+        provider: "openai" as const,
+        model: "gpt-4o",
+        apiKey: "openai-key-2",
+        rpmLimit: 10,
+        tpmLimit: 1000,
+    },
+];
+
+describe("SmartRouter", () => {
+    it("routes to the deployment with the least cumulative token usage", async () => {
+        const calls: string[] = [];
+        const router = new SmartRouter({
+            deployments,
+            transport: async (config) => {
+                const auth = config.headers?.Authorization as string;
+                calls.push(auth);
+                return {
+                    status: 200,
+                    data: {
+                        choices: [{ message: { content: auth } }],
+                        usage: {
+                            prompt_tokens: 4,
+                            completion_tokens: auth.includes("openai-key-2")
+                                ? 2
+                                : 80,
+                            total_tokens: auth.includes("openai-key-2")
+                                ? 6
+                                : 84,
+                        },
+                    },
+                };
+            },
+        });
+
+        await router.chat({ prompt: "first", model: "gpt-4o" });
+        const second = await router.chat({ prompt: "second", model: "gpt-4o" });
+
+        expect(calls).toEqual(["Bearer openai-key", "Bearer openai-key-2"]);
+        expect("content" in second && second.content).toBe(
+            "Bearer openai-key-2",
+        );
+    });
+
+    it("falls back after a rate-limit response and records failure callbacks", async () => {
+        const sentry = { captureException: jest.fn() };
+        const posthog = { capture: jest.fn() };
+        const router = new SmartRouter({
+            deployments,
+            transport: async (config) => {
+                if (
+                    (config.headers?.Authorization as string) ===
+                    "Bearer openai-key"
+                ) {
+                    throw { status: 429, message: "rate limited" };
+                }
+                return {
+                    status: 200,
+                    data: {
+                        choices: [{ message: { content: "fallback ok" } }],
+                        usage: {
+                            prompt_tokens: 1,
+                            completion_tokens: 2,
+                            total_tokens: 3,
+                        },
+                    },
+                };
+            },
+        });
+        router.addCallback(sentryCallback(sentry));
+        router.addCallback(posthogCallback(posthog));
+
+        const response = await router.chat({
+            prompt: "hello",
+            model: "gpt-4o",
+        });
+
+        expect("content" in response && response.content).toBe("fallback ok");
+        expect(sentry.captureException).toHaveBeenCalledTimes(1);
+        expect(posthog.capture).toHaveBeenCalledWith(
+            expect.objectContaining({ event: "smart_router_failure" }),
+        );
+        expect(posthog.capture).toHaveBeenCalledWith(
+            expect.objectContaining({ event: "smart_router_success" }),
+        );
+    });
+
+    it("normalizes Google PaLM/Gemini and Cohere usage shapes", async () => {
+        const router = new SmartRouter({
+            deployments: [
+                {
+                    id: "palm",
+                    provider: "google_palm",
+                    model: "gemini-pro",
+                    apiKey: "palm-key",
+                },
+                {
+                    id: "cohere",
+                    provider: "cohere",
+                    model: "command-r",
+                    apiKey: "cohere-key",
+                },
+            ],
+            transport: async (config) => {
+                if (
+                    (config.headers?.["x-goog-api-key"] as string) ===
+                    "palm-key"
+                ) {
+                    return {
+                        status: 200,
+                        data: {
+                            candidates: [
+                                {
+                                    content: {
+                                        parts: [{ text: "palm text" }],
+                                    },
+                                },
+                            ],
+                            usageMetadata: {
+                                promptTokenCount: 3,
+                                candidatesTokenCount: 4,
+                                totalTokenCount: 7,
+                            },
+                        },
+                    };
+                }
+
+                return {
+                    status: 200,
+                    data: {
+                        text: "cohere text",
+                        meta: {
+                            billed_units: {
+                                input_tokens: 5,
+                                output_tokens: 6,
+                            },
+                        },
+                    },
+                };
+            },
+        });
+
+        const palm = await router.chat({
+            prompt: "hello",
+            model: "gemini-pro",
+        });
+        const cohere = await router.chat({
+            prompt: "hello",
+            model: "command-r",
+        });
+
+        expect("content" in palm && palm.content).toBe("palm text");
+        expect("usage" in palm && palm.usage.total_tokens).toBe(7);
+        expect("content" in cohere && cohere.content).toBe("cohere text");
+        expect("usage" in cohere && cohere.usage.total_tokens).toBe(11);
+    });
+
+    it("returns streaming chunks as an async iterable", async () => {
+        const router = new SmartRouter({
+            deployments: [deployments[0]],
+            transport: async () => ({
+                status: 200,
+                data:
+                    'data: {"choices":[{"delta":{"content":"hello "}}]}\n' +
+                    'data: {"choices":[{"delta":{"content":"world"}}]}\n' +
+                    "data: [DONE]\n",
+            }),
+        });
+
+        const stream = await router.chat({
+            prompt: "stream",
+            model: "gpt-4o",
+            stream: true,
+        });
+        const chunks: string[] = [];
+
+        if (Symbol.asyncIterator in Object(stream)) {
+            for await (const chunk of stream as AsyncIterable<string>) {
+                chunks.push(chunk);
+            }
+        }
+
+        expect(chunks).toEqual(["hello ", "world"]);
+    });
+});

--- a/JS/edgechains/examples/smart-router/.gitignore
+++ b/JS/edgechains/examples/smart-router/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.env

--- a/JS/edgechains/examples/smart-router/jsonnet/router.jsonnet
+++ b/JS/edgechains/examples/smart-router/jsonnet/router.jsonnet
@@ -1,0 +1,20 @@
+{
+  deployments: [
+    {
+      id: 'openai-primary',
+      provider: 'openai',
+      model: 'gpt-4o',
+      rpmLimit: 60,
+      tpmLimit: 100000,
+      timeoutMs: 30000,
+    },
+    {
+      id: 'openai-backup',
+      provider: 'openai',
+      model: 'gpt-4o',
+      rpmLimit: 60,
+      tpmLimit: 100000,
+      timeoutMs: 30000,
+    },
+  ],
+}

--- a/JS/edgechains/examples/smart-router/package.json
+++ b/JS/edgechains/examples/smart-router/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "smart-router",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "build": "tsc -b",
+        "start": "tsc && node dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "^0.23.6",
+        "@arakoodev/jsonnet": "^0.23.6",
+        "dotenv": "^16.4.5",
+        "file-uri-to-path": "^2.0.0",
+        "path": "^0.12.7"
+    },
+    "devDependencies": {
+        "@types/node": "^20.14.1",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/smart-router/readme.md
+++ b/JS/edgechains/examples/smart-router/readme.md
@@ -1,0 +1,10 @@
+# Smart Router Example
+
+This example loads router deployments from Jsonnet and sends a chat request through the SmartRouter. The router selects the deployment below its request/token limits with the least cumulative token usage, tracks usage, supports streaming, and exposes logging callbacks.
+
+## Setup
+
+```bash
+npm install
+OPENAI_API_KEY=sk-... npm start
+```

--- a/JS/edgechains/examples/smart-router/src/index.ts
+++ b/JS/edgechains/examples/smart-router/src/index.ts
@@ -1,0 +1,46 @@
+import "dotenv/config";
+import Jsonnet from "@arakoodev/jsonnet";
+import {
+    posthogCallback,
+    sentryCallback,
+    SmartRouter,
+} from "@arakoodev/edgechains.js/ai";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const jsonnet = new Jsonnet();
+const config = JSON.parse(
+    jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/router.jsonnet")),
+);
+
+const deployments = config.deployments.map((deployment) => ({
+    ...deployment,
+    apiKey: process.env.OPENAI_API_KEY || "",
+}));
+
+const router = new SmartRouter({ deployments });
+
+router.addCallback(
+    sentryCallback({
+        captureException: (error, context) => {
+            console.error("SmartRouter failure", error, context);
+        },
+    }),
+);
+
+router.addCallback(
+    posthogCallback({
+        capture: (event) => {
+            console.log("SmartRouter event", event);
+        },
+    }),
+);
+
+const response = await router.chat({
+    model: "gpt-4o",
+    prompt: "Explain why smart routing improves LLM reliability in one sentence.",
+    max_tokens: 100,
+});
+
+console.log(JSON.stringify(response, null, 2));

--- a/JS/edgechains/examples/smart-router/tsconfig.json
+++ b/JS/edgechains/examples/smart-router/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a `SmartRouter` that routes across OpenAI, Google PaLM/Gemini, and Cohere deployments
- support least-token deployment selection, RPM/TPM limit checks, 429 cooldown/fallback, and provider-specific request shaping
- normalize provider responses and usage into an OpenAI-compatible shape
- support streaming responses as an async iterable
- add Sentry and PostHog callback adapters without adding those tools as hard dependencies
- export router types from the AI package
- add a Jsonnet-backed `examples/smart-router` example

## Tests
- npm run build
- npx jest src/ai/src/tests/router/smartRouter.test.ts --runInBand

Closes #286