### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -3,3 +3,33 @@ Installation
 ```
 npm install arakoodev
 ```
+
+Qdrant vector database
+
+```ts
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY);
+const client = qdrant.createClient();
+
+await qdrant.createCollection({
+  client,
+  collectionName: "documents",
+  vectorSize: 1536,
+});
+
+await qdrant.insertVectorData({
+  client,
+  collectionName: "documents",
+  id: "doc-1",
+  content: "Qdrant stores vectors and payloads.",
+  embedding: [0.1, 0.2, 0.3],
+});
+
+const matches = await qdrant.getDataFromQuery({
+  client,
+  collectionName: "documents",
+  embedding: [0.1, 0.2, 0.3],
+  limit: 5,
+});
+```

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,335 @@
+import { config } from "dotenv";
+config();
+
+type QdrantPointId = string | number;
+type FetchLike = typeof fetch;
+
+interface QdrantClient {
+  url: string;
+  apiKey?: string;
+  fetch: FetchLike;
+}
+
+interface QdrantRequestOptions {
+  method?: string;
+  body?: unknown;
+}
+
+interface InsertVectorDataArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  id?: QdrantPointId;
+  embedding?: number[];
+  vector?: number[];
+  payload?: Record<string, any>;
+  content?: string;
+  [key: string]: any;
+}
+
+interface GetDataFromQueryArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  embedding?: number[];
+  vector?: number[];
+  limit?: number;
+  filter?: Record<string, any>;
+  with_payload?: boolean;
+  with_vector?: boolean;
+  score_threshold?: number;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+  private fetcher: FetchLike;
+
+  constructor(
+    QDRANT_URL?: string,
+    QDRANT_API_KEY?: string,
+    fetcher?: FetchLike,
+  ) {
+    this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(
+      /\/+$/,
+      "",
+    );
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    this.fetcher = fetcher || fetch;
+
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required to create a Qdrant client");
+    }
+  }
+
+  createClient(): QdrantClient {
+    return {
+      url: this.QDRANT_URL,
+      apiKey: this.QDRANT_API_KEY,
+      fetch: this.fetcher,
+    };
+  }
+
+  async createCollection({
+    client,
+    collectionName,
+    tableName,
+    vectorSize,
+    distance = "Cosine",
+  }: {
+    client: QdrantClient;
+    collectionName?: string;
+    tableName?: string;
+    vectorSize: number;
+    distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${this.collection(collectionName, tableName)}`,
+      {
+        method: "PUT",
+        body: {
+          vectors: {
+            size: vectorSize,
+            distance,
+          },
+        },
+      },
+    );
+  }
+
+  async insertVectorData({
+    client,
+    tableName,
+    collectionName,
+    id,
+    embedding,
+    vector,
+    payload,
+    content,
+    ...args
+  }: InsertVectorDataArgs): Promise<any> {
+    const pointVector = vector || embedding;
+    if (!pointVector) {
+      throw new Error(
+        "Qdrant insertVectorData requires an embedding or vector",
+      );
+    }
+
+    const pointPayload = {
+      ...(content === undefined ? {} : { content }),
+      ...(payload || {}),
+      ...args,
+    };
+
+    return this.request(
+      client,
+      `/collections/${this.collection(collectionName, tableName)}/points`,
+      {
+        method: "PUT",
+        body: {
+          points: [
+            {
+              id: id ?? this.createPointId(),
+              vector: pointVector,
+              payload: pointPayload,
+            },
+          ],
+        },
+      },
+    );
+  }
+
+  async getDataFromQuery({
+    client,
+    tableName,
+    collectionName,
+    embedding,
+    vector,
+    limit = 10,
+    filter,
+    with_payload = true,
+    with_vector = false,
+    score_threshold,
+  }: GetDataFromQueryArgs): Promise<any> {
+    const queryVector = vector || embedding;
+    if (!queryVector) {
+      throw new Error(
+        "Qdrant getDataFromQuery requires an embedding or vector",
+      );
+    }
+
+    return this.request(
+      client,
+      `/collections/${this.collection(collectionName, tableName)}/points/search`,
+      {
+        method: "POST",
+        body: {
+          vector: queryVector,
+          limit,
+          filter,
+          with_payload,
+          with_vector,
+          score_threshold,
+        },
+      },
+    );
+  }
+
+  async getData({
+    client,
+    tableName,
+    collectionName,
+    limit = 100,
+    offset,
+    filter,
+    with_payload = true,
+    with_vector = false,
+  }: {
+    client: QdrantClient;
+    tableName?: string;
+    collectionName?: string;
+    limit?: number;
+    offset?: QdrantPointId;
+    filter?: Record<string, any>;
+    with_payload?: boolean;
+    with_vector?: boolean;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${this.collection(collectionName, tableName)}/points/scroll`,
+      {
+        method: "POST",
+        body: {
+          limit,
+          offset,
+          filter,
+          with_payload,
+          with_vector,
+        },
+      },
+    );
+  }
+
+  async getDataById({
+    client,
+    tableName,
+    collectionName,
+    id,
+    with_payload = true,
+    with_vector = false,
+  }: {
+    client: QdrantClient;
+    tableName?: string;
+    collectionName?: string;
+    id: QdrantPointId;
+    with_payload?: boolean;
+    with_vector?: boolean;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${this.collection(collectionName, tableName)}/points`,
+      {
+        method: "POST",
+        body: {
+          ids: [id],
+          with_payload,
+          with_vector,
+        },
+      },
+    );
+  }
+
+  async updateById({
+    client,
+    tableName,
+    collectionName,
+    id,
+    updatedContent,
+    payload,
+  }: {
+    client: QdrantClient;
+    tableName?: string;
+    collectionName?: string;
+    id: QdrantPointId;
+    updatedContent?: Record<string, any>;
+    payload?: Record<string, any>;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${this.collection(collectionName, tableName)}/points/payload`,
+      {
+        method: "POST",
+        body: {
+          points: [id],
+          payload: updatedContent || payload || {},
+        },
+      },
+    );
+  }
+
+  async deleteById({
+    client,
+    tableName,
+    collectionName,
+    id,
+  }: {
+    client: QdrantClient;
+    tableName?: string;
+    collectionName?: string;
+    id: QdrantPointId;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${this.collection(collectionName, tableName)}/points/delete`,
+      {
+        method: "POST",
+        body: {
+          points: [id],
+        },
+      },
+    );
+  }
+
+  private collection(collectionName?: string, tableName?: string): string {
+    const collection = collectionName || tableName;
+    if (!collection) {
+      throw new Error("Qdrant collectionName or tableName is required");
+    }
+    return encodeURIComponent(collection);
+  }
+
+  private async request(
+    client: QdrantClient,
+    path: string,
+    options: QdrantRequestOptions = {},
+  ) {
+    const response = await client.fetch(`${client.url}${path}`, {
+      method: options.method || "GET",
+      headers: {
+        "Content-Type": "application/json",
+        ...(client.apiKey ? { "api-key": client.apiKey } : {}),
+      },
+      body:
+        options.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : {};
+
+    if (!response.ok) {
+      throw new Error(
+        `Qdrant request failed with status ${response.status}: ${JSON.stringify(data)}`,
+      );
+    }
+
+    return data;
+  }
+
+  private createPointId(): string {
+    if (globalThis.crypto?.randomUUID) {
+      return globalThis.crypto.randomUUID();
+    }
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+const createResponse = (body: unknown, ok = true, status = 200) =>
+  ({
+    ok,
+    status,
+    text: async () => JSON.stringify(body),
+  }) as Response;
+
+describe("Qdrant", () => {
+  it("creates collections through the REST API", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(createResponse({ result: true }));
+    const qdrant = new Qdrant(
+      "https://qdrant.example",
+      "secret",
+      fetchMock as any,
+    );
+    const client = qdrant.createClient();
+
+    await qdrant.createCollection({
+      client,
+      collectionName: "documents",
+      vectorSize: 1536,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "api-key": "secret",
+        }),
+        body: JSON.stringify({
+          vectors: {
+            size: 1536,
+            distance: "Cosine",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("upserts vector points using existing insertVectorData shape", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(createResponse({ status: "ok" }));
+    const qdrant = new Qdrant(
+      "https://qdrant.example",
+      undefined,
+      fetchMock as any,
+    );
+    const client = qdrant.createClient();
+
+    await qdrant.insertVectorData({
+      client,
+      tableName: "documents",
+      id: 42,
+      content: "hello",
+      embedding: [0.1, 0.2, 0.3],
+      source: "unit-test",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents/points",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          points: [
+            {
+              id: 42,
+              vector: [0.1, 0.2, 0.3],
+              payload: {
+                content: "hello",
+                source: "unit-test",
+              },
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("searches points from an embedding", async () => {
+    const response = { result: [{ id: 1, score: 0.98 }] };
+    const fetchMock = vi.fn().mockResolvedValue(createResponse(response));
+    const qdrant = new Qdrant(
+      "https://qdrant.example",
+      undefined,
+      fetchMock as any,
+    );
+    const client = qdrant.createClient();
+
+    const result = await qdrant.getDataFromQuery({
+      client,
+      collectionName: "documents",
+      embedding: [0.5, 0.6],
+      limit: 3,
+      filter: { must: [{ key: "type", match: { value: "note" } }] },
+    });
+
+    expect(result).toEqual(response);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents/points/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          vector: [0.5, 0.6],
+          limit: 3,
+          filter: { must: [{ key: "type", match: { value: "note" } }] },
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+  });
+
+  it("retrieves, updates, and deletes by id", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(createResponse({ result: true }));
+    const qdrant = new Qdrant(
+      "https://qdrant.example",
+      undefined,
+      fetchMock as any,
+    );
+    const client = qdrant.createClient();
+
+    await qdrant.getDataById({ client, tableName: "documents", id: "abc" });
+    await qdrant.updateById({
+      client,
+      tableName: "documents",
+      id: "abc",
+      updatedContent: { content: "redacted" },
+    });
+    await qdrant.deleteById({ client, tableName: "documents", id: "abc" });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://qdrant.example/collections/documents/points",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          ids: ["abc"],
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://qdrant.example/collections/documents/points/payload",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          points: ["abc"],
+          payload: { content: "redacted" },
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://qdrant.example/collections/documents/points/delete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          points: ["abc"],
+        }),
+      }),
+    );
+  });
+
+  it("throws readable errors when Qdrant returns a non-2xx response", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        createResponse({ status: { error: "bad vector" } }, false, 400),
+      );
+    const qdrant = new Qdrant(
+      "https://qdrant.example",
+      undefined,
+      fetchMock as any,
+    );
+    const client = qdrant.createClient();
+
+    await expect(
+      qdrant.getDataFromQuery({
+        client,
+        tableName: "documents",
+        embedding: [1],
+      }),
+    ).rejects.toThrow("Qdrant request failed with status 400");
+  });
+});


### PR DESCRIPTION
## Summary

/claim #273

Adds dependency-free Qdrant vector database support to the JavaScript SDK. The new `Qdrant` client uses the Qdrant REST API directly, matching the bounty requirement to avoid Qdrant npm packages.

What changed:
- added `Qdrant` under the existing `vector-db` package
- supports collection creation, vector upsert, vector search, scroll/list, point lookup, payload update, and point deletion
- exports `Qdrant` from `@arakoodev/edgechains.js/vector-db`
- adds focused mocked-fetch tests for the Qdrant REST requests and error handling
- documents a small usage example in the SDK README

## Verification

Run from `JS/edgechains/arakoodev`:

```bash
npm run build
npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts
```

Local result:
- `npm run build` passes
- Qdrant test file passes: 5 tests

## Demo

The test suite demonstrates the Qdrant REST integration without requiring a live Qdrant server by mocking `fetch` and asserting the exact REST URLs, methods, headers, and request bodies for create collection, upsert, search, retrieve, update, delete, and non-2xx error handling.

No Qdrant SDK dependency is introduced.