### PR TITLE
feat(ai): add palm2 client

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,6 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,97 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+
+const defaultBaseUrl = "https://generativelanguage.googleapis.com/v1beta2";
+
+interface Palm2ConstructionOptions {
+    apiKey?: string;
+    baseUrl?: string;
+}
+
+type Palm2SafetyCategory =
+    | "HARM_CATEGORY_DEROGATORY"
+    | "HARM_CATEGORY_TOXICITY"
+    | "HARM_CATEGORY_VIOLENCE"
+    | "HARM_CATEGORY_SEXUAL"
+    | "HARM_CATEGORY_MEDICAL"
+    | "HARM_CATEGORY_DANGEROUS";
+
+type Palm2SafetyThreshold =
+    | "BLOCK_NONE"
+    | "BLOCK_ONLY_HIGH"
+    | "BLOCK_MEDIUM_AND_ABOVE"
+    | "BLOCK_LOW_AND_ABOVE";
+
+interface Palm2SafetySetting {
+    category: Palm2SafetyCategory;
+    threshold: Palm2SafetyThreshold;
+}
+
+interface Palm2TextOptions {
+    model?: string;
+    prompt: string;
+    temperature?: number;
+    maxOutputTokens?: number;
+    topP?: number;
+    topK?: number;
+    candidateCount?: number;
+    safetySettings?: Palm2SafetySetting[];
+    max_retry?: number;
+    delay?: number;
+}
+
+interface Palm2Candidate {
+    output: string;
+    safetyRatings?: Array<{
+        category: Palm2SafetyCategory;
+        probability: string;
+    }>;
+}
+
+interface Palm2TextResponse {
+    candidates: Palm2Candidate[];
+}
+
+export class Palm2AI {
+    apiKey: string;
+    baseUrl: string;
+
+    constructor(options: Palm2ConstructionOptions = {}) {
+        this.apiKey = options.apiKey || process.env.PALM_API_KEY || "";
+        this.baseUrl = (options.baseUrl || defaultBaseUrl).replace(/\/$/, "");
+    }
+
+    async generateText(options: Palm2TextOptions): Promise<Palm2TextResponse> {
+        const model = options.model || "text-bison-001";
+        const url = `${this.baseUrl}/models/${model}:generateText?key=${this.apiKey}`;
+        const data = {
+            prompt: {
+                text: options.prompt,
+            },
+            temperature: options.temperature ?? 0.7,
+            maxOutputTokens: options.maxOutputTokens ?? 1024,
+            topP: options.topP,
+            topK: options.topK,
+            candidateCount: options.candidateCount,
+            safetySettings: options.safetySettings,
+        };
+
+        return await retry(
+            async () => {
+                return (
+                    await axios.post(url, data, {
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                    })
+                ).data;
+            },
+            { maxAttempts: options.max_retry || 3, delay: options.delay || 200 }
+        );
+    }
+
+    async chat(options: Palm2TextOptions): Promise<Palm2Candidate> {
+        const response = await this.generateText(options);
+        return response.candidates[0];
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
@@ -1,0 +1,66 @@
+import axios from "axios";
+
+import { Palm2AI } from "../../lib/palm2/palm2.js";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Palm2AI", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("generates text with the Palm2 REST API", async () => {
+        mockedAxios.post.mockResolvedValueOnce({
+            data: {
+                candidates: [{ output: "hello from palm2" }],
+            },
+        });
+
+        const palm2 = new Palm2AI({
+            apiKey: "test-key",
+            baseUrl: "https://generativelanguage.googleapis.com/v1beta2",
+        });
+
+        const response = await palm2.generateText({
+            prompt: "Say hello",
+            temperature: 0.2,
+            maxOutputTokens: 64,
+        });
+
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            "https://generativelanguage.googleapis.com/v1beta2/models/text-bison-001:generateText?key=test-key",
+            {
+                prompt: {
+                    text: "Say hello",
+                },
+                temperature: 0.2,
+                maxOutputTokens: 64,
+                topP: undefined,
+                topK: undefined,
+                candidateCount: undefined,
+                safetySettings: undefined,
+            },
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            }
+        );
+        expect(response.candidates[0].output).toBe("hello from palm2");
+    });
+
+    test("returns the first candidate from chat", async () => {
+        mockedAxios.post.mockResolvedValueOnce({
+            data: {
+                candidates: [{ output: "first candidate" }],
+            },
+        });
+
+        const palm2 = new Palm2AI({ apiKey: "test-key" });
+        const response = await palm2.chat({ prompt: "Pick one" });
+
+        expect(response.output).toBe("first candidate");
+    });
+});

--- a/JS/edgechains/examples/palm2/README.md
+++ b/JS/edgechains/examples/palm2/README.md
@@ -1,0 +1,7 @@
+# Palm2 Example
+
+This example uses Jsonnet for prompts and secrets, then calls the JavaScript SDK Palm2 class.
+
+1. Add your API key in `jsonnet/secrets.jsonnet`.
+2. Edit the prompt in `jsonnet/main.jsonnet`.
+3. Run the example after installing dependencies.

--- a/JS/edgechains/examples/palm2/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2/jsonnet/main.jsonnet
@@ -1,0 +1,5 @@
+{
+  prompt: 'Write a two sentence explanation of why Jsonnet is useful for AI application config.',
+  temperature: 0.2,
+  max_output_tokens: 128,
+}

--- a/JS/edgechains/examples/palm2/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2/jsonnet/secrets.jsonnet
@@ -1,0 +1,3 @@
+{
+  palm_api_key: 'YOUR_PALM_API_KEY',
+}

--- a/JS/edgechains/examples/palm2/package.json
+++ b/JS/edgechains/examples/palm2/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "palm2-example",
+    "version": "0.0.1",
+    "scripts": {
+        "start": "ts-node src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "*",
+        "@arakoodev/jsonnet": "^0.25.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/palm2/src/index.ts
+++ b/JS/edgechains/examples/palm2/src/index.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+
+import Jsonnet from "@arakoodev/jsonnet";
+import { Palm2AI } from "@arakoodev/edgechains.js/ai";
+
+const jsonnet = new Jsonnet();
+const config = JSON.parse(jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet")));
+const secrets = JSON.parse(jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet")));
+
+async function main() {
+    const palm2 = new Palm2AI({ apiKey: secrets.palm_api_key });
+    const response = await palm2.chat({
+        prompt: config.prompt,
+        temperature: config.temperature,
+        maxOutputTokens: config.max_output_tokens,
+    });
+
+    console.log(response.output);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/JS/edgechains/examples/palm2/tsconfig.json
+++ b/JS/edgechains/examples/palm2/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "exclude": ["./jsonnet"]
+}


### PR DESCRIPTION
Fixes #279.\n\nAdds a Palm2AI class for the JavaScript/TypeScript SDK, including typed generateText/chat options, mocked unit tests under a palm2 test folder, and a Jsonnet-based example under examples/palm2.\n\nVerification: static inspection completed; dependency-backed test run is blocked by npm registry certificate validation failure on this machine.