### PR TITLE
Add Qdrant vector database support

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,9 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+    QdrantClientOptions,
+    QdrantCollectionOptions,
+    QdrantDistance,
+    QdrantPoint,
+    QdrantSearchOptions,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,184 @@
+import axios, { type AxiosInstance } from "axios";
+import { config } from "dotenv";
+
+config();
+
+export type QdrantDistance = "Cosine" | "Dot" | "Euclid" | "Manhattan";
+export type QdrantPointId = number | string;
+export type QdrantPayload = Record<string, unknown>;
+
+export interface QdrantClientOptions {
+    url?: string;
+    apiKey?: string;
+    timeout?: number;
+}
+
+export interface QdrantCollectionOptions {
+    client: AxiosInstance;
+    collectionName: string;
+    vectorSize: number;
+    distance?: QdrantDistance;
+}
+
+export interface QdrantPoint {
+    id: QdrantPointId;
+    vector: number[];
+    payload?: QdrantPayload;
+}
+
+export interface QdrantInsertVectorDataArgs {
+    client: AxiosInstance;
+    collectionName: string;
+    points?: QdrantPoint[];
+    id?: QdrantPointId;
+    vector?: number[];
+    payload?: QdrantPayload;
+    wait?: boolean;
+}
+
+export interface QdrantSearchOptions {
+    client: AxiosInstance;
+    collectionName: string;
+    vector: number[];
+    limit?: number;
+    filter?: QdrantPayload;
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+}
+
+export interface QdrantPointLookupOptions {
+    client: AxiosInstance;
+    collectionName: string;
+    id: QdrantPointId;
+}
+
+export interface QdrantDeleteOptions extends QdrantPointLookupOptions {
+    wait?: boolean;
+}
+
+export class Qdrant {
+    readonly url: string;
+    readonly apiKey: string;
+    readonly timeout: number;
+
+    constructor(options: QdrantClientOptions = {}) {
+        this.url = options.url || process.env.QDRANT_URL || "http://localhost:6333";
+        this.apiKey = options.apiKey || process.env.QDRANT_API_KEY || "";
+        this.timeout = options.timeout || 30000;
+    }
+
+    createClient(): AxiosInstance {
+        return axios.create({
+            baseURL: this.url.replace(/\/$/, ""),
+            timeout: this.timeout,
+            headers: {
+                "Content-Type": "application/json",
+                ...(this.apiKey ? { "api-key": this.apiKey } : {}),
+            },
+        });
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: QdrantCollectionOptions): Promise<unknown> {
+        const response = await client.put(`/collections/${collectionName}`, {
+            vectors: {
+                size: vectorSize,
+                distance,
+            },
+        });
+
+        return response.data;
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        points,
+        id,
+        vector,
+        payload,
+        wait,
+    }: QdrantInsertVectorDataArgs): Promise<unknown> {
+        const normalizedPoints = points ?? this.createSinglePoint({ id, vector, payload });
+        const response = await client.put(`/collections/${collectionName}/points`, {
+            points: normalizedPoints,
+            ...(wait === undefined ? {} : { wait }),
+        });
+
+        return response.data;
+    }
+
+    async search({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: QdrantSearchOptions): Promise<unknown> {
+        const response = await client.post(`/collections/${collectionName}/points/search`, {
+            vector,
+            limit,
+            ...(filter === undefined ? {} : { filter }),
+            with_payload: withPayload,
+            with_vector: withVector,
+        });
+
+        return response.data;
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        id,
+    }: QdrantPointLookupOptions): Promise<unknown> {
+        const response = await client.get(`/collections/${collectionName}/points/${id}`);
+
+        return response.data;
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        id,
+        wait,
+    }: QdrantDeleteOptions): Promise<unknown> {
+        const response = await client.post(`/collections/${collectionName}/points/delete`, {
+            points: [id],
+            ...(wait === undefined ? {} : { wait }),
+        });
+
+        return response.data;
+    }
+
+    private createSinglePoint({
+        id,
+        vector,
+        payload,
+    }: {
+        id?: QdrantPointId;
+        vector?: number[];
+        payload?: QdrantPayload;
+    }): QdrantPoint[] {
+        if (id === undefined) {
+            throw new Error("Qdrant point id is required when points are not provided.");
+        }
+
+        if (!vector || vector.length === 0) {
+            throw new Error("Qdrant point vector is required when points are not provided.");
+        }
+
+        return [
+            {
+                id,
+                vector,
+                ...(payload === undefined ? {} : { payload }),
+            },
+        ];
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import axios, { type AxiosInstance } from "axios";
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+vi.mock("axios", () => ({
+    default: {
+        create: vi.fn(),
+    },
+}));
+
+const createMockClient = (): AxiosInstance => {
+    return {
+        put: vi.fn().mockResolvedValue({ data: { status: "ok" } }),
+        post: vi.fn().mockResolvedValue({ data: { result: [] } }),
+        get: vi.fn().mockResolvedValue({ data: { result: { id: 1 } } }),
+    } as unknown as AxiosInstance;
+};
+
+describe("Qdrant", () => {
+    it("creates an axios client with Qdrant headers", () => {
+        const mockClient = createMockClient();
+        vi.mocked(axios.create).mockReturnValue(mockClient);
+
+        const qdrant = new Qdrant({
+            url: "https://example.qdrant.io/",
+            apiKey: "test-key",
+            timeout: 1000,
+        });
+
+        expect(qdrant.createClient()).toBe(mockClient);
+        expect(axios.create).toHaveBeenCalledWith({
+            baseURL: "https://example.qdrant.io",
+            timeout: 1000,
+            headers: {
+                "Content-Type": "application/json",
+                "api-key": "test-key",
+            },
+        });
+    });
+
+    it("creates a collection with vector size and distance", async () => {
+        const client = createMockClient();
+        const qdrant = new Qdrant();
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+            distance: "Cosine",
+        });
+
+        expect(client.put).toHaveBeenCalledWith("/collections/documents", {
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
+    });
+
+    it("upserts a single vector point", async () => {
+        const client = createMockClient();
+        const qdrant = new Qdrant();
+
+        await qdrant.insertVectorData({
+            client,
+            collectionName: "documents",
+            id: 1,
+            vector: [0.1, 0.2, 0.3],
+            payload: { content: "hello" },
+        });
+
+        expect(client.put).toHaveBeenCalledWith("/collections/documents/points", {
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+        });
+    });
+
+    it("searches points by vector", async () => {
+        const client = createMockClient();
+        const qdrant = new Qdrant();
+
+        await qdrant.search({
+            client,
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+        });
+
+        expect(client.post).toHaveBeenCalledWith("/collections/documents/points/search", {
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+            with_payload: true,
+            with_vector: false,
+        });
+    });
+
+    it("gets and deletes points by id", async () => {
+        const client = createMockClient();
+        const qdrant = new Qdrant();
+
+        await qdrant.getDataById({ client, collectionName: "documents", id: 1 });
+        await qdrant.deleteById({ client, collectionName: "documents", id: 1 });
+
+        expect(client.get).toHaveBeenCalledWith("/collections/documents/points/1");
+        expect(client.post).toHaveBeenCalledWith("/collections/documents/points/delete", {
+            points: [1],
+        });
+    });
+});

--- a/JS/edgechains/examples/qdrant-vector-db/package.json
+++ b/JS/edgechains/examples/qdrant-vector-db/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "qdrant-vector-db-example",
+    "type": "module",
+    "scripts": {
+        "start": "tsx src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "tsx": "^4.19.2"
+    },
+    "devDependencies": {
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/qdrant-vector-db/src/index.ts
+++ b/JS/edgechains/examples/qdrant-vector-db/src/index.ts
@@ -1,0 +1,34 @@
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant({
+    url: process.env.QDRANT_URL,
+    apiKey: process.env.QDRANT_API_KEY,
+});
+const client = qdrant.createClient();
+const collectionName = process.env.QDRANT_COLLECTION ?? "edgechains_docs";
+
+await qdrant.createCollection({
+    client,
+    collectionName,
+    vectorSize: 3,
+    distance: "Cosine",
+});
+
+await qdrant.insertVectorData({
+    client,
+    collectionName,
+    id: 1,
+    vector: [0.1, 0.2, 0.3],
+    payload: {
+        content: "Qdrant REST support for EdgeChains",
+    },
+});
+
+const searchResult = await qdrant.search({
+    client,
+    collectionName,
+    vector: [0.1, 0.2, 0.3],
+    limit: 1,
+});
+
+console.log(searchResult);


### PR DESCRIPTION
## Summary
- add a Qdrant vector database wrapper to the JavaScript SDK using the REST API directly
- expose `Qdrant` from `@arakoodev/edgechains.js/vector-db`
- support collection creation, vector upsert, vector search, point lookup, and point deletion
- add unit tests with a mocked Axios client
- add a minimal Qdrant example under `examples/qdrant-vector-db`

Closes #273.

## Validation
- `bunx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts`
- `bun run build`

## Notes
This implementation follows the bounty request by calling Qdrant REST endpoints directly instead of using Qdrant packages.