### PR TITLE
feat: add AWS Comprehend PII redactor

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -33,6 +33,7 @@
         "cheerio": "^1.0.0-rc.12",
         "cors": "^2.8.5",
         "document": "^0.4.7",
+        "dotenv": "^16.4.5",
         "dts-bundle-generator": "^9.3.1",
         "esbuild": "^0.20.2",
         "hono": "3.9",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,14 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
+export {
+    AwsComprehendRedactor,
+    type AwsComprehendRedactorOptions,
+    type ComprehendClientLike,
+    type ComprehendPiiEntity,
+    type DetectPiiEntitiesInput,
+    type DetectPiiEntitiesResponse,
+    type PiiEntityType,
+} from "./lib/aws-comprehend/awsComprehendRedactor.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
@@ -1,0 +1,140 @@
+export type PiiEntityType =
+    | "BANK_ACCOUNT_NUMBER"
+    | "BANK_ROUTING"
+    | "CREDIT_DEBIT_NUMBER"
+    | "CREDIT_DEBIT_CVV"
+    | "CREDIT_DEBIT_EXPIRY"
+    | "PIN"
+    | "EMAIL"
+    | "ADDRESS"
+    | "NAME"
+    | "PHONE"
+    | "SSN"
+    | "DATE_TIME"
+    | "PASSPORT_NUMBER"
+    | "DRIVER_ID"
+    | "URL"
+    | "AGE"
+    | "USERNAME"
+    | "PASSWORD"
+    | "AWS_ACCESS_KEY"
+    | "AWS_SECRET_KEY"
+    | "IP_ADDRESS"
+    | "MAC_ADDRESS"
+    | "ALL";
+
+export interface ComprehendPiiEntity {
+    Type?: PiiEntityType | string;
+    Score?: number;
+    BeginOffset?: number;
+    EndOffset?: number;
+}
+
+export interface DetectPiiEntitiesResponse {
+    Entities?: ComprehendPiiEntity[];
+}
+
+export interface DetectPiiEntitiesInput {
+    Text: string;
+    LanguageCode: string;
+}
+
+export interface ComprehendClientLike {
+    detectPiiEntities?: (input: DetectPiiEntitiesInput) => Promise<DetectPiiEntitiesResponse>;
+    send?: (command: unknown) => Promise<DetectPiiEntitiesResponse>;
+}
+
+export interface AwsComprehendRedactorOptions {
+    client: ComprehendClientLike;
+    detectPiiEntitiesCommand?: new (input: DetectPiiEntitiesInput) => unknown;
+    languageCode?: string;
+    minScore?: number;
+    replacement?: string | ((entity: ComprehendPiiEntity, value: string) => string);
+}
+
+export class AwsComprehendRedactor {
+    private client: ComprehendClientLike;
+    private detectPiiEntitiesCommand?: new (input: DetectPiiEntitiesInput) => unknown;
+    private languageCode: string;
+    private minScore: number;
+    private replacement: string | ((entity: ComprehendPiiEntity, value: string) => string);
+
+    constructor(options: AwsComprehendRedactorOptions) {
+        this.client = options.client;
+        this.detectPiiEntitiesCommand = options.detectPiiEntitiesCommand;
+        this.languageCode = options.languageCode || "en";
+        this.minScore = options.minScore ?? 0;
+        this.replacement = options.replacement || ((entity) => `[${entity.Type || "PII"}]`);
+    }
+
+    async redact(text: string): Promise<string> {
+        if (!text) {
+            return text;
+        }
+
+        const response = await this.detectPiiEntities(text);
+        const entities = (response.Entities || [])
+            .filter((entity) => {
+                return (
+                    typeof entity.BeginOffset === "number" &&
+                    typeof entity.EndOffset === "number" &&
+                    entity.BeginOffset < entity.EndOffset &&
+                    (entity.Score ?? 1) >= this.minScore
+                );
+            })
+            .sort((a, b) => (b.BeginOffset || 0) - (a.BeginOffset || 0));
+
+        return entities.reduce((redactedText, entity) => {
+            const start = entity.BeginOffset || 0;
+            const end = entity.EndOffset || 0;
+            const value = redactedText.slice(start, end);
+            const replacement =
+                typeof this.replacement === "function"
+                    ? this.replacement(entity, value)
+                    : this.replacement;
+
+            return redactedText.slice(0, start) + replacement + redactedText.slice(end);
+        }, text);
+    }
+
+    async redactPrompt<T extends { prompt?: string; messages?: Array<{ content?: string }> }>(
+        promptOptions: T
+    ): Promise<T> {
+        const clonedOptions = {
+            ...promptOptions,
+            messages: promptOptions.messages
+                ? await Promise.all(
+                      promptOptions.messages.map(async (message) => ({
+                          ...message,
+                          content: message.content ? await this.redact(message.content) : message.content,
+                      }))
+                  )
+                : promptOptions.messages,
+        };
+
+        if (promptOptions.prompt) {
+            clonedOptions.prompt = await this.redact(promptOptions.prompt);
+        }
+
+        return clonedOptions;
+    }
+
+    private async detectPiiEntities(text: string): Promise<DetectPiiEntitiesResponse> {
+        const input = {
+            Text: text,
+            LanguageCode: this.languageCode,
+        };
+
+        if (this.client.detectPiiEntities) {
+            return this.client.detectPiiEntities(input);
+        }
+
+        if (this.client.send && this.detectPiiEntitiesCommand) {
+            return this.client.send(new this.detectPiiEntitiesCommand(input));
+        }
+
+        throw new Error(
+            "AwsComprehendRedactor requires either client.detectPiiEntities or client.send with detectPiiEntitiesCommand"
+        );
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/awsComprehendRedactor.test.ts
@@ -1,0 +1,46 @@
+import { AwsComprehendRedactor } from "../../lib/aws-comprehend/awsComprehendRedactor.js";
+
+describe("AwsComprehendRedactor", () => {
+    test("redacts detected PII entities", async () => {
+        const redactor = new AwsComprehendRedactor({
+            client: {
+                detectPiiEntities: async () => ({
+                    Entities: [
+                        {
+                            Type: "EMAIL",
+                            Score: 0.99,
+                            BeginOffset: 14,
+                            EndOffset: 30,
+                        },
+                    ],
+                }),
+            },
+        });
+
+        await expect(redactor.redact("Contact me at me@example.com")).resolves.toEqual(
+            "Contact me at [EMAIL]"
+        );
+    });
+
+    test("redacts prompt options for endpoint chaining", async () => {
+        const redactor = new AwsComprehendRedactor({
+            client: {
+                detectPiiEntities: async () => ({
+                    Entities: [
+                        {
+                            Type: "PHONE",
+                            Score: 0.99,
+                            BeginOffset: 5,
+                            EndOffset: 17,
+                        },
+                    ],
+                }),
+            },
+        });
+
+        await expect(redactor.redactPrompt({ prompt: "Call 415-555-1212" })).resolves.toEqual({
+            prompt: "Call [PHONE]",
+            messages: undefined,
+        });
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,12 @@
+# AWS Comprehend PII Redaction
+
+This example redacts PII from a prompt before sending it to an LLM endpoint.
+
+## Setup
+
+```sh
+pnpm install
+AWS_REGION=us-east-1 OPENAI_API_KEY=... OPENAI_ORG_ID=... pnpm start
+```
+
+The AWS credentials are loaded through the standard AWS SDK credential chain.

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "aws-comprehend-redaction-example",
+    "version": "0.0.1",
+    "type": "module",
+    "scripts": {
+        "start": "ts-node src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "latest",
+        "@aws-sdk/client-comprehend": "^3.699.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+    },
+    "devDependencies": {
+        "@types/node": "^20.17.2"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,26 @@
+import {
+    ComprehendClient,
+    DetectPiiEntitiesCommand,
+} from "@aws-sdk/client-comprehend";
+import { AwsComprehendRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+const comprehend = new ComprehendClient({
+    region: process.env.AWS_REGION || "us-east-1",
+});
+
+const redactor = new AwsComprehendRedactor({
+    client: comprehend,
+    detectPiiEntitiesCommand: DetectPiiEntitiesCommand,
+});
+
+const openAI = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    orgId: process.env.OPENAI_ORG_ID,
+});
+
+const promptOptions = await redactor.redactPrompt({
+    prompt: "Summarize this customer message: email me@example.com called from 415-555-1212",
+});
+
+const response = await openAI.chat(promptOptions);
+console.log(response.content);

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true
+    }
+}


### PR DESCRIPTION
## Summary
- add `AwsComprehendRedactor` for redacting AWS Comprehend PII entities before sending prompts/messages to LLM endpoints
- export the redactor and related TypeScript types from the AI package
- add tests for redacting raw text and prompt options
- add an AWS Comprehend redaction example
- add missing `dotenv` dependency used by the existing package build

## Verification
- `pnpm install --no-frozen-lockfile`
- `pnpm run build` passes locally
- `pnpm exec vitest run src/ai/src/tests/aws-comprehend/awsComprehendRedactor.test.ts` could not start locally because macOS rejected Rollup's native optional dependency code signature in this environment

Closes #290