### PR TITLE
feat: integrate AWS Comprehend for PII redaction #290

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -22,6 +22,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.556.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,4 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AwsComprehend } from "./lib/aws/aws-comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws/aws-comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws/aws-comprehend.ts
@@ -1,0 +1,61 @@
+import { ComprehendClient, DetectPiiEntitiesCommand, PiiEntity } from "@aws-sdk/client-comprehend";
+
+export interface AWSComprehendOptions {
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+}
+
+export class AwsComprehend {
+    private client: ComprehendClient;
+
+    constructor(options: AWSComprehendOptions = {}) {
+        const region = options.region || process.env.AWS_REGION || "us-east-1";
+        const accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+        const secretAccessKey = options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "";
+
+        this.client = new ComprehendClient({
+            region,
+            credentials: {
+                accessKeyId,
+                secretAccessKey,
+            },
+        });
+    }
+
+    /**
+     * Redacts PII entities from the given text.
+     * @param text The text to redact.
+     * @param languageCode Language of the text (default: 'en').
+     * @returns The redacted text with PII replaced by placeholders like [NAME], [EMAIL], etc.
+     */
+    async redact(text: string, languageCode: "en" | "es" | "fr" | "de" | "it" | "pt" | "ar" | "hi" | "ja" | "ko" | "zh" | "zh-TW" = "en"): Promise<string> {
+        const command = new DetectPiiEntitiesCommand({
+            Text: text,
+            LanguageCode: languageCode,
+        });
+
+        try {
+            const response = await this.client.send(command);
+            let redactedText = text;
+            if (response.Entities) {
+                // Sort entities in reverse order by BeginOffset to avoid index shifting issues
+                const entities = [...response.Entities].sort((a, b) => (b.BeginOffset || 0) - (a.BeginOffset || 0));
+
+                for (const entity of entities) {
+                    const begin = entity.BeginOffset;
+                    const end = entity.EndOffset;
+                    const type = entity.Type;
+
+                    if (begin !== undefined && end !== undefined && type !== undefined) {
+                        redactedText = redactedText.substring(0, begin) + `[${type}]` + redactedText.substring(end);
+                    }
+                }
+            }
+            return redactedText;
+        } catch (error: any) {
+            console.error("AWS Comprehend Redaction Error:", error.message);
+            throw error;
+        }
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AwsComprehend } from "../lib/aws/aws-comprehend";
+import { DetectPiiEntitiesCommand } from "@aws-sdk/client-comprehend";
+
+// Mock AWS SDK
+vi.mock("@aws-sdk/client-comprehend", () => {
+    return {
+        ComprehendClient: vi.fn().mockImplementation(() => {
+            return {
+                send: vi.fn(),
+            };
+        }),
+        DetectPiiEntitiesCommand: vi.fn(),
+    };
+});
+
+describe("AwsComprehend", () => {
+    let awsComprehend: AwsComprehend;
+    let mockClient: any;
+
+    beforeEach(() => {
+        awsComprehend = new AwsComprehend({
+            region: "us-east-1",
+            accessKeyId: "test-key",
+            secretAccessKey: "test-secret",
+        });
+        // @ts-ignore
+        mockClient = awsComprehend.client;
+    });
+
+    it("should redact PII entities correctly", async () => {
+        const text = "Hello, my name is John Doe and my email is john@example.com.";
+        const mockResponse = {
+            Entities: [
+                {
+                    BeginOffset: 18,
+                    EndOffset: 26,
+                    Type: "NAME",
+                    Score: 0.99,
+                },
+                {
+                    BeginOffset: 43,
+                    EndOffset: 54,
+                    Type: "EMAIL",
+                    Score: 0.99,
+                },
+            ],
+        };
+
+        mockClient.send.mockResolvedValue(mockResponse);
+
+        const result = await awsComprehend.redact(text);
+
+        expect(result).toBe("Hello, my name is [NAME] and my email is [EMAIL].");
+        expect(mockClient.send).toHaveBeenCalledWith(expect.any(DetectPiiEntitiesCommand));
+    });
+
+    it("should handle overlapping or shifting indices correctly by redacting from end to start", async () => {
+        const text = "Contact Alice at alice@web.com";
+        // Alice (8-13), alice@web.com (17-21) -> wait, index shifting is the concern.
+        const mockResponse = {
+            Entities: [
+                {
+                    BeginOffset: 8,
+                    EndOffset: 13,
+                    Type: "NAME",
+                },
+                {
+                    BeginOffset: 17,
+                    EndOffset: 30,
+                    Type: "EMAIL",
+                },
+            ],
+        };
+
+        mockClient.send.mockResolvedValue(mockResponse);
+
+        const result = await awsComprehend.redact(text);
+
+        expect(result).toBe("Contact [NAME] at [EMAIL]");
+    });
+
+    it("should return original text if no entities are found", async () => {
+        const text = "Clean text with no PII.";
+        mockClient.send.mockResolvedValue({ Entities: [] });
+
+        const result = await awsComprehend.redact(text);
+
+        expect(result).toBe(text);
+    });
+
+    it("should throw error if AWS client fails", async () => {
+        mockClient.send.mockRejectedValue(new Error("AWS Error"));
+
+        await expect(awsComprehend.redact("some text")).rejects.toThrow("AWS Error");
+    });
+});

--- a/JS/edgechains/examples/aws-pii-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-pii-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,9 @@
+local textToRedact = std.extVar('text');
+
+local main() =
+  local response = arakoo.native('awsRedact')({ text: textToRedact });
+  {
+    redactedText: response
+  };
+
+main()

--- a/JS/edgechains/examples/aws-pii-redaction/package.json
+++ b/JS/edgechains/examples/aws-pii-redaction/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "aws-pii-redaction-example",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "@arakoodev/jsonnet": "latest",
+    "file-uri-to-path": "latest",
+    "dotenv": "latest"
+  },
+  "scripts": {
+    "start": "ts-node src/index.ts"
+  }
+}

--- a/JS/edgechains/examples/aws-pii-redaction/readme.md
+++ b/JS/edgechains/examples/aws-pii-redaction/readme.md
@@ -1,0 +1,45 @@
+# AWS PII Redaction Example
+
+This example demonstrates how to use the `AwsComprehend` utility within EdgeChains to detect and redact Personally Identifiable Information (PII) from text.
+
+## How it works
+
+1.  **Jsonnet**: The prompt/text management is handled via `jsonnet/main.jsonnet`.
+2.  **Worker**: A sync RPC worker (`awsRedact.cts`) calls the `AwsComprehend` class.
+3.  **Server**: The main server (`src/index.ts`) exposes a `/redact` endpoint.
+
+## Setup
+
+1.  Set your AWS credentials in `.env`:
+    ```env
+    AWS_REGION=us-east-1
+    AWS_ACCESS_KEY_ID=your_access_key
+    AWS_SECRET_ACCESS_KEY=your_secret_key
+    ```
+
+2.  Install dependencies:
+    ```bash
+    npm install
+    ```
+
+3.  Run the example:
+    ```bash
+    npm start
+    ```
+
+## Usage
+
+Send a POST request to `http://localhost:3000/redact`:
+
+```json
+{
+  "text": "Hello, my name is John Doe and my email is john@example.com"
+}
+```
+
+Response:
+```json
+{
+  "redactedText": "Hello, my name is [NAME] and my email is [EMAIL]"
+}
+```

--- a/JS/edgechains/examples/aws-pii-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-pii-redaction/src/index.ts
@@ -1,0 +1,28 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const awsRedact = createSyncRPC(path.join(__dirname, "./lib/awsRedact.cjs"));
+
+app.post("/redact", async (c: any) => {
+    try {
+        const { text } = await c.req.json();
+        jsonnet.extString("text", text || "");
+        jsonnet.javascriptCallback("awsRedact", awsRedact);
+        let response = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+        return c.json(JSON.parse(response));
+    } catch (error) {
+        console.log("error occured", error);
+        return c.json({ error: "Internal Server Error" }, 500);
+    }
+});
+
+server.listen(3000);
+console.log("Server running on http://localhost:3000/redact");

--- a/JS/edgechains/examples/aws-pii-redaction/src/lib/awsRedact.cts
+++ b/JS/edgechains/examples/aws-pii-redaction/src/lib/awsRedact.cts
@@ -1,0 +1,13 @@
+const { AwsComprehend } = require("@arakoodev/edgechains.js/ai");
+
+async function awsRedact({ text }: any) {
+    try {
+        const aws = new AwsComprehend();
+        let res = await aws.redact(text);
+        return res;
+    } catch (error: any) {
+        return error.message;
+    }
+}
+
+module.exports = awsRedact;


### PR DESCRIPTION
This PR implements AWS Comprehend integration for data redaction as requested in issue #290. Includes unit tests and a Jsonnet example.