### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,135 @@
+interface QdrantPoint {
+    id: string | number;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+interface QdrantSearchArgs {
+    collectionName: string;
+    vector: number[];
+    limit?: number;
+    filter?: Record<string, any>;
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+}
+
+interface QdrantUpsertArgs {
+    collectionName: string;
+    points: QdrantPoint[];
+}
+
+interface QdrantCreateCollectionArgs {
+    collectionName: string;
+    vectorSize: number;
+    distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+}
+
+interface QdrantRequestOptions {
+    method: string;
+    path: string;
+    body?: Record<string, any>;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    private async request({ method, path, body }: QdrantRequestOptions): Promise<any> {
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required");
+        }
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        const response = await fetch(`${this.QDRANT_URL}${path}`, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+        });
+
+        const payload = await response.json().catch(() => undefined);
+
+        if (!response.ok) {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(payload)}`
+            );
+        }
+
+        return payload;
+    }
+
+    async createCollection({
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: QdrantCreateCollectionArgs): Promise<any> {
+        return this.request({
+            method: "PUT",
+            path: `/collections/${collectionName}`,
+            body: {
+                vectors: {
+                    size: vectorSize,
+                    distance,
+                },
+            },
+        });
+    }
+
+    async insertVectorData({ collectionName, points }: QdrantUpsertArgs): Promise<any> {
+        return this.request({
+            method: "PUT",
+            path: `/collections/${collectionName}/points?wait=true`,
+            body: {
+                points,
+            },
+        });
+    }
+
+    async search({
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: QdrantSearchArgs): Promise<any> {
+        return this.request({
+            method: "POST",
+            path: `/collections/${collectionName}/points/search`,
+            body: {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+            },
+        });
+    }
+
+    async deleteById({
+        collectionName,
+        ids,
+    }: {
+        collectionName: string;
+        ids: Array<string | number>;
+    }): Promise<any> {
+        return this.request({
+            method: "POST",
+            path: `/collections/${collectionName}/points/delete?wait=true`,
+            body: {
+                points: ids,
+            },
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,51 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+describe("Qdrant vector database client", () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    it("should upsert points into a collection", async () => {
+        const mockFetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ result: { operation_id: 1, status: "completed" } }),
+        });
+        global.fetch = mockFetch as any;
+
+        const qdrant = new Qdrant("https://qdrant.example.com", "test-api-key");
+        const result = await qdrant.insertVectorData({
+            collectionName: "documents",
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                    "api-key": "test-api-key",
+                }),
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: 1,
+                            vector: [0.1, 0.2, 0.3],
+                            payload: { content: "hello" },
+                        },
+                    ],
+                }),
+            })
+        );
+        expect(result.result.status).toBe("completed");
+    });
+});


### PR DESCRIPTION
## Summary
- adds a Qdrant vector database client for collection creation, point upsert, search, and delete-by-id operations
- exports the Qdrant client from the vector-db package entrypoint
- adds a Jest unit test covering Qdrant point upsert request construction

Closes #273

## Verification
- npx tsc -b
- npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand

Note: the existing npm test script uses Vitest while existing tests rely on Jest globals, so I verified the new test with Jest directly.