### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,209 @@
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+type QdrantDistanceMetric = "Cosine" | "Euclid" | "Dot" | "Manhattan";
+
+interface QdrantClientConfig {
+    url: string;
+    apiKey?: string;
+}
+
+interface QdrantPoint {
+    id: number | string;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+interface CreateCollectionArgs {
+    client: QdrantClientConfig;
+    collectionName: string;
+    vectorSize: number;
+    distance?: QdrantDistanceMetric;
+}
+
+interface InsertVectorDataArgs {
+    client: QdrantClientConfig;
+    collectionName: string;
+    id: number | string;
+    vector?: number[] | Record<string, number[]>;
+    embedding?: number[];
+    payload?: Record<string, any>;
+    [key: string]: any;
+}
+
+interface UpsertPointsArgs {
+    client: QdrantClientConfig;
+    collectionName: string;
+    points: QdrantPoint[];
+}
+
+interface SearchVectorDataArgs {
+    client: QdrantClientConfig;
+    collectionName: string;
+    vector: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, any>;
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+}
+
+interface DeleteByIdArgs {
+    client: QdrantClientConfig;
+    collectionName: string;
+    ids: Array<number | string>;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL!;
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(): QdrantClientConfig {
+        return {
+            url: this.QDRANT_URL.replace(/\/$/, ""),
+            apiKey: this.QDRANT_API_KEY,
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: CreateCollectionArgs): Promise<any> {
+        return this.requestWithRetry(client, `/collections/${collectionName}`, {
+            method: "PUT",
+            body: JSON.stringify({
+                vectors: {
+                    size: vectorSize,
+                    distance,
+                },
+            }),
+        });
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        id,
+        vector,
+        embedding,
+        payload,
+        ...args
+    }: InsertVectorDataArgs): Promise<any> {
+        const pointVector = vector || embedding;
+        if (!pointVector) {
+            throw new Error("Qdrant insertVectorData requires either vector or embedding");
+        }
+
+        return this.upsertPoints({
+            client,
+            collectionName,
+            points: [
+                {
+                    id,
+                    vector: pointVector,
+                    payload: payload || args,
+                },
+            ],
+        });
+    }
+
+    async upsertPoints({ client, collectionName, points }: UpsertPointsArgs): Promise<any> {
+        return this.requestWithRetry(
+            client,
+            `/collections/${collectionName}/points?wait=true`,
+            {
+                method: "PUT",
+                body: JSON.stringify({ points }),
+            }
+        );
+    }
+
+    async searchVectorData({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: SearchVectorDataArgs): Promise<any> {
+        return this.requestWithRetry(client, `/collections/${collectionName}/points/search`, {
+            method: "POST",
+            body: JSON.stringify({
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+            }),
+        });
+    }
+
+    async deleteById({ client, collectionName, ids }: DeleteByIdArgs): Promise<any> {
+        return this.requestWithRetry(
+            client,
+            `/collections/${collectionName}/points/delete?wait=true`,
+            {
+                method: "POST",
+                body: JSON.stringify({
+                    points: ids,
+                }),
+            }
+        );
+    }
+
+    private async requestWithRetry(
+        client: QdrantClientConfig,
+        path: string,
+        init: RequestInit
+    ): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    const response = await fetch(`${client.url}${path}`, {
+                        ...init,
+                        headers: {
+                            "Content-Type": "application/json",
+                            ...(client.apiKey ? { "api-key": client.apiKey } : {}),
+                            ...init.headers,
+                        },
+                    });
+
+                    const data = await response.json().catch(() => ({}));
+
+                    if (!response.ok) {
+                        const error = new Error(
+                            `Qdrant request failed with status ${response.status}: ${JSON.stringify(data)}`
+                        );
+                        if (operation.retry(error)) return;
+                        reject(error);
+                        return;
+                    }
+
+                    resolve(data);
+                } catch (error: any) {
+                    if (operation.retry(error)) return;
+                    reject(error);
+                }
+            });
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,127 @@
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("Qdrant", () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ result: "ok" }),
+        });
+    });
+
+    it("creates a client from constructor values", () => {
+        const qdrant = new Qdrant("https://example-qdrant.io/", "mock-api-key");
+
+        expect(qdrant.createClient()).toEqual({
+            url: "https://example-qdrant.io",
+            apiKey: "mock-api-key",
+        });
+    });
+
+    it("creates a collection through the Qdrant REST API", async () => {
+        const qdrant = new Qdrant("https://example-qdrant.io", "mock-api-key");
+        const client = qdrant.createClient();
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://example-qdrant.io/collections/documents",
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                    "api-key": "mock-api-key",
+                }),
+                body: JSON.stringify({
+                    vectors: {
+                        size: 1536,
+                        distance: "Cosine",
+                    },
+                }),
+            })
+        );
+    });
+
+    it("inserts vector data as a Qdrant point", async () => {
+        const qdrant = new Qdrant("https://example-qdrant.io", "mock-api-key");
+        const client = qdrant.createClient();
+
+        await qdrant.insertVectorData({
+            client,
+            collectionName: "documents",
+            id: 1,
+            embedding: [0.1, 0.2, 0.3],
+            content: "hello",
+            filename: "sample.txt",
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://example-qdrant.io/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: 1,
+                            vector: [0.1, 0.2, 0.3],
+                            payload: {
+                                content: "hello",
+                                filename: "sample.txt",
+                            },
+                        },
+                    ],
+                }),
+            })
+        );
+    });
+
+    it("searches vector data through the Qdrant REST API", async () => {
+        const qdrant = new Qdrant("https://example-qdrant.io", "mock-api-key");
+        const client = qdrant.createClient();
+
+        await qdrant.searchVectorData({
+            client,
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: {
+                must: [
+                    {
+                        key: "filename",
+                        match: { value: "sample.txt" },
+                    },
+                ],
+            },
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://example-qdrant.io/collections/documents/points/search",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    vector: [0.1, 0.2, 0.3],
+                    limit: 3,
+                    filter: {
+                        must: [
+                            {
+                                key: "filename",
+                                match: { value: "sample.txt" },
+                            },
+                        ],
+                    },
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            })
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- add a Qdrant vector database client alongside the existing Supabase vector DB client
- support collection creation, point upsert/insert, vector search, and point deletion via Qdrant's REST API
- export `Qdrant` from the vector-db package entrypoint
- add focused unit coverage for Qdrant client creation, collection creation, insertion, and search

Closes #273

## Tests
- `npm run build`
- `npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts`

## Notes
Full `npm test -- --run` still fails on existing baseline tests unrelated to this change: older tests use Jest globals under Vitest, scraper tests depend on network access, and one Playwright test requires local browser installation.