### PR TITLE
Add Qdrant vector database support to JavaScript SDK

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,250 @@
+import { config } from "dotenv";
+config();
+
+type QdrantId = string | number;
+
+interface QdrantClientOptions {
+    url?: string;
+    apiKey?: string;
+}
+
+interface QdrantPoint {
+    id: QdrantId;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+interface CollectionVectorConfig {
+    size: number;
+    distance: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+    on_disk?: boolean;
+}
+
+interface SearchArgs {
+    collectionName: string;
+    vector: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, any>;
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string);
+    constructor(options?: QdrantClientOptions);
+    constructor(
+        QDRANT_URLOrOptions?: string | QdrantClientOptions,
+        QDRANT_API_KEY?: string
+    ) {
+        if (typeof QDRANT_URLOrOptions === "object") {
+            this.QDRANT_URL = QDRANT_URLOrOptions.url || process.env.QDRANT_URL!;
+            this.QDRANT_API_KEY = QDRANT_URLOrOptions.apiKey || process.env.QDRANT_API_KEY;
+        } else {
+            this.QDRANT_URL = QDRANT_URLOrOptions || process.env.QDRANT_URL!;
+            this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+        }
+    }
+
+    private async request(path: string, init: RequestInit = {}) {
+        const baseUrl = this.QDRANT_URL?.replace(/\/+$/, "");
+        if (!baseUrl) throw new Error("QDRANT_URL is required");
+
+        const response = await fetch(`${baseUrl}${path}`, {
+            ...init,
+            headers: {
+                "Content-Type": "application/json",
+                ...(this.QDRANT_API_KEY ? { "api-key": this.QDRANT_API_KEY } : {}),
+                ...(init.headers || {}),
+            },
+        });
+
+        const text = await response.text();
+        const data = text ? JSON.parse(text) : {};
+
+        if (!response.ok) {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(data)}`
+            );
+        }
+
+        return data;
+    }
+
+    /**
+     * Create a Qdrant collection.
+     * @param collectionName The collection to create.
+     * @param vectors Vector size and distance config accepted by Qdrant.
+     */
+    async createCollection({
+        collectionName,
+        vectors,
+        ...args
+    }: {
+        collectionName: string;
+        vectors: CollectionVectorConfig | Record<string, CollectionVectorConfig>;
+        [key: string]: any;
+    }): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}`, {
+            method: "PUT",
+            body: JSON.stringify({ vectors, ...args }),
+        });
+    }
+
+    /**
+     * Insert or update vector points in a Qdrant collection.
+     * @param collectionName The collection to write to.
+     * @param points Qdrant point objects with id, vector, and optional payload.
+     */
+    async insertVectorData({
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points?wait=${wait}`,
+            {
+                method: "PUT",
+                body: JSON.stringify({ points }),
+            }
+        );
+    }
+
+    /**
+     * Search Qdrant points by vector similarity.
+     */
+    async getDataFromQuery({
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: SearchArgs): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points/search`, {
+            method: "POST",
+            body: JSON.stringify({
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+            }),
+        });
+    }
+
+    /**
+     * Scroll data from a Qdrant collection.
+     */
+    async getData({
+        collectionName,
+        limit = 10,
+        offset,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: {
+        collectionName: string;
+        limit?: number;
+        offset?: QdrantId;
+        filter?: Record<string, any>;
+        withPayload?: boolean | string[] | Record<string, any>;
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points/scroll`, {
+            method: "POST",
+            body: JSON.stringify({
+                limit,
+                offset,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+            }),
+        });
+    }
+
+    /**
+     * Fetch Qdrant points by id.
+     */
+    async getDataById({
+        collectionName,
+        id,
+        ids,
+        withPayload = true,
+        withVector = false,
+    }: {
+        collectionName: string;
+        id?: QdrantId;
+        ids?: QdrantId[];
+        withPayload?: boolean | string[] | Record<string, any>;
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        const pointIds = ids || (id !== undefined ? [id] : []);
+
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points`, {
+            method: "POST",
+            body: JSON.stringify({
+                ids: pointIds,
+                with_payload: withPayload,
+                with_vector: withVector,
+            }),
+        });
+    }
+
+    /**
+     * Update a single point by id.
+     */
+    async updateById({
+        collectionName,
+        id,
+        vector,
+        payload,
+        wait = true,
+    }: {
+        collectionName: string;
+        id: QdrantId;
+        vector?: number[] | Record<string, number[]>;
+        payload?: Record<string, any>;
+        wait?: boolean;
+    }): Promise<any> {
+        return this.insertVectorData({
+            collectionName,
+            wait,
+            points: [{ id, vector: vector || [], payload }],
+        });
+    }
+
+    /**
+     * Delete points by id.
+     */
+    async deleteById({
+        collectionName,
+        id,
+        ids,
+        wait = true,
+    }: {
+        collectionName: string;
+        id?: QdrantId;
+        ids?: QdrantId[];
+        wait?: boolean;
+    }): Promise<any> {
+        const pointIds = ids || (id !== undefined ? [id] : []);
+
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points/delete?wait=${wait}`,
+            {
+                method: "POST",
+                body: JSON.stringify({ points: pointIds }),
+            }
+        );
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+describe("Qdrant", () => {
+    beforeEach(() => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ result: { status: "ok" } }),
+        }) as any;
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("should insert vector points using Qdrant REST API", async () => {
+        const qdrant = new Qdrant("https://qdrant.example.com", "mock-api-key");
+
+        const result = await qdrant.insertVectorData({
+            collectionName: "documents",
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+        });
+
+        expect(result).toEqual({ result: { status: "ok" } });
+        expect(global.fetch).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: 1,
+                            vector: [0.1, 0.2, 0.3],
+                            payload: { content: "hello" },
+                        },
+                    ],
+                }),
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                    "api-key": "mock-api-key",
+                }),
+            })
+        );
+    });
+
+    it("should search vector points using Qdrant REST API", async () => {
+        const qdrant = new Qdrant({ url: "https://qdrant.example.com" });
+
+        await qdrant.getDataFromQuery({
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            withPayload: true,
+            withVector: false,
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents/points/search",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    vector: [0.1, 0.2, 0.3],
+                    limit: 3,
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            })
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- add a Qdrant vector database client for the JavaScript SDK using Qdrant REST APIs directly
- export Qdrant from the vector-db package alongside Supabase
- cover insert and search request behavior with tests

## Verification
- npm run build
- npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts

Closes #273