### PR TITLE
Add AWS Comprehend PII redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -10,6 +10,7 @@
         "./vector-db": "./dist/vector-db/src/index.js",
         "./document-loader": "./dist/document-loader/src/index.js",
         "./splitter": "./dist/splitter/src/index.js",
+        "./redaction": "./dist/redaction/src/index.js",
         "./arakooserver": "./dist/arakooserver/src/index.js",
         "./db": "./dist/db/src/index.js",
         "./scraper": "./dist/scraper/src/index.js",
@@ -22,6 +23,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.1050.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",

--- a/JS/edgechains/arakoodev/src/redaction/src/index.ts
+++ b/JS/edgechains/arakoodev/src/redaction/src/index.ts
@@ -1,0 +1,8 @@
+export {
+    AwsComprehendRedactor,
+    type AwsComprehendRedactionMask,
+    type AwsComprehendRedactionResult,
+    type AwsComprehendRedactorOptions,
+    type RedactableMessage,
+    type RedactablePromptOptions,
+} from "./lib/aws-comprehend/awsComprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/redaction/src/lib/aws-comprehend/awsComprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/redaction/src/lib/aws-comprehend/awsComprehendRedactor.ts
@@ -1,0 +1,118 @@
+import {
+    ComprehendClient,
+    DetectPiiEntitiesCommand,
+    type ComprehendClientConfig,
+    type PiiEntity,
+} from "@aws-sdk/client-comprehend";
+
+export type AwsComprehendRedactionMask = string | ((entity: PiiEntity) => string);
+
+export interface AwsComprehendRedactorOptions {
+    client?: ComprehendClient;
+    clientConfig?: ComprehendClientConfig;
+    languageCode?: "en" | "es";
+    mask?: AwsComprehendRedactionMask;
+}
+
+export interface AwsComprehendRedactionResult {
+    text: string;
+    redactedText: string;
+    entities: PiiEntity[];
+}
+
+export interface RedactableMessage {
+    content: string;
+    [key: string]: unknown;
+}
+
+export interface RedactablePromptOptions {
+    prompt?: string;
+    messages?: RedactableMessage[];
+    [key: string]: unknown;
+}
+
+export class AwsComprehendRedactor {
+    private readonly client: ComprehendClient;
+    private readonly languageCode: "en" | "es";
+    private readonly mask: AwsComprehendRedactionMask;
+
+    constructor(options: AwsComprehendRedactorOptions = {}) {
+        this.client = options.client ?? new ComprehendClient(options.clientConfig ?? {});
+        this.languageCode = options.languageCode ?? "en";
+        this.mask = options.mask ?? ((entity: PiiEntity): string => `[${entity.Type ?? "PII"}]`);
+    }
+
+    async redact(text: string): Promise<AwsComprehendRedactionResult> {
+        if (!text.trim()) {
+            return {
+                text,
+                redactedText: text,
+                entities: [],
+            };
+        }
+
+        const response = await this.client.send(
+            new DetectPiiEntitiesCommand({
+                Text: text,
+                LanguageCode: this.languageCode,
+            })
+        );
+        const entities = response.Entities ?? [];
+
+        return {
+            text,
+            redactedText: this.applyRedactions(text, entities),
+            entities,
+        };
+    }
+
+    async transform(text: string): Promise<string> {
+        const result = await this.redact(text);
+        return result.redactedText;
+    }
+
+    async run(text: string): Promise<string> {
+        return this.transform(text);
+    }
+
+    async redactPromptOptions<T extends RedactablePromptOptions>(options: T): Promise<T> {
+        const prompt = options.prompt ? await this.transform(options.prompt) : options.prompt;
+        const messages = options.messages
+            ? await Promise.all(
+                  options.messages.map(async (message) => ({
+                      ...message,
+                      content: await this.transform(message.content),
+                  }))
+              )
+            : options.messages;
+
+        return {
+            ...options,
+            ...(prompt === undefined ? {} : { prompt }),
+            ...(messages === undefined ? {} : { messages }),
+        };
+    }
+
+    private applyRedactions(text: string, entities: PiiEntity[]): string {
+        return [...entities]
+            .filter((entity): entity is PiiEntity & { BeginOffset: number; EndOffset: number } => {
+                return (
+                    typeof entity.BeginOffset === "number" &&
+                    typeof entity.EndOffset === "number" &&
+                    entity.BeginOffset >= 0 &&
+                    entity.EndOffset <= text.length &&
+                    entity.BeginOffset < entity.EndOffset
+                );
+            })
+            .sort((a, b) => b.BeginOffset - a.BeginOffset)
+            .reduce((redactedText, entity) => {
+                const replacement =
+                    typeof this.mask === "function" ? this.mask(entity) : this.mask;
+                return (
+                    redactedText.slice(0, entity.BeginOffset) +
+                    replacement +
+                    redactedText.slice(entity.EndOffset)
+                );
+            }, text);
+    }
+}

--- a/JS/edgechains/arakoodev/src/redaction/src/tests/aws-comprehend/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/redaction/src/tests/aws-comprehend/awsComprehendRedactor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ComprehendClient, PiiEntity } from "@aws-sdk/client-comprehend";
+import { AwsComprehendRedactor } from "../../lib/aws-comprehend/awsComprehendRedactor";
+
+const createClient = (entities: PiiEntity[]): ComprehendClient => {
+    return {
+        send: vi.fn().mockResolvedValue({ Entities: entities }),
+    } as unknown as ComprehendClient;
+};
+
+describe("AwsComprehendRedactor", () => {
+    it("redacts PII entities returned by AWS Comprehend", async () => {
+        const text = "Contact Jane at jane@example.com or +1 555 123 4567.";
+        const client = createClient([
+            {
+                Type: "EMAIL",
+                BeginOffset: 16,
+                EndOffset: 32,
+                Score: 0.99,
+            },
+            {
+                Type: "PHONE",
+                BeginOffset: 36,
+                EndOffset: 51,
+                Score: 0.98,
+            },
+        ]);
+
+        const redactor = new AwsComprehendRedactor({ client });
+        const result = await redactor.redact(text);
+
+        expect(result.redactedText).toBe("Contact Jane at [EMAIL] or [PHONE].");
+        expect(result.entities).toHaveLength(2);
+        expect(client.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("supports a custom redaction mask", async () => {
+        const text = "My card number is 4111111111111111.";
+        const client = createClient([
+            {
+                Type: "CREDIT_DEBIT_NUMBER",
+                BeginOffset: 18,
+                EndOffset: 34,
+                Score: 0.99,
+            },
+        ]);
+
+        const redactor = new AwsComprehendRedactor({ client, mask: "[REDACTED]" });
+        const redactedText = await redactor.transform(text);
+
+        expect(redactedText).toBe("My card number is [REDACTED].");
+    });
+
+    it("does not call AWS for blank text", async () => {
+        const client = createClient([]);
+        const redactor = new AwsComprehendRedactor({ client });
+
+        const result = await redactor.redact("   ");
+
+        expect(result.redactedText).toBe("   ");
+        expect(client.send).not.toHaveBeenCalled();
+    });
+
+    it("redacts prompt options without mutating the original object", async () => {
+        const client = createClient([
+            {
+                Type: "EMAIL",
+                BeginOffset: 12,
+                EndOffset: 28,
+                Score: 0.99,
+            },
+        ]);
+        const redactor = new AwsComprehendRedactor({ client });
+        const options = {
+            model: "gpt-4",
+            messages: [{ role: "user", content: "Email me at jane@example.com" }],
+        };
+
+        const redactedOptions = await redactor.redactPromptOptions(options);
+
+        expect(redactedOptions).toEqual({
+            model: "gpt-4",
+            messages: [{ role: "user", content: "Email me at [EMAIL]" }],
+        });
+        expect(options.messages[0].content).toBe("Email me at jane@example.com");
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "aws-comprehend-redaction-example",
+    "type": "module",
+    "scripts": {
+        "start": "tsx src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "tsx": "^4.19.2"
+    },
+    "devDependencies": {
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,19 @@
+import { AwsComprehendRedactor } from "@arakoodev/edgechains.js/redaction";
+
+const redactor = new AwsComprehendRedactor({
+    clientConfig: {
+        region: process.env.AWS_REGION ?? "us-east-1",
+    },
+});
+
+const prompt =
+    "Please summarize this support request from Jane Doe at jane@example.com about invoice 12345.";
+
+const result = await redactor.redact(prompt);
+const safeChatOptions = await redactor.redactPromptOptions({
+    model: "gpt-4",
+    messages: [{ role: "user", content: prompt }],
+});
+
+console.log(result.redactedText);
+console.log(safeChatOptions);


### PR DESCRIPTION
## Summary
- add an AWS Comprehend-based PII redaction utility for the JavaScript SDK
- expose the new redaction module via `@arakoodev/edgechains.js/redaction`
- add helpers for redacting raw prompt text and chat-style prompt options before forwarding to endpoint classes
- add unit tests with a mocked Comprehend client
- add a working example under `examples/aws-comprehend-redaction`

Closes #290.

## Validation
- `bunx vitest run src/redaction/src/tests/aws-comprehend/awsComprehendRedactor.test.ts`
- `bun run build`

## Notes
I also tried the full `bun run test` suite. The new redaction tests pass, but the existing suite currently has unrelated failures around old Jest globals in Vitest, missing `dist/openai/...` imports, missing Playwright browser binaries, and a scraper test receiving HTTP 403.