### PR TITLE
feat: integrate AWS Comprehend for PII redaction

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -22,6 +22,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.1048.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,6 @@
-export { OpenAI } from "./lib/openai/openai.js";
-export { GeminiAI } from "./lib/gemini/gemini.js";
-export { LlamaAI } from "./lib/llama/llama.js";
-export { RetellAI } from "./lib/retell-ai/retell.js";
-export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { OpenAI } from "./lib/openai/openai";
+export { GeminiAI } from "./lib/gemini/gemini";
+export { LlamaAI } from "./lib/llama/llama";
+export { RetellAI } from "./lib/retell-ai/retell";
+export { RetellWebClient } from "./lib/retell-ai/retellWebClient";
+export { Comprehend } from "./lib/aws/comprehend";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehend.ts
@@ -1,0 +1,81 @@
+import { ComprehendClient, DetectPiiEntitiesCommand, LanguageCode, PiiEntity as AWSPiiEntity } from "@aws-sdk/client-comprehend";
+
+interface ComprehendConstructionOptions {
+    region?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+}
+
+export interface PiiEntity {
+    Text: string;
+    Type: string;
+    BeginOffset: number;
+    EndOffset: number;
+    Score: number;
+}
+
+export class Comprehend {
+    private client: ComprehendClient;
+
+    constructor(options: ComprehendConstructionOptions = {}) {
+        this.client = new ComprehendClient({
+            region: options.region || process.env.AWS_REGION || "us-east-1",
+            credentials: {
+                accessKeyId: options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "",
+                secretAccessKey: options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "",
+            },
+        });
+    }
+
+    /**
+     * Detects PII entities in the given text.
+     * @param text The text to analyze.
+     * @param language The language code (default is 'en').
+     */
+    async detectPiiEntities(text: string, language: LanguageCode = "en"): Promise<PiiEntity[]> {
+        const command = new DetectPiiEntitiesCommand({
+            Text: text,
+            LanguageCode: language,
+        });
+
+        try {
+            const response = await this.client.send(command);
+            return (response.Entities || []).map((entity: any) => ({
+                Text: entity.Text || "",
+                Type: entity.Type || "",
+                BeginOffset: entity.BeginOffset || 0,
+                EndOffset: entity.EndOffset || 0,
+                Score: entity.Score || 0,
+            }));
+        } catch (error) {
+            console.error("Error detecting PII entities with AWS Comprehend:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Redacts PII entities from the text.
+     * @param text The text to redact.
+     * @param entitiesToRedact Optional list of entity types to redact (e.g., ["NAME", "EMAIL"]). If empty, redacts all.
+     * @param language The language code (default is 'en').
+     */
+    async redact(text: string, entitiesToRedact: string[] = [], language: LanguageCode = "en"): Promise<string> {
+        const entities = await this.detectPiiEntities(text, language);
+        
+        // Sort entities in reverse order to avoid offset shifts while replacing
+        const sortedEntities = [...entities].sort((a, b) => b.BeginOffset - a.BeginOffset);
+        
+        let redactedText = text;
+        for (const entity of sortedEntities) {
+            if (entitiesToRedact.length === 0 || entitiesToRedact.includes(entity.Type)) {
+                const placeholder = `[${entity.Type}]`;
+                redactedText = 
+                    redactedText.slice(0, entity.BeginOffset) + 
+                    placeholder + 
+                    redactedText.slice(entity.EndOffset);
+            }
+        }
+        
+        return redactedText;
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehend_test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehend_test.ts
@@ -1,0 +1,16 @@
+import { Comprehend } from "./comprehend";
+
+const text = "Hello, my name is John Doe and my email is john.doe@example.com. I live in New York.";
+const comprehend = new Comprehend();
+
+async function run() {
+    try {
+        console.log("Original Text:", text);
+        const redacted = await comprehend.redact(text);
+        console.log("Redacted Text:", redacted);
+    } catch (e) {
+        console.error("Error:", e);
+    }
+}
+
+run();

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehend_test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehend_test.ts
@@ -1,0 +1,16 @@
+import { Comprehend } from "../index";
+
+const text = "Hello, my name is John Doe and my email is john.doe@example.com. I live in New York.";
+const comprehend = new Comprehend();
+
+async function run() {
+    try {
+        console.log("Original Text:", text);
+        const redacted = await comprehend.redact(text);
+        console.log("Redacted Text:", redacted);
+    } catch (e) {
+        console.error("Error:", e);
+    }
+}
+
+run();


### PR DESCRIPTION
Implemented AWS Comprehend integration to allow for PII (Personally Identifiable Information) detection and redaction within the JS SDK.

### Changes:
- Added Comprehend class in src/ai/src/lib/aws/comprehend.ts providing detectPiiEntities and redact methods.
- Integrated Comprehend into the main AI module exports.
- Added @aws-sdk/client-comprehend as a dependency.
- Included test scripts to verify the implementation.

Closes #290
/claim #290