### PR TITLE
Add Qdrant vector database support to JavaScript SDK

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,11 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+  QdrantDenseVector,
+  QdrantDistanceMetric,
+  QdrantFilter,
+  QdrantPayload,
+  QdrantPoint,
+  QdrantPointId,
+  QdrantVector,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,317 @@
+import axios, { AxiosInstance, AxiosResponse } from "axios";
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+export type QdrantPointId = number | string;
+export type QdrantDistanceMetric = "Cosine" | "Dot" | "Euclid" | "Manhattan";
+export type QdrantDenseVector = number[];
+export type QdrantVector =
+  | QdrantDenseVector
+  | Record<string, QdrantDenseVector>;
+export type QdrantPayload = Record<string, any>;
+export type QdrantFilter = Record<string, any>;
+
+export interface QdrantPoint {
+  id: QdrantPointId;
+  vector: QdrantVector;
+  payload?: QdrantPayload;
+}
+
+interface QdrantConstructionOptions {
+  url?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  httpClient?: QdrantHttpClient;
+}
+
+interface QdrantHttpClient {
+  get<T = any>(url: string, config?: any): Promise<AxiosResponse<T>>;
+  put<T = any>(
+    url: string,
+    data?: any,
+    config?: any,
+  ): Promise<AxiosResponse<T>>;
+  post<T = any>(
+    url: string,
+    data?: any,
+    config?: any,
+  ): Promise<AxiosResponse<T>>;
+  delete<T = any>(url: string, config?: any): Promise<AxiosResponse<T>>;
+}
+
+interface RetryOptions {
+  retries?: number;
+  factor?: number;
+  minTimeout?: number;
+  maxTimeout?: number;
+}
+
+interface CreateCollectionOptions {
+  collectionName: string;
+  vectorSize?: number;
+  distance?: QdrantDistanceMetric;
+  vectors?: Record<string, { size: number; distance: QdrantDistanceMetric }>;
+  shardNumber?: number;
+  replicationFactor?: number;
+  onDiskPayload?: boolean;
+}
+
+interface InsertVectorDataOptions {
+  collectionName: string;
+  points?: QdrantPoint[];
+  id?: QdrantPointId;
+  vector?: QdrantVector;
+  payload?: QdrantPayload;
+  wait?: boolean;
+}
+
+interface QueryPointsOptions {
+  collectionName: string;
+  query: QdrantVector;
+  limit?: number;
+  filter?: QdrantFilter;
+  using?: string;
+  withPayload?: boolean | string[] | QdrantPayload;
+  withVector?: boolean | string[];
+  scoreThreshold?: number;
+}
+
+interface SearchPointsOptions {
+  collectionName: string;
+  vector: QdrantVector;
+  limit?: number;
+  filter?: QdrantFilter;
+  withPayload?: boolean | string[] | QdrantPayload;
+  withVector?: boolean | string[];
+  scoreThreshold?: number;
+}
+
+interface GetDataByIdOptions {
+  collectionName: string;
+  ids: QdrantPointId[];
+  withPayload?: boolean | string[] | QdrantPayload;
+  withVector?: boolean | string[];
+}
+
+interface DeleteByIdOptions {
+  collectionName: string;
+  ids: QdrantPointId[];
+  wait?: boolean;
+}
+
+export class Qdrant {
+  url: string;
+  apiKey: string;
+  private client: QdrantHttpClient;
+  private retryOptions: Required<RetryOptions>;
+
+  constructor(options: QdrantConstructionOptions = {}) {
+    this.url = this.normalizeUrl(
+      options.url || process.env.QDRANT_URL || "http://localhost:6333",
+    );
+    this.apiKey = options.apiKey || process.env.QDRANT_API_KEY || "";
+    this.client =
+      options.httpClient ||
+      axios.create({
+        baseURL: this.url,
+        timeout: options.timeoutMs || 30000,
+        headers: {
+          "content-type": "application/json",
+          ...(this.apiKey ? { "api-key": this.apiKey } : {}),
+        },
+      });
+    this.retryOptions = {
+      retries: 5,
+      factor: 3,
+      minTimeout: 1 * 1000,
+      maxTimeout: 60 * 1000,
+    };
+  }
+
+  async createCollection({
+    collectionName,
+    vectorSize,
+    distance = "Cosine",
+    vectors,
+    shardNumber,
+    replicationFactor,
+    onDiskPayload,
+  }: CreateCollectionOptions): Promise<any> {
+    if (!vectors && !vectorSize) {
+      throw new Error("Either vectorSize or vectors must be provided.");
+    }
+
+    const payload = {
+      vectors: vectors || { size: vectorSize, distance },
+      shard_number: shardNumber,
+      replication_factor: replicationFactor,
+      on_disk_payload: onDiskPayload,
+    };
+
+    return this.request(() =>
+      this.client.put(
+        `/collections/${this.collection(collectionName)}`,
+        this.removeUndefined(payload),
+      ),
+    );
+  }
+
+  async deleteCollection(collectionName: string): Promise<any> {
+    return this.request(() =>
+      this.client.delete(`/collections/${this.collection(collectionName)}`),
+    );
+  }
+
+  async insertVectorData({
+    collectionName,
+    points,
+    id,
+    vector,
+    payload,
+    wait = true,
+  }: InsertVectorDataOptions): Promise<any> {
+    const pointsToInsert =
+      points ||
+      (id !== undefined && vector ? [{ id, vector, payload }] : undefined);
+    if (!pointsToInsert?.length) {
+      throw new Error("At least one point or id/vector pair must be provided.");
+    }
+
+    return this.request(() =>
+      this.client.put(
+        `/collections/${this.collection(collectionName)}/points${this.waitParam(wait)}`,
+        {
+          points: pointsToInsert,
+        },
+      ),
+    );
+  }
+
+  async queryPoints({
+    collectionName,
+    query,
+    limit = 10,
+    filter,
+    using,
+    withPayload = true,
+    withVector = false,
+    scoreThreshold,
+  }: QueryPointsOptions): Promise<any> {
+    return this.request(() =>
+      this.client.post(
+        `/collections/${this.collection(collectionName)}/points/query`,
+        this.removeUndefined({
+          query,
+          limit,
+          filter,
+          using,
+          with_payload: withPayload,
+          with_vector: withVector,
+          score_threshold: scoreThreshold,
+        }),
+      ),
+    );
+  }
+
+  async searchPoints({
+    collectionName,
+    vector,
+    limit = 10,
+    filter,
+    withPayload = true,
+    withVector = false,
+    scoreThreshold,
+  }: SearchPointsOptions): Promise<any> {
+    return this.request(() =>
+      this.client.post(
+        `/collections/${this.collection(collectionName)}/points/search`,
+        this.removeUndefined({
+          vector,
+          limit,
+          filter,
+          with_payload: withPayload,
+          with_vector: withVector,
+          score_threshold: scoreThreshold,
+        }),
+      ),
+    );
+  }
+
+  async getDataById({
+    collectionName,
+    ids,
+    withPayload = true,
+    withVector = false,
+  }: GetDataByIdOptions): Promise<any> {
+    return this.request(() =>
+      this.client.post(
+        `/collections/${this.collection(collectionName)}/points`,
+        {
+          ids,
+          with_payload: withPayload,
+          with_vector: withVector,
+        },
+      ),
+    );
+  }
+
+  async deleteById({
+    collectionName,
+    ids,
+    wait = true,
+  }: DeleteByIdOptions): Promise<any> {
+    return this.request(() =>
+      this.client.post(
+        `/collections/${this.collection(collectionName)}/points/delete${this.waitParam(wait)}`,
+        {
+          points: ids,
+        },
+      ),
+    );
+  }
+
+  private async request<T>(
+    callback: () => Promise<AxiosResponse<T>>,
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const operation = retry.operation({
+        ...this.retryOptions,
+        randomize: true,
+      });
+
+      operation.attempt(async () => {
+        try {
+          const response = await callback();
+          resolve(response.data);
+        } catch (error: any) {
+          if (operation.retry(error)) return;
+          reject(error);
+        }
+      });
+    });
+  }
+
+  private collection(collectionName: string): string {
+    if (!collectionName) {
+      throw new Error("collectionName is required.");
+    }
+    return encodeURIComponent(collectionName);
+  }
+
+  private normalizeUrl(url: string): string {
+    return url.replace(/\/+$/, "");
+  }
+
+  private waitParam(wait: boolean): string {
+    return `?wait=${wait}`;
+  }
+
+  private removeUndefined<T extends Record<string, any>>(
+    payload: T,
+  ): Partial<T> {
+    return Object.fromEntries(
+      Object.entries(payload).filter(([, value]) => value !== undefined),
+    ) as Partial<T>;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,106 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+const createHttpClient = () => ({
+  get: jest.fn(),
+  put: jest.fn(),
+  post: jest.fn(),
+  delete: jest.fn(),
+});
+
+describe("Qdrant", () => {
+  it("creates a collection with the configured vector size", async () => {
+    const httpClient = createHttpClient();
+    httpClient.put.mockResolvedValue({ data: { result: true } });
+    const qdrant = new Qdrant({ url: "http://localhost:6333/", httpClient });
+
+    const result = await qdrant.createCollection({
+      collectionName: "documents",
+      vectorSize: 1536,
+      distance: "Cosine",
+    });
+
+    expect(result).toEqual({ result: true });
+    expect(httpClient.put).toHaveBeenCalledWith("/collections/documents", {
+      vectors: { size: 1536, distance: "Cosine" },
+    });
+  });
+
+  it("upserts vector points directly through the Qdrant REST API", async () => {
+    const httpClient = createHttpClient();
+    httpClient.put.mockResolvedValue({ data: { status: "ok" } });
+    const qdrant = new Qdrant({ httpClient });
+
+    const result = await qdrant.insertVectorData({
+      collectionName: "documents",
+      points: [
+        {
+          id: "doc-1",
+          vector: [0.1, 0.2, 0.3],
+          payload: { content: "hello" },
+        },
+      ],
+    });
+
+    expect(result).toEqual({ status: "ok" });
+    expect(httpClient.put).toHaveBeenCalledWith(
+      "/collections/documents/points?wait=true",
+      {
+        points: [
+          {
+            id: "doc-1",
+            vector: [0.1, 0.2, 0.3],
+            payload: { content: "hello" },
+          },
+        ],
+      },
+    );
+  });
+
+  it("queries points with payloads by default", async () => {
+    const httpClient = createHttpClient();
+    httpClient.post.mockResolvedValue({
+      data: {
+        result: {
+          points: [{ id: "doc-1", score: 0.9, payload: { content: "hello" } }],
+        },
+      },
+    });
+    const qdrant = new Qdrant({ httpClient });
+
+    const result = await qdrant.queryPoints({
+      collectionName: "documents",
+      query: [0.1, 0.2, 0.3],
+      limit: 3,
+    });
+
+    expect(result.result.points[0].id).toBe("doc-1");
+    expect(httpClient.post).toHaveBeenCalledWith(
+      "/collections/documents/points/query",
+      {
+        query: [0.1, 0.2, 0.3],
+        limit: 3,
+        with_payload: true,
+        with_vector: false,
+      },
+    );
+  });
+
+  it("deletes points by id", async () => {
+    const httpClient = createHttpClient();
+    httpClient.post.mockResolvedValue({ data: { status: "acknowledged" } });
+    const qdrant = new Qdrant({ httpClient });
+
+    const result = await qdrant.deleteById({
+      collectionName: "documents",
+      ids: ["doc-1", "doc-2"],
+    });
+
+    expect(result).toEqual({ status: "acknowledged" });
+    expect(httpClient.post).toHaveBeenCalledWith(
+      "/collections/documents/points/delete?wait=true",
+      {
+        points: ["doc-1", "doc-2"],
+      },
+    );
+  });
+});

--- a/JS/edgechains/examples/qdrant-vector-db/package.json
+++ b/JS/edgechains/examples/qdrant-vector-db/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "qdrant-vector-db-example",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsc && node dist/index.js"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "^0.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/JS/edgechains/examples/qdrant-vector-db/src/index.ts
+++ b/JS/edgechains/examples/qdrant-vector-db/src/index.ts
@@ -1,0 +1,43 @@
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant({
+  url: process.env.QDRANT_URL || "http://localhost:6333",
+  apiKey: process.env.QDRANT_API_KEY,
+});
+
+const collectionName = "edgechains-documents";
+
+async function main() {
+  await qdrant.createCollection({
+    collectionName,
+    vectorSize: 3,
+    distance: "Cosine",
+  });
+
+  await qdrant.insertVectorData({
+    collectionName,
+    points: [
+      {
+        id: "doc-1",
+        vector: [0.1, 0.2, 0.3],
+        payload: {
+          content: "Qdrant support in EdgeChains",
+          source: "example",
+        },
+      },
+    ],
+  });
+
+  const result = await qdrant.queryPoints({
+    collectionName,
+    query: [0.1, 0.2, 0.3],
+    limit: 1,
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/JS/edgechains/examples/qdrant-vector-db/tsconfig.json
+++ b/JS/edgechains/examples/qdrant-vector-db/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
/claim #273
Closes #273

Adds Qdrant vector database support to the JavaScript SDK using Qdrant's REST API directly, without adding a Qdrant package dependency.

Changes:
- Added `Qdrant` client under `vector-db`
- Exported Qdrant types and client from `vector-db`
- Added support for collection creation, point upsert, query/search, retrieve by id, delete by id
- Added mocked unit tests for REST API calls
- Added a small Qdrant vector DB example

Verification:
- `npx tsc -b`
- `npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand`
/claim #273