### PR TITLE
feat(ai): add Comprehend redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,14 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { ComprehendRedactor } from "./lib/aws-comprehend/comprehendRedactor.js";
+export type {
+    AwsComprehendClientLike,
+    ComprehendDetector,
+    ComprehendPiiEntity,
+    ComprehendRedactorOptions,
+    DetectPiiEntitiesInput,
+    DetectPiiEntitiesResponse,
+    RedactOptions,
+    RedactResult,
+} from "./lib/aws-comprehend/comprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehendRedactor.ts
@@ -1,0 +1,192 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+export interface ComprehendPiiEntity {
+    Type?: string;
+    BeginOffset?: number;
+    EndOffset?: number;
+    Score?: number;
+}
+
+export interface DetectPiiEntitiesResponse {
+    Entities?: ComprehendPiiEntity[];
+}
+
+export interface DetectPiiEntitiesInput {
+    Text: string;
+    LanguageCode: string;
+}
+
+export type ComprehendDetector = (
+    input: DetectPiiEntitiesInput
+) => Promise<DetectPiiEntitiesResponse>;
+
+export interface AwsComprehendClientLike {
+    detectPiiEntities?: (
+        input: DetectPiiEntitiesInput
+    ) => Promise<DetectPiiEntitiesResponse> | { promise: () => Promise<DetectPiiEntitiesResponse> };
+    send?: (command: unknown) => Promise<DetectPiiEntitiesResponse>;
+}
+
+export interface ComprehendRedactorOptions {
+    client?: AwsComprehendClientLike;
+    detector?: ComprehendDetector;
+    commandConstructor?: new (input: DetectPiiEntitiesInput) => unknown;
+    languageCode?: string;
+    minScore?: number;
+    replacementText?: string;
+    replacementFormatter?: (entity: ComprehendPiiEntity) => string;
+}
+
+export interface RedactOptions {
+    languageCode?: string;
+    minScore?: number;
+    replacementText?: string;
+    replacementFormatter?: (entity: ComprehendPiiEntity) => string;
+}
+
+export interface RedactResult {
+    text: string;
+    entities: ComprehendPiiEntity[];
+}
+
+type PiiRange = Required<Pick<ComprehendPiiEntity, "BeginOffset" | "EndOffset">> &
+    ComprehendPiiEntity;
+
+export class ComprehendRedactor {
+    private readonly client?: AwsComprehendClientLike;
+    private readonly detector?: ComprehendDetector;
+    private readonly commandConstructor?: new (input: DetectPiiEntitiesInput) => unknown;
+    private readonly languageCode: string;
+    private readonly minScore: number;
+    private readonly replacementText?: string;
+    private readonly replacementFormatter?: (entity: ComprehendPiiEntity) => string;
+
+    constructor(options: ComprehendRedactorOptions = {}) {
+        this.client = options.client;
+        this.detector = options.detector;
+        this.commandConstructor = options.commandConstructor;
+        this.languageCode = options.languageCode || "en";
+        this.minScore = options.minScore ?? 0;
+        this.replacementText = options.replacementText;
+        this.replacementFormatter = options.replacementFormatter;
+
+        if (!this.detector && !this.client) {
+            throw new Error("ComprehendRedactor requires either a detector or a Comprehend client.");
+        }
+    }
+
+    async redactText(text: string, options: RedactOptions = {}): Promise<RedactResult> {
+        const response = await this.detect({
+            Text: text,
+            LanguageCode: options.languageCode || this.languageCode,
+        });
+        const minScore = options.minScore ?? this.minScore;
+        const entities = this.validRanges(response.Entities || [], text.length, minScore);
+        const redactedText = this.applyRedactions(text, entities, options);
+
+        return {
+            text: redactedText,
+            entities,
+        };
+    }
+
+    async redactFile(
+        inputPath: string,
+        outputPath: string,
+        options: RedactOptions = {}
+    ): Promise<RedactResult> {
+        const text = await readFile(inputPath, "utf8");
+        const result = await this.redactText(text, options);
+        await writeFile(outputPath, result.text, "utf8");
+
+        return result;
+    }
+
+    private async detect(input: DetectPiiEntitiesInput): Promise<DetectPiiEntitiesResponse> {
+        if (this.detector) {
+            return this.detector(input);
+        }
+
+        if (this.client?.detectPiiEntities) {
+            const response = this.client.detectPiiEntities(input);
+            if ("promise" in response) {
+                return response.promise();
+            }
+
+            return response;
+        }
+
+        if (this.client?.send) {
+            const command = this.commandConstructor ? new this.commandConstructor(input) : input;
+            return this.client.send(command);
+        }
+
+        throw new Error("ComprehendRedactor could not find a supported Comprehend API.");
+    }
+
+    private validRanges(
+        entities: ComprehendPiiEntity[],
+        textLength: number,
+        minScore: number
+    ): PiiRange[] {
+        return entities
+            .filter((entity): entity is PiiRange => {
+                const begin = entity.BeginOffset;
+                const end = entity.EndOffset;
+                const score = entity.Score ?? 1;
+
+                return (
+                    typeof begin === "number" &&
+                    typeof end === "number" &&
+                    Number.isInteger(begin) &&
+                    Number.isInteger(end) &&
+                    begin >= 0 &&
+                    end > begin &&
+                    end <= textLength &&
+                    score >= minScore
+                );
+            })
+            .sort((left, right) => left.BeginOffset - right.BeginOffset);
+    }
+
+    private applyRedactions(text: string, entities: PiiRange[], options: RedactOptions): string {
+        const occupiedRanges: PiiRange[] = [];
+        let redacted = text;
+
+        for (const entity of [...entities].sort((left, right) => right.BeginOffset - left.BeginOffset)) {
+            if (occupiedRanges.some((range) => this.overlaps(entity, range))) {
+                continue;
+            }
+
+            redacted =
+                redacted.slice(0, entity.BeginOffset) +
+                this.replacementFor(entity, options) +
+                redacted.slice(entity.EndOffset);
+            occupiedRanges.push(entity);
+        }
+
+        return redacted;
+    }
+
+    private overlaps(left: PiiRange, right: PiiRange): boolean {
+        return left.BeginOffset < right.EndOffset && right.BeginOffset < left.EndOffset;
+    }
+
+    private replacementFor(entity: ComprehendPiiEntity, options: RedactOptions): string {
+        const formatter = options.replacementFormatter || this.replacementFormatter;
+
+        if (formatter) {
+            return formatter(entity);
+        }
+
+        const replacementText = options.replacementText ?? this.replacementText;
+        if (replacementText !== undefined) {
+            return replacementText;
+        }
+
+        const type = String(entity.Type || "PII")
+            .replace(/[^a-z0-9_]/gi, "_")
+            .toUpperCase();
+        return `[${type}]`;
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/comprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/comprehendRedactor.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "vitest";
+import { ComprehendRedactor } from "../../lib/aws-comprehend/comprehendRedactor.js";
+
+describe("ComprehendRedactor", () => {
+    test("redacts PII detected by AWS Comprehend", async () => {
+        const redactor = new ComprehendRedactor({
+            detector: async () => ({
+                Entities: [
+                    { Type: "NAME", BeginOffset: 0, EndOffset: 10, Score: 0.99 },
+                    { Type: "EMAIL", BeginOffset: 29, EndOffset: 42, Score: 0.98 },
+                ],
+            }),
+        });
+
+        const result = await redactor.redactText("Jane Smith can be emailed at jane@test.com.");
+
+        expect(result.text).toEqual("[NAME] can be emailed at [EMAIL].");
+        expect(result.entities).toHaveLength(2);
+    });
+
+    test("supports score thresholds and custom replacement text", async () => {
+        const redactor = new ComprehendRedactor({
+            detector: async () => ({
+                Entities: [
+                    { Type: "NAME", BeginOffset: 0, EndOffset: 4, Score: 0.7 },
+                    { Type: "EMAIL", BeginOffset: 14, EndOffset: 27, Score: 0.96 },
+                ],
+            }),
+            minScore: 0.9,
+            replacementText: "[REDACTED]",
+        });
+
+        const result = await redactor.redactText("Jane wrote to jane@test.com");
+
+        expect(result.text).toEqual("Jane wrote to [REDACTED]");
+        expect(result.entities).toHaveLength(1);
+    });
+
+    test("redacts files", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "edgechains-comprehend-"));
+        const inputPath = join(directory, "input.txt");
+        const outputPath = join(directory, "output.txt");
+
+        try {
+            await writeFile(inputPath, "Call me at 206-555-0101", "utf8");
+
+            const redactor = new ComprehendRedactor({
+                detector: async () => ({
+                    Entities: [{ Type: "PHONE", BeginOffset: 11, EndOffset: 23, Score: 0.99 }],
+                }),
+            });
+
+            await redactor.redactFile(inputPath, outputPath);
+
+            expect(await readFile(outputPath, "utf8")).toEqual("Call me at [PHONE]");
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+});

--- a/JS/edgechains/examples/comprehend-redaction/README.md
+++ b/JS/edgechains/examples/comprehend-redaction/README.md
@@ -1,0 +1,19 @@
+# AWS Comprehend Redaction
+
+This example shows how to use `ComprehendRedactor` to replace PII spans returned by AWS Comprehend.
+
+```ts
+import { ComprehendRedactor } from "@arakoodev/edgechains.js/ai";
+import { ComprehendClient, DetectPiiEntitiesCommand } from "@aws-sdk/client-comprehend";
+
+const redactor = new ComprehendRedactor({
+    client: new ComprehendClient({ region: "us-east-1" }),
+    commandConstructor: DetectPiiEntitiesCommand,
+});
+
+const result = await redactor.redactText("Jane Smith uses jane@example.com.");
+
+console.log(result.text);
+```
+
+The utility also accepts a custom detector function, which is useful in tests or in a Jsonnet native bridge.

--- a/JS/edgechains/examples/comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,6 @@
+local input = std.extVar('input');
+
+local redact(text) =
+  arakoo.native('comprehendRedact')({ text: text });
+
+redact(input)

--- a/JS/edgechains/examples/comprehend-redaction/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/comprehend-redaction/jsonnet/secrets.jsonnet
@@ -1,0 +1,3 @@
+{
+  aws_region: "us-east-1",
+}

--- a/JS/edgechains/examples/comprehend-redaction/package.json
+++ b/JS/edgechains/examples/comprehend-redaction/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "comprehend-redaction",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node ./dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/comprehend-redaction/src/index.ts
@@ -1,0 +1,16 @@
+import { ComprehendRedactor } from "@arakoodev/edgechains.js/ai";
+
+const sampleText = "Alice Nguyen can be reached at alice@example.com.";
+
+const redactor = new ComprehendRedactor({
+    detector: async () => ({
+        Entities: [
+            { Type: "NAME", BeginOffset: 0, EndOffset: 12, Score: 0.99 },
+            { Type: "EMAIL", BeginOffset: 31, EndOffset: 48, Score: 0.99 },
+        ],
+    }),
+});
+
+const result = await redactor.redactText(sampleText);
+
+console.log(result.text);

--- a/JS/edgechains/examples/comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/comprehend-redaction/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Fixes #290.

## Summary
- add a ComprehendRedactor utility for redacting PII spans returned by AWS Comprehend
- support text and file redaction, custom score thresholds, replacement text/formatters, and AWS SDK v2/v3 style clients
- add mocked coverage for text redaction, threshold filtering, and file redaction
- add a Comprehend redaction example with Jsonnet native bridge shape

## Verification
- 
pm exec --yes --package typescript --package @types/node -- tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --esModuleInterop --types node JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehendRedactor.ts
- Full package test install was not available in this environment because the local npm/pnpm registry setup intermittently fails certificate verification; tests are mocked and committed for CI.