### PR TITLE
Add Qdrant support to vector-db

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,272 @@
+import { config } from "dotenv";
+config();
+
+type QdrantPointId = string | number;
+type QdrantDistance = "Cosine" | "Euclid" | "Dot" | "Manhattan";
+
+interface ArgsObject {
+    [key: string]: any;
+}
+
+interface QdrantClient {
+    request<T>(method: string, path: string, body?: ArgsObject): Promise<T>;
+}
+
+interface QdrantClientArgs {
+    client?: QdrantClient;
+}
+
+interface CollectionArgs extends QdrantClientArgs {
+    collectionName?: string;
+}
+
+interface CreateCollectionArgs extends CollectionArgs {
+    vectorSize: number;
+    distance?: QdrantDistance;
+}
+
+interface InsertVectorDataArgs extends CollectionArgs {
+    id: QdrantPointId;
+    vector: number[];
+    payload?: ArgsObject;
+    wait?: boolean;
+}
+
+interface GetDataFromQueryArgs extends CollectionArgs {
+    vector: number[];
+    limit?: number;
+    filter?: ArgsObject;
+    withPayload?: boolean | string[] | ArgsObject;
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+}
+
+interface GetDataArgs extends CollectionArgs {
+    limit?: number;
+    offset?: QdrantPointId;
+    filter?: ArgsObject;
+    withPayload?: boolean | string[] | ArgsObject;
+    withVector?: boolean | string[];
+}
+
+interface GetDataByIdArgs extends CollectionArgs {
+    id: QdrantPointId;
+    withPayload?: boolean | string[] | ArgsObject;
+    withVector?: boolean | string[];
+}
+
+interface UpdateByIdArgs extends CollectionArgs {
+    id: QdrantPointId;
+    updatedContent: ArgsObject;
+    wait?: boolean;
+}
+
+interface DeleteByIdArgs extends CollectionArgs {
+    id: QdrantPointId;
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY: string;
+    COLLECTION_NAME: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string, COLLECTION_NAME?: string) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY || "";
+        this.COLLECTION_NAME = COLLECTION_NAME || process.env.QDRANT_COLLECTION_NAME || "";
+    }
+
+    createClient(): QdrantClient {
+        return {
+            request: this.request.bind(this),
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: CreateCollectionArgs): Promise<any> {
+        return this.getClient(client).request(
+            "PUT",
+            `/collections/${this.getCollectionName(collectionName)}`,
+            {
+                vectors: {
+                    size: vectorSize,
+                    distance,
+                },
+            }
+        );
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        id,
+        vector,
+        payload = {},
+        wait = true,
+    }: InsertVectorDataArgs): Promise<any> {
+        return this.getClient(client).request(
+            "PUT",
+            `/collections/${this.getCollectionName(collectionName)}/points?wait=${wait}`,
+            {
+                points: [
+                    {
+                        id,
+                        vector,
+                        payload,
+                    },
+                ],
+            }
+        );
+    }
+
+    async getDataFromQuery({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: GetDataFromQueryArgs): Promise<any> {
+        return this.getClient(client).request(
+            "POST",
+            `/collections/${this.getCollectionName(collectionName)}/points/search`,
+            {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+            }
+        );
+    }
+
+    async getData({
+        client,
+        collectionName,
+        limit = 10,
+        offset,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: GetDataArgs): Promise<any> {
+        return this.getClient(client).request(
+            "POST",
+            `/collections/${this.getCollectionName(collectionName)}/points/scroll`,
+            {
+                limit,
+                offset,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+            }
+        );
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: GetDataByIdArgs): Promise<any> {
+        const params = new URLSearchParams({
+            with_payload: JSON.stringify(withPayload),
+            with_vector: JSON.stringify(withVector),
+        });
+
+        return this.getClient(client).request(
+            "GET",
+            `/collections/${this.getCollectionName(collectionName)}/points/${encodeURIComponent(
+                String(id)
+            )}?${params.toString()}`
+        );
+    }
+
+    async updateById({
+        client,
+        collectionName,
+        id,
+        updatedContent,
+        wait = true,
+    }: UpdateByIdArgs): Promise<any> {
+        return this.getClient(client).request(
+            "POST",
+            `/collections/${this.getCollectionName(collectionName)}/points/payload?wait=${wait}`,
+            {
+                payload: updatedContent,
+                points: [id],
+            }
+        );
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        id,
+        wait = true,
+    }: DeleteByIdArgs): Promise<any> {
+        return this.getClient(client).request(
+            "POST",
+            `/collections/${this.getCollectionName(collectionName)}/points/delete?wait=${wait}`,
+            {
+                points: [id],
+            }
+        );
+    }
+
+    private getClient(client?: QdrantClient): QdrantClient {
+        return client || this.createClient();
+    }
+
+    private getCollectionName(collectionName?: string): string {
+        const name = collectionName || this.COLLECTION_NAME;
+        if (!name) {
+            throw new Error("Qdrant collectionName is required");
+        }
+        return encodeURIComponent(name);
+    }
+
+    private async request<T>(method: string, path: string, body?: ArgsObject): Promise<T> {
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required");
+        }
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        const response = await fetch(`${this.QDRANT_URL}${path}`, {
+            method,
+            headers,
+            body: body ? JSON.stringify(this.removeUndefined(body)) : undefined,
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Qdrant request failed with ${response.status}: ${errorText}`);
+        }
+
+        if (response.status === 204) {
+            return null as T;
+        }
+
+        return (await response.json()) as T;
+    }
+
+    private removeUndefined(value: ArgsObject): ArgsObject {
+        return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+    }
+}
+

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,98 @@
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch as any;
+});
+
+describe("Qdrant", () => {
+    it("should insert vector data through the Qdrant HTTP API", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ result: { operation_id: 1, status: "completed" } }),
+        });
+
+        const qdrant = new Qdrant("https://qdrant.example", "test-api-key", "documents");
+        const result = await qdrant.insertVectorData({
+            id: "doc-1",
+            vector: [0.1, 0.2, 0.3],
+            payload: { content: "hello" },
+        });
+
+        expect(result).toEqual({ result: { operation_id: 1, status: "completed" } });
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                headers: {
+                    "Content-Type": "application/json",
+                    "api-key": "test-api-key",
+                },
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: "doc-1",
+                            vector: [0.1, 0.2, 0.3],
+                            payload: { content: "hello" },
+                        },
+                    ],
+                }),
+            })
+        );
+    });
+
+    it("should search vector data through the Qdrant HTTP API", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ result: [{ id: "doc-1", score: 0.98 }] }),
+        });
+
+        const qdrant = new Qdrant("https://qdrant.example", "", "documents");
+        const result = await qdrant.getDataFromQuery({
+            vector: [0.1, 0.2, 0.3],
+            limit: 2,
+            filter: { must: [{ key: "source", match: { value: "faq" } }] },
+            withPayload: true,
+            withVector: false,
+        });
+
+        expect(result).toEqual({ result: [{ id: "doc-1", score: 0.98 }] });
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents/points/search",
+            expect.objectContaining({
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    vector: [0.1, 0.2, 0.3],
+                    limit: 2,
+                    filter: { must: [{ key: "source", match: { value: "faq" } }] },
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            })
+        );
+    });
+
+    it("should surface Qdrant API errors", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 400,
+            text: async () => "bad vector size",
+        });
+
+        const qdrant = new Qdrant("https://qdrant.example", "", "documents");
+
+        await expect(
+            qdrant.insertVectorData({
+                id: 1,
+                vector: [1],
+            })
+        ).rejects.toThrow("Qdrant request failed with 400: bad vector size");
+    });
+});


### PR DESCRIPTION
## Summary

- add a Qdrant vector database wrapper for collection creation, upsert, search, scroll, payload update, and point deletion
- export Qdrant from the vector-db package entrypoint
- add Qdrant HTTP API unit tests with mocked fetch

## Verification

- `./node_modules/.bin/jest src/vector-db/src/tests/qdrant/qdrant.test.ts --config jest.config.cjs --runInBand`
- `./node_modules/.bin/tsc -b`
- `./node_modules/.bin/jest src/vector-db/src/tests --config jest.config.cjs --runInBand`

Fixes #273
