### PR TITLE
Add Amazon Comprehend PII redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -27,6 +27,7 @@
         "@hono/node-server": "^0.6.0",
         "@lifeomic/attempt": "^3.1.0",
         "@playwright/test": "^1.45.3",
+        "@aws-sdk/client-comprehend": "^3.743.0",
         "@supabase/supabase-js": "^2.42.3",
         "axios": "^1.7.4",
         "axios-retry": "^4.1.0",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,4 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { PIIRedactor } from "./lib/pii-redactor/piiRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
@@ -1,9 +1,11 @@
 import axios from "axios";
 import { retry } from "@lifeomic/attempt";
+import { PIIRedactor } from "../pii-redactor/piiRedactor.js";
 const url = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
 
 interface GeminiAIConstructionOptions {
     apiKey?: string;
+    piiRedactor?: PIIRedactor;
 }
 
 type SafetyRating = {
@@ -56,18 +58,23 @@ interface GeminiAIChatOptions {
 
 export class GeminiAI {
     apiKey: string;
+    piiRedactor?: PIIRedactor;
     constructor(options: GeminiAIConstructionOptions) {
         this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
+        this.piiRedactor = options.piiRedactor;
     }
 
     async chat(chatOptions: GeminiAIChatOptions): Promise<Response> {
+        const prompt = this.piiRedactor
+            ? await this.piiRedactor.redactPrompt(chatOptions.prompt)
+            : chatOptions.prompt;
         let data = JSON.stringify({
             contents: [
                 {
                     role: "user",
                     parts: [
                         {
-                            text: chatOptions.prompt,
+                            text: prompt,
                         },
                     ],
                 },

--- a/JS/edgechains/arakoodev/src/ai/src/lib/openai/openai.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/openai/openai.ts
@@ -2,11 +2,13 @@ import axios from "axios";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { z } from "zod";
 import { ChatModel, role } from "../../types/index";
+import { PIIRedactor } from "../pii-redactor/piiRedactor.js";
 const openAI_url = "https://api.openai.com/v1/chat/completions";
 
 interface OpenAIConstructionOptions {
     apiKey?: string;
     orgId?: string;
+    piiRedactor?: PIIRedactor;
 }
 
 interface messageOption {
@@ -60,9 +62,11 @@ interface OpenAIChatReturnOptions {
 export class OpenAI {
     apiKey: string;
     orgId: string;
+    piiRedactor?: PIIRedactor;
     constructor(options: OpenAIConstructionOptions) {
         this.apiKey = options.apiKey || process.env.OPENAI_API_KEY || "";
         this.orgId = options.orgId || process.env.OPENAI_ORG_ID || "";
+        this.piiRedactor = options.piiRedactor;
         this.checkKeys();
     }
 
@@ -80,6 +84,7 @@ export class OpenAI {
     }
 
     async chat(chatOptions: OpenAIChatOptions): Promise<OpenAIChatReturnOptions> {
+        chatOptions = await this.redactChatOptions(chatOptions);
         const response = await axios
             .post(
                 openAI_url,
@@ -122,6 +127,7 @@ export class OpenAI {
     }
 
     async streamedChat(chatOptions: OpenAIChatOptions): Promise<OpenAIChatReturnOptions> {
+        chatOptions = await this.redactChatOptions(chatOptions);
         const response = await axios
             .post(
                 openAI_url,
@@ -167,6 +173,7 @@ export class OpenAI {
     async chatWithFunction(
         chatOptions: chatWithFunctionOptions
     ): Promise<chatWithFunctionReturnOptions> {
+        chatOptions = await this.redactChatOptions(chatOptions);
         const response = await axios
             .post(
                 openAI_url,
@@ -244,6 +251,7 @@ export class OpenAI {
     async zodSchemaResponse<S extends z.ZodTypeAny>(
         chatOptions: ZodSchemaResponseOptions<S>
     ): Promise<S> {
+        const prompt = await this.redactPrompt(chatOptions.prompt);
         const jsonSchema = zodToJsonSchema(chatOptions.schema, { $refStrategy: "none" });
         const openAIFunctionCallDefinition = {
             name: "generateSchema",
@@ -256,7 +264,7 @@ export class OpenAI {
                         Remembrer if any field like url or link is not available please create a dummy link based on the following prompt
                         
                         prompt:
-                        ${chatOptions.prompt || ""}
+                        ${prompt || ""}
                         `;
 
         const response = await axios
@@ -302,5 +310,15 @@ export class OpenAI {
         } else {
             throw new Error("Response did not contain valid JSON.");
         }
+    }
+
+    private async redactPrompt(prompt: string): Promise<string> {
+        return this.piiRedactor ? this.piiRedactor.redactPrompt(prompt) : prompt;
+    }
+
+    private async redactChatOptions<T extends { prompt?: string; messages?: messageOption[] }>(
+        chatOptions: T
+    ): Promise<T> {
+        return this.piiRedactor ? this.piiRedactor.redactChatOptions(chatOptions) : chatOptions;
     }
 }

--- a/JS/edgechains/arakoodev/src/ai/src/lib/pii-redactor/piiRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/pii-redactor/piiRedactor.ts
@@ -1,0 +1,172 @@
+import {
+    ComprehendClient,
+    DetectPiiEntitiesCommand,
+    type ComprehendClientConfig,
+    type DetectPiiEntitiesCommandOutput,
+    type LanguageCode,
+} from "@aws-sdk/client-comprehend";
+
+type PiiEntity = NonNullable<DetectPiiEntitiesCommandOutput["Entities"]>[number];
+
+export interface PIIMessage {
+    content: string;
+}
+
+export interface PIIRedaction {
+    beginOffset: number;
+    endOffset: number;
+    score?: number;
+    text: string;
+    type?: string;
+}
+
+export interface PIIRedactionResult {
+    originalText: string;
+    redactedText: string;
+    entities: PiiEntity[];
+    redactions: PIIRedaction[];
+}
+
+export interface RedactableChatOptions {
+    prompt?: string;
+    messages?: PIIMessage[];
+}
+
+export interface ComprehendPIIClient {
+    send(command: DetectPiiEntitiesCommand): Promise<DetectPiiEntitiesCommandOutput>;
+}
+
+export interface PIIRedactorOptions {
+    client?: ComprehendPIIClient;
+    comprehendClientConfig?: ComprehendClientConfig;
+    languageCode?: LanguageCode;
+    minScore?: number;
+    redactTypes?: string[];
+    replacement?: string | ((redaction: PIIRedaction) => string);
+    region?: string;
+}
+
+export class PIIRedactor {
+    private client: ComprehendPIIClient;
+    private languageCode: LanguageCode;
+    private minScore: number;
+    private redactTypes?: Set<string>;
+    private replacement: string | ((redaction: PIIRedaction) => string);
+
+    constructor(options: PIIRedactorOptions = {}) {
+        this.client =
+            options.client ||
+            new ComprehendClient({
+                ...options.comprehendClientConfig,
+                region: options.region || options.comprehendClientConfig?.region,
+            });
+        this.languageCode = options.languageCode || "en";
+        this.minScore = options.minScore ?? 0;
+        this.redactTypes = options.redactTypes ? new Set(options.redactTypes) : undefined;
+        this.replacement = options.replacement || "[PII]";
+    }
+
+    async redact(text: string): Promise<PIIRedactionResult> {
+        if (!text) {
+            return {
+                originalText: text,
+                redactedText: text,
+                entities: [],
+                redactions: [],
+            };
+        }
+
+        const response = await this.client.send(
+            new DetectPiiEntitiesCommand({
+                Text: text,
+                LanguageCode: this.languageCode,
+            })
+        );
+        const entities = response.Entities || [];
+        const redactions = this.getRedactions(text, entities);
+
+        return {
+            originalText: text,
+            redactedText: this.applyRedactions(text, redactions),
+            entities,
+            redactions,
+        };
+    }
+
+    async redactPrompt(prompt: string): Promise<string> {
+        return (await this.redact(prompt)).redactedText;
+    }
+
+    async redactMessages<T extends PIIMessage>(messages: T[]): Promise<T[]> {
+        return Promise.all(
+            messages.map(async (message) => ({
+                ...message,
+                content: await this.redactPrompt(message.content),
+            }))
+        );
+    }
+
+    async redactChatOptions<T extends RedactableChatOptions>(chatOptions: T): Promise<T> {
+        const redactedOptions: T = { ...chatOptions };
+
+        if (chatOptions.prompt) {
+            redactedOptions.prompt = await this.redactPrompt(chatOptions.prompt);
+        }
+
+        if (chatOptions.messages) {
+            redactedOptions.messages = await this.redactMessages(chatOptions.messages);
+        }
+
+        return redactedOptions;
+    }
+
+    private getRedactions(text: string, entities: PiiEntity[]): PIIRedaction[] {
+        const redactions = entities
+            .filter((entity) => {
+                if (entity.BeginOffset === undefined || entity.EndOffset === undefined) return false;
+                if ((entity.Score || 0) < this.minScore) return false;
+                if (this.redactTypes && entity.Type && !this.redactTypes.has(entity.Type)) {
+                    return false;
+                }
+                return entity.BeginOffset < entity.EndOffset;
+            })
+            .map((entity) => ({
+                beginOffset: entity.BeginOffset as number,
+                endOffset: entity.EndOffset as number,
+                score: entity.Score,
+                text: text.slice(entity.BeginOffset, entity.EndOffset),
+                type: entity.Type,
+            }))
+            .sort((left, right) => left.beginOffset - right.beginOffset);
+
+        return redactions.reduce<PIIRedaction[]>((mergedRedactions, redaction) => {
+            const previous = mergedRedactions[mergedRedactions.length - 1];
+            if (!previous || redaction.beginOffset >= previous.endOffset) {
+                mergedRedactions.push(redaction);
+                return mergedRedactions;
+            }
+
+            previous.endOffset = Math.max(previous.endOffset, redaction.endOffset);
+            previous.score = Math.max(previous.score || 0, redaction.score || 0);
+            previous.text = text.slice(previous.beginOffset, previous.endOffset);
+            previous.type = previous.type || redaction.type;
+            return mergedRedactions;
+        }, []);
+    }
+
+    private applyRedactions(text: string, redactions: PIIRedaction[]): string {
+        let cursor = 0;
+        let redactedText = "";
+
+        for (const redaction of redactions) {
+            redactedText += text.slice(cursor, redaction.beginOffset);
+            redactedText +=
+                typeof this.replacement === "function"
+                    ? this.replacement(redaction)
+                    : this.replacement;
+            cursor = redaction.endOffset;
+        }
+
+        return redactedText + text.slice(cursor);
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/piiRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/piiRedactor.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from "vitest";
+import { DetectPiiEntitiesCommand } from "@aws-sdk/client-comprehend";
+import { PIIRedactor } from "../lib/pii-redactor/piiRedactor";
+
+describe("PIIRedactor", () => {
+    test("redacts PII spans returned by Amazon Comprehend", async () => {
+        const send = vi.fn(async (command: DetectPiiEntitiesCommand) => {
+            expect(command.input).toEqual({
+                Text: "Contact me at jane@example.com or 555-0100.",
+                LanguageCode: "en",
+            });
+
+            return {
+                Entities: [
+                    { BeginOffset: 14, EndOffset: 30, Score: 0.99, Type: "EMAIL" },
+                    { BeginOffset: 34, EndOffset: 42, Score: 0.98, Type: "PHONE" },
+                    { BeginOffset: 0, EndOffset: 7, Score: 0.2, Type: "NAME" },
+                ],
+            };
+        });
+        const redactor = new PIIRedactor({
+            client: { send },
+            minScore: 0.8,
+            replacement: (redaction) => `[${redaction.type}]`,
+        });
+
+        const result = await redactor.redact("Contact me at jane@example.com or 555-0100.");
+
+        expect(result.redactedText).toBe("Contact me at [EMAIL] or [PHONE].");
+        expect(result.redactions).toEqual([
+            {
+                beginOffset: 14,
+                endOffset: 30,
+                score: 0.99,
+                text: "jane@example.com",
+                type: "EMAIL",
+            },
+            {
+                beginOffset: 34,
+                endOffset: 42,
+                score: 0.98,
+                text: "555-0100",
+                type: "PHONE",
+            },
+        ]);
+    });
+
+    test("redacts prompts and message contents without mutating chat options", async () => {
+        const send = vi.fn(async () => ({
+            Entities: [{ BeginOffset: 0, EndOffset: 16, Score: 0.99, Type: "EMAIL" }],
+        }));
+        const redactor = new PIIRedactor({ client: { send }, replacement: "[REDACTED]" });
+        const chatOptions = {
+            prompt: "jane@example.com asked a question",
+            messages: [{ role: "user", content: "jane@example.com asked a question" }],
+        };
+
+        const result = await redactor.redactChatOptions(chatOptions);
+
+        expect(result.prompt).toBe("[REDACTED] asked a question");
+        expect(result.messages).toEqual([
+            { role: "user", content: "[REDACTED] asked a question" },
+        ]);
+        expect(chatOptions.prompt).toBe("jane@example.com asked a question");
+    });
+});


### PR DESCRIPTION
## Summary
- Add a PIIRedactor utility backed by Amazon Comprehend DetectPiiEntities.
- Export PIIRedactor from the AI package.
- Add optional PII redaction for OpenAI and Gemini prompts/messages before provider calls.

## Test Plan
- npx tsc -p tsconfig.json --noEmit
- npx vitest run src/ai/src/tests/piiRedactor.test.ts --pool=threads --poolOptions.threads.singleThread=true

Closes #290