### PR TITLE
feat: add AWS Comprehend PII detection and redaction utility (#290)

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,12 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AWSComprehend } from "./lib/comprehend/comprehend.js";
+export type {
+    AWSComprehendConstructionOptions,
+    PiiEntityResult,
+    RedactionOptions,
+    RedactionResult,
+    DetectionResult,
+    PiiEntityType,
+} from "./lib/comprehend/comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
@@ -1,0 +1,261 @@
+import axios from "axios";
+import crypto from "crypto";
+
+interface AWSComprehendConstructionOptions {
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+}
+
+interface PiiEntityResult {
+    score: number;
+    type: string;
+    beginOffset: number;
+    endOffset: number;
+}
+
+interface RedactionOptions {
+    text: string;
+    languageCode?: string;
+    maskChar?: string;
+}
+
+interface RedactionResult {
+    redactedText: string;
+    entities: PiiEntityResult[];
+}
+
+interface DetectionResult {
+    entities: PiiEntityResult[];
+}
+
+type PiiEntityType =
+    | "BANK_ACCOUNT_NUMBER"
+    | "BANK_ROUTING"
+    | "CREDIT_DEBIT_NUMBER"
+    | "CREDIT_DEBIT_CVV"
+    | "CREDIT_DEBIT_EXPIRY"
+    | "PIN"
+    | "EMAIL"
+    | "ADDRESS"
+    | "NAME"
+    | "PHONE"
+    | "SSN"
+    | "DATE_TIME"
+    | "PASSPORT_NUMBER"
+    | "DRIVER_ID"
+    | "URL"
+    | "AGE"
+    | "USERNAME"
+    | "PASSWORD"
+    | "AWS_ACCESS_KEY"
+    | "AWS_SECRET_KEY"
+    | "IP_ADDRESS"
+    | "MAC_ADDRESS"
+    | "ALL"
+    | "LICENSE_PLATE"
+    | "VEHICLE_IDENTIFICATION_NUMBER"
+    | "UK_NATIONAL_INSURANCE_NUMBER"
+    | "CA_SOCIAL_INSURANCE_NUMBER"
+    | "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER"
+    | "MEDICAL_RECORD_NUMBER"
+    | "HEALTH_PLAN_BENEFIT_NUMBER"
+    | "DRUG_PRESCRIPTION_ID"
+    | "MEDICAL_TEST_RESULT"
+    | "MEDICAL_DEVICE_ID"
+    | "DEPARTMENT_OF_DEFENSE_ID_NUMBER"
+    | "US_PASSPORT_NUMBER"
+    | "US_SOCIAL_SECURITY_NUMBER"
+    | "INTERNATIONAL_BANK_ACCOUNT_NUMBER"
+    | "SWIFT_CODE"
+    | "IBAN_CODE"
+    | "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER"
+    | "IN_PAN"
+    | "IN_AADHAAR"
+    | "IN_VOTER_NUMBER"
+    | "IN_PASSPORT"
+    | "IN_DRIVING_LICENSE";
+
+export class AWSComprehend {
+    private accessKeyId: string;
+    private secretAccessKey: string;
+    private region: string;
+
+    constructor(options: AWSComprehendConstructionOptions = {}) {
+        this.accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+        this.secretAccessKey = options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "";
+        this.region = options.region || process.env.AWS_REGION || "us-east-1";
+        this.checkKeys();
+    }
+
+    private checkKeys(): void {
+        if (!this.accessKeyId || !this.secretAccessKey) {
+            console.error(
+                "AWS credentials are missing. Please provide valid AWS credentials via constructor options or environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)."
+            );
+        }
+    }
+
+    private async signRequest(
+        payload: string,
+        service: string,
+        host: string,
+        amzTarget: string
+    ): Promise<{ headers: Record<string, string>; url: string }> {
+        const amzDate = new Date().toISOString().replace(/[:\-]|\.\d{3}/g, "");
+        const dateStamp = amzDate.substring(0, 8);
+        const endpoint = `https://${host}`;
+        const canonicalUri = "/";
+        const payloadHash = crypto.createHash("sha256").update(payload).digest("hex");
+
+        const canonicalHeaders = [
+            `content-type:application/x-amz-json-1.1`,
+            `host:${host}`,
+            `x-amz-date:${amzDate}`,
+            `x-amz-target:${amzTarget}`,
+        ].join("\n") + "\n";
+
+        const signedHeaders = "content-type;host;x-amz-date;x-amz-target";
+        const canonicalRequest = [
+            "POST",
+            canonicalUri,
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            payloadHash,
+        ].join("\n");
+
+        const credentialScope = `${dateStamp}/${this.region}/${service}/aws4_request`;
+        const stringToSign = [
+            "AWS4-HMAC-SHA256",
+            amzDate,
+            credentialScope,
+            crypto.createHash("sha256").update(canonicalRequest).digest("hex"),
+        ].join("\n");
+
+        const sign = (key: Buffer, msg: string) =>
+            crypto.createHmac("sha256", key).update(msg).digest();
+
+        let signingKey = sign(
+            sign(
+                sign(
+                    sign(Buffer.from("AWS4" + this.secretAccessKey), dateStamp),
+                    this.region
+                ),
+                service
+            ),
+            "aws4_request"
+        );
+
+        const signature = crypto.createHmac("sha256", signingKey).update(stringToSign).digest("hex");
+
+        const authorizationHeader =
+            `AWS4-HMAC-SHA256 Credential=${this.accessKeyId}/${credentialScope}, ` +
+            `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+        return {
+            url: endpoint,
+            headers: {
+                "Content-Type": "application/x-amz-json-1.1",
+                "X-Amz-Date": amzDate,
+                "X-Amz-Target": amzTarget,
+                Authorization: authorizationHeader,
+                Host: host,
+            },
+        };
+    }
+
+    async detectPiiEntities(
+        text: string,
+        languageCode: string = "en"
+    ): Promise<DetectionResult> {
+        const payload = JSON.stringify({
+            Text: text,
+            LanguageCode: languageCode,
+        });
+
+        const host = `comprehend.${this.region}.amazonaws.com`;
+        const { url, headers } = await this.signRequest(
+            payload,
+            "comprehend",
+            host,
+            "Comprehend_20171127.DetectPiiEntities"
+        );
+
+        const response = await axios.post(url, payload, { headers }).catch((error) => {
+            if (error.response) {
+                console.error("AWS Comprehend error:", error.response.status, error.response.data);
+            } else {
+                console.error("AWS Comprehend request failed:", error.message);
+            }
+            throw error;
+        });
+
+        const entities: PiiEntityResult[] = (response.data.Entities || []).map(
+            (entity: any) => ({
+                score: entity.Score || 0,
+                type: entity.Type || "UNKNOWN",
+                beginOffset: entity.BeginOffset || 0,
+                endOffset: entity.EndOffset || 0,
+            })
+        );
+
+        return { entities };
+    }
+
+    async redactPii(options: RedactionOptions): Promise<RedactionResult> {
+        const { entities } = await this.detectPiiEntities(
+            options.text,
+            options.languageCode || "en"
+        );
+        const maskChar = options.maskChar || "*";
+
+        let redactedText = options.text;
+        const sortedEntities = [...entities].sort((a, b) => b.beginOffset - a.beginOffset);
+
+        for (const entity of sortedEntities) {
+            const replacement = maskChar.repeat(entity.endOffset - entity.beginOffset);
+            redactedText =
+                redactedText.substring(0, entity.beginOffset) +
+                replacement +
+                redactedText.substring(entity.endOffset);
+        }
+
+        return { redactedText, entities };
+    }
+
+    async containsPii(text: string, languageCode: string = "en"): Promise<boolean> {
+        const payload = JSON.stringify({
+            Text: text,
+            LanguageCode: languageCode,
+        });
+
+        const host = `comprehend.${this.region}.amazonaws.com`;
+        const { url, headers } = await this.signRequest(
+            payload,
+            "comprehend",
+            host,
+            "Comprehend_20171127.ContainsPiiEntities"
+        );
+
+        const response = await axios.post(url, payload, { headers }).catch((error) => {
+            if (error.response) {
+                console.error("AWS Comprehend error:", error.response.status, error.response.data);
+            } else {
+                console.error("AWS Comprehend request failed:", error.message);
+            }
+            throw error;
+        });
+
+        return (response.data.Labels || []).length > 0;
+    }
+}
+
+export type {
+    AWSComprehendConstructionOptions,
+    PiiEntityResult,
+    RedactionOptions,
+    RedactionResult,
+    DetectionResult,
+    PiiEntityType,
+};

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehend/comprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehend/comprehend.test.ts
@@ -1,0 +1,164 @@
+import axios from "axios";
+import { AWSComprehend } from "../lib/comprehend/comprehend";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("AWSComprehend", () => {
+    let comprehend: AWSComprehend;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        comprehend = new AWSComprehend({
+            accessKeyId: "test-access-key",
+            secretAccessKey: "test-secret-key",
+            region: "us-east-1",
+        });
+    });
+
+    describe("detectPiiEntities", () => {
+        test("should detect PII entities in text", async () => {
+            const mockResponse = {
+                data: {
+                    Entities: [
+                        {
+                            Score: 0.99,
+                            Type: "EMAIL",
+                            BeginOffset: 18,
+                            EndOffset: 36,
+                        },
+                        {
+                            Score: 0.95,
+                            Type: "PHONE",
+                            BeginOffset: 55,
+                            EndOffset: 67,
+                        },
+                    ],
+                },
+            };
+
+            mockedAxios.post = jest.fn().mockResolvedValueOnce(mockResponse);
+
+            const result = await comprehend.detectPiiEntities(
+                "My email is john@example.com and my phone is 555-123-4567"
+            );
+
+            expect(result.entities).toHaveLength(2);
+            expect(result.entities[0].type).toBe("EMAIL");
+            expect(result.entities[0].beginOffset).toBe(18);
+            expect(result.entities[0].endOffset).toBe(36);
+            expect(result.entities[1].type).toBe("PHONE");
+        });
+
+        test("should return empty array when no PII detected", async () => {
+            const mockResponse = {
+                data: { Entities: [] },
+            };
+
+            mockedAxios.post = jest.fn().mockResolvedValueOnce(mockResponse);
+
+            const result = await comprehend.detectPiiEntities("Hello world");
+            expect(result.entities).toHaveLength(0);
+        });
+    });
+
+    describe("redactPii", () => {
+        test("should redact PII from text", async () => {
+            const mockResponse = {
+                data: {
+                    Entities: [
+                        {
+                            Score: 0.99,
+                            Type: "EMAIL",
+                            BeginOffset: 11,
+                            EndOffset: 27,
+                        },
+                    ],
+                },
+            };
+
+            mockedAxios.post = jest.fn().mockResolvedValueOnce(mockResponse);
+
+            const result = await comprehend.redactPii({
+                text: "My email is test@example.com here",
+                maskChar: "*",
+            });
+
+            expect(result.redactedText).toBe("My email is **************** here");
+            expect(result.entities[0].type).toBe("EMAIL");
+        });
+
+        test("should return original text when no PII found", async () => {
+            const mockResponse = {
+                data: { Entities: [] },
+            };
+
+            mockedAxios.post = jest.fn().mockResolvedValueOnce(mockResponse);
+
+            const result = await comprehend.redactPii({ text: "No PII here" });
+            expect(result.redactedText).toBe("No PII here");
+            expect(result.entities).toHaveLength(0);
+        });
+
+        test("should use custom mask character", async () => {
+            const mockResponse = {
+                data: {
+                    Entities: [
+                        {
+                            Score: 0.99,
+                            Type: "SSN",
+                            BeginOffset: 0,
+                            EndOffset: 11,
+                        },
+                    ],
+                },
+            };
+
+            mockedAxios.post = jest.fn().mockResolvedValueOnce(mockResponse);
+
+            const result = await comprehend.redactPii({
+                text: "123-45-6789 is my SSN",
+                maskChar: "X",
+            });
+
+            expect(result.redactedText).toBe("XXXXXXXXXXX is my SSN");
+        });
+    });
+
+    describe("containsPii", () => {
+        test("should return true when PII is present", async () => {
+            const mockResponse = {
+                data: {
+                    Labels: [{ Name: "EMAIL", Score: 0.99 }],
+                },
+            };
+
+            mockedAxios.post = jest.fn().mockResolvedValueOnce(mockResponse);
+
+            const result = await comprehend.containsPii("Email me at test@example.com");
+            expect(result).toBe(true);
+        });
+
+        test("should return false when no PII is present", async () => {
+            const mockResponse = {
+                data: { Labels: [] },
+            };
+
+            mockedAxios.post = jest.fn().mockResolvedValueOnce(mockResponse);
+
+            const result = await comprehend.containsPii("Just a normal text");
+            expect(result).toBe(false);
+        });
+    });
+
+    describe("constructor", () => {
+        test("should warn when credentials are missing", () => {
+            const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+            new AWSComprehend();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining("AWS credentials are missing")
+            );
+            consoleSpy.mockRestore();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Addresses #290 - Integrates AWS Comprehend as a utility to detect and redact PII data in the JavaScript SDK.

### Changes

- AWSComprehend class with detectPiiEntities, redactPii, and containsPii methods
- Uses AWS SigV4 signing via Node.js crypto (no extra SDK dependency)
- Full TypeScript types for all options, results, and PII entity types
- Comprehensive test suite

### Usage

```typescript
import { AWSComprehend } from "@arakoodev/edgechains.js/ai";

const comprehend = new AWSComprehend({
  accessKeyId: "YOUR_KEY",
  secretAccessKey: "YOUR_SECRET",
  region: "us-east-1"
});

const { redactedText } = await comprehend.redactPii({
  text: "My email is john@example.com",
  maskChar: "*"
});
```