### PR TITLE
feat(vector-db): add qdrant client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,156 @@
+import axios, { AxiosRequestConfig } from "axios";
+import { config } from "dotenv";
+config();
+
+type QdrantVector = number[];
+type QdrantPayload = Record<string, unknown>;
+
+interface QdrantPoint {
+    id: string | number;
+    vector: QdrantVector;
+    payload?: QdrantPayload;
+}
+
+interface QdrantCollectionOptions {
+    collectionName: string;
+    vectorSize: number;
+    distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+}
+
+interface QdrantSearchOptions {
+    collectionName: string;
+    vector: QdrantVector;
+    limit?: number;
+    filter?: QdrantPayload;
+    withPayload?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    private requestConfig(): AxiosRequestConfig {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        return { headers };
+    }
+
+    private collectionUrl(collectionName: string, path = ""): string {
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required to use the Qdrant vector database client.");
+        }
+
+        return `${this.QDRANT_URL}/collections/${collectionName}${path}`;
+    }
+
+    async createCollection({
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: QdrantCollectionOptions): Promise<any> {
+        const response = await axios.put(
+            this.collectionUrl(collectionName),
+            {
+                vectors: {
+                    size: vectorSize,
+                    distance,
+                },
+            },
+            this.requestConfig()
+        );
+
+        return response.data;
+    }
+
+    async insertVectorData({
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        const response = await axios.put(
+            this.collectionUrl(collectionName, `/points?wait=${wait}`),
+            { points },
+            this.requestConfig()
+        );
+
+        return response.data;
+    }
+
+    async search({
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+    }: QdrantSearchOptions): Promise<any> {
+        const response = await axios.post(
+            this.collectionUrl(collectionName, "/points/search"),
+            {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+            },
+            this.requestConfig()
+        );
+
+        return response.data;
+    }
+
+    async getDataById({
+        collectionName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: {
+        collectionName: string;
+        id: string | number;
+        withPayload?: boolean;
+        withVector?: boolean;
+    }): Promise<any> {
+        const response = await axios.get(
+            this.collectionUrl(
+                collectionName,
+                `/points/${id}?with_payload=${withPayload}&with_vector=${withVector}`
+            ),
+            this.requestConfig()
+        );
+
+        return response.data;
+    }
+
+    async deleteById({
+        collectionName,
+        ids,
+        wait = true,
+    }: {
+        collectionName: string;
+        ids: Array<string | number>;
+        wait?: boolean;
+    }): Promise<any> {
+        const response = await axios.post(
+            this.collectionUrl(collectionName, `/points/delete?wait=${wait}`),
+            {
+                points: ids,
+            },
+            this.requestConfig()
+        );
+
+        return response.data;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,105 @@
+import axios from "axios";
+
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Qdrant", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("creates a collection through the Qdrant REST API", async () => {
+        mockedAxios.put.mockResolvedValueOnce({ data: { result: true } });
+        const qdrant = new Qdrant("https://qdrant.example", "test-key");
+
+        const result = await qdrant.createCollection({
+            collectionName: "documents",
+            vectorSize: 1536,
+        });
+
+        expect(mockedAxios.put).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents",
+            {
+                vectors: {
+                    size: 1536,
+                    distance: "Cosine",
+                },
+            },
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                    "api-key": "test-key",
+                },
+            }
+        );
+        expect(result).toEqual({ result: true });
+    });
+
+    test("upserts vector points without using a qdrant package", async () => {
+        mockedAxios.put.mockResolvedValueOnce({ data: { status: "ok" } });
+        const qdrant = new Qdrant("https://qdrant.example");
+
+        await qdrant.insertVectorData({
+            collectionName: "documents",
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+        });
+
+        expect(mockedAxios.put).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents/points?wait=true",
+            {
+                points: [
+                    {
+                        id: 1,
+                        vector: [0.1, 0.2, 0.3],
+                        payload: { content: "hello" },
+                    },
+                ],
+            },
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            }
+        );
+    });
+
+    test("searches vectors with payloads", async () => {
+        mockedAxios.post.mockResolvedValueOnce({
+            data: {
+                result: [{ id: 1, score: 0.98, payload: { content: "hello" } }],
+            },
+        });
+        const qdrant = new Qdrant("https://qdrant.example");
+
+        const result = await qdrant.search({
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+        });
+
+        expect(mockedAxios.post).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents/points/search",
+            {
+                vector: [0.1, 0.2, 0.3],
+                limit: 3,
+                filter: undefined,
+                with_payload: true,
+            },
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            }
+        );
+        expect(result.result[0].score).toBe(0.98);
+    });
+});


### PR DESCRIPTION
Fixes #273.\n\nAdds Qdrant vector database support to the JavaScript SDK using Qdrant REST APIs directly through the existing axios dependency, without adding a qdrant package.\n\nIncluded methods: createCollection, insertVectorData, search, getDataById, and deleteById. Added mocked tests for collection creation, upsert, and search request payloads.\n\nVerification: dependency-backed test run was attempted locally but npm registry certificate validation failed on this machine.