### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -3,3 +3,39 @@ Installation
 ```
 npm install arakoodev
 ```
+
+Qdrant vector database
+
+```ts
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant(process.env.QDRANT_URL!, process.env.QDRANT_API_KEY);
+const client = qdrant.createClient();
+
+await qdrant.createCollection({
+    client,
+    collectionName: "documents",
+    vectors: { size: 1536, distance: "Cosine" },
+});
+
+await qdrant.insertVectorData({
+    client,
+    collectionName: "documents",
+    points: [
+        {
+            id: 1,
+            vector: [0.1, 0.2, 0.3],
+            payload: { content: "hello" },
+        },
+    ],
+    wait: true,
+});
+
+const matches = await qdrant.getDataFromQuery({
+    client,
+    collectionName: "documents",
+    query: [0.1, 0.2, 0.3],
+    limit: 5,
+    withPayload: true,
+});
+```

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant, type QdrantClient, type QdrantPoint } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,294 @@
+import { config } from "dotenv";
+config();
+
+type QdrantPointId = number | string;
+type QdrantVector = number[] | Record<string, number[]>;
+type QdrantPayload = Record<string, unknown>;
+type QdrantOrdering = "weak" | "medium" | "strong";
+
+export interface QdrantClient {
+    url: string;
+    apiKey?: string;
+}
+
+export interface QdrantPoint {
+    id: QdrantPointId;
+    vector: QdrantVector;
+    payload?: QdrantPayload;
+}
+
+interface QdrantRequestOptions {
+    consistency?: number | string;
+    timeout?: number;
+    wait?: boolean;
+    ordering?: QdrantOrdering;
+}
+
+interface InsertVectorDataArgs extends QdrantRequestOptions {
+    client: QdrantClient;
+    collectionName: string;
+    points?: QdrantPoint[];
+    id?: QdrantPointId;
+    vector?: QdrantVector;
+    payload?: QdrantPayload;
+}
+
+interface GetDataFromQueryArgs extends QdrantRequestOptions {
+    client: QdrantClient;
+    collectionName: string;
+    query?: unknown;
+    prefetch?: unknown;
+    using?: string;
+    filter?: unknown;
+    params?: unknown;
+    scoreThreshold?: number;
+    limit?: number;
+    offset?: number;
+    withPayload?: boolean | string[] | Record<string, unknown>;
+    withVector?: boolean | string[];
+    lookupFrom?: unknown;
+    shardKey?: unknown;
+}
+
+interface GetDataByIdArgs extends QdrantRequestOptions {
+    client: QdrantClient;
+    collectionName: string;
+    ids?: QdrantPointId[];
+    id?: QdrantPointId;
+    withPayload?: boolean | string[] | Record<string, unknown>;
+    withVector?: boolean | string[];
+    shardKey?: unknown;
+}
+
+interface DeleteByIdArgs extends QdrantRequestOptions {
+    client: QdrantClient;
+    collectionName: string;
+    ids?: QdrantPointId[];
+    id?: QdrantPointId;
+    filter?: unknown;
+    shardKey?: unknown;
+}
+
+interface CreateCollectionArgs extends QdrantRequestOptions {
+    client: QdrantClient;
+    collectionName: string;
+    vectors: unknown;
+    shardNumber?: number;
+    replicationFactor?: number;
+    writeConsistencyFactor?: number;
+    onDiskPayload?: boolean;
+}
+
+interface UpdateByIdArgs extends QdrantRequestOptions {
+    client: QdrantClient;
+    collectionName: string;
+    id: QdrantPointId;
+    vector: QdrantVector;
+    payload?: QdrantPayload;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL!;
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(): QdrantClient {
+        return {
+            url: this.QDRANT_URL.replace(/\/+$/, ""),
+            apiKey: this.QDRANT_API_KEY,
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectors,
+        shardNumber,
+        replicationFactor,
+        writeConsistencyFactor,
+        onDiskPayload,
+        ...queryOptions
+    }: CreateCollectionArgs): Promise<any> {
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collectionName)}`,
+            query: this.queryFromOptions(queryOptions),
+            body: this.cleanObject({
+                vectors,
+                shard_number: shardNumber,
+                replication_factor: replicationFactor,
+                write_consistency_factor: writeConsistencyFactor,
+                on_disk_payload: onDiskPayload,
+            }),
+        });
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        points,
+        id,
+        vector,
+        payload,
+        ...queryOptions
+    }: InsertVectorDataArgs): Promise<any> {
+        const pointsToUpsert = points || [{ id, vector, payload }];
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collectionName)}/points`,
+            query: this.queryFromOptions(queryOptions),
+            body: {
+                points: pointsToUpsert.map((point) => this.cleanObject(point)),
+            },
+        });
+    }
+
+    async getDataFromQuery({
+        client,
+        collectionName,
+        scoreThreshold,
+        withPayload,
+        withVector,
+        lookupFrom,
+        shardKey,
+        consistency,
+        timeout,
+        wait,
+        ordering,
+        ...args
+    }: GetDataFromQueryArgs): Promise<any> {
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collectionName)}/points/query`,
+            query: this.queryFromOptions({ consistency, timeout, wait, ordering }),
+            body: this.cleanObject({
+                ...args,
+                score_threshold: scoreThreshold,
+                with_payload: withPayload,
+                with_vector: withVector,
+                lookup_from: lookupFrom,
+                shard_key: shardKey,
+            }),
+        });
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        ids,
+        id,
+        withPayload,
+        withVector,
+        shardKey,
+        ...queryOptions
+    }: GetDataByIdArgs): Promise<any> {
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collectionName)}/points`,
+            query: this.queryFromOptions(queryOptions),
+            body: this.cleanObject({
+                ids: ids || [id],
+                with_payload: withPayload,
+                with_vector: withVector,
+                shard_key: shardKey,
+            }),
+        });
+    }
+
+    async updateById({ client, collectionName, id, vector, payload, ...queryOptions }: UpdateByIdArgs) {
+        return this.insertVectorData({
+            client,
+            collectionName,
+            points: [{ id, vector, payload }],
+            ...queryOptions,
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        ids,
+        id,
+        filter,
+        shardKey,
+        ...queryOptions
+    }: DeleteByIdArgs): Promise<any> {
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collectionName)}/points/delete`,
+            query: this.queryFromOptions(queryOptions),
+            body: this.cleanObject({
+                points: ids || (id !== undefined ? [id] : undefined),
+                filter,
+                shard_key: shardKey,
+            }),
+        });
+    }
+
+    private async request({
+        client,
+        method,
+        path,
+        query,
+        body,
+    }: {
+        client: QdrantClient;
+        method: string;
+        path: string;
+        query?: URLSearchParams;
+        body?: unknown;
+    }): Promise<any> {
+        const queryString = query?.toString();
+        const response = await fetch(`${client.url}${path}${queryString ? `?${queryString}` : ""}`, {
+            method,
+            headers: this.cleanObject({
+                "Content-Type": "application/json",
+                "api-key": client.apiKey,
+            }) as HeadersInit,
+            body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        const responseBody = await response.json().catch(() => undefined);
+
+        if (!response.ok || responseBody?.status === "error") {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(responseBody)}`
+            );
+        }
+
+        return responseBody?.result ?? responseBody;
+    }
+
+    private queryFromOptions(options: QdrantRequestOptions): URLSearchParams {
+        const query = new URLSearchParams();
+        const queryMap: Record<string, unknown> = {
+            consistency: options.consistency,
+            timeout: options.timeout,
+            wait: options.wait,
+            ordering: options.ordering,
+        };
+
+        Object.entries(queryMap).forEach(([key, value]) => {
+            if (value !== undefined) {
+                query.set(key, String(value));
+            }
+        });
+
+        return query;
+    }
+
+    private cleanObject<T extends Record<string, unknown>>(value: T): T {
+        return Object.fromEntries(
+            Object.entries(value).filter(([, entryValue]) => entryValue !== undefined)
+        ) as T;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../index.js";
+
+const jsonResponse = (body: unknown, init?: ResponseInit) =>
+    new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        ...init,
+    });
+
+describe("Qdrant", () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        vi.stubGlobal("fetch", fetchMock);
+        fetchMock.mockResolvedValue(jsonResponse({ status: "ok", result: {} }));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.clearAllMocks();
+    });
+
+    it("upserts vector points into a collection", async () => {
+        const qdrant = new Qdrant("http://localhost:6333", "api-key");
+        const client = qdrant.createClient();
+
+        await qdrant.insertVectorData({
+            client,
+            collectionName: "documents",
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+            wait: true,
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "http://localhost:6333/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                    "api-key": "api-key",
+                }),
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: 1,
+                            vector: [0.1, 0.2, 0.3],
+                            payload: { content: "hello" },
+                        },
+                    ],
+                }),
+            })
+        );
+    });
+
+    it("queries vector points from a collection", async () => {
+        fetchMock.mockResolvedValueOnce(
+            jsonResponse({
+                status: "ok",
+                result: {
+                    points: [{ id: 1, score: 0.9, payload: { content: "hello" } }],
+                },
+            })
+        );
+        const qdrant = new Qdrant("http://localhost:6333", "api-key");
+        const client = qdrant.createClient();
+
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "documents",
+            query: [0.1, 0.2, 0.3],
+            limit: 1,
+            withPayload: true,
+        });
+
+        expect(result).toEqual({
+            points: [{ id: 1, score: 0.9, payload: { content: "hello" } }],
+        });
+        expect(fetchMock).toHaveBeenCalledWith(
+            "http://localhost:6333/collections/documents/points/query",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    query: [0.1, 0.2, 0.3],
+                    limit: 1,
+                    with_payload: true,
+                }),
+            })
+        );
+    });
+});


### PR DESCRIPTION
/claim #273

Resolves #273

## Summary

- Adds a `Qdrant` vector database client to `@arakoodev/edgechains.js/vector-db`.
- Supports creating collections, upserting vector points, querying by vector, fetching points by id, updating points, and deleting points through Qdrant's HTTP API.
- Exports `Qdrant`, `QdrantClient`, and `QdrantPoint` from the vector-db package entrypoint.
- Documents basic Qdrant usage in the package README.

## Validation

- `npm.cmd test -- src/vector-db/src/tests/qdrant/qdrant.test.ts --run`
- `npx.cmd tsc -b`

## Notes

The full `src/vector-db/src/tests` suite currently fails on existing Supabase tests because those tests use global `jest` APIs while the package test script runs `vitest`. The new Qdrant tests pass independently and do not require a live Qdrant service because `fetch` is mocked.
