### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -3,3 +3,37 @@ Installation
 ```
 npm install arakoodev
 ```
+
+## Qdrant vector database
+
+The vector database package exports a Qdrant REST client alongside the existing
+Supabase client:
+
+```ts
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY);
+const client = qdrant.createClient();
+
+await qdrant.createCollection({
+    client,
+    collectionName: "documents",
+    vectorSize: 1536,
+    distance: "Cosine",
+});
+
+await qdrant.insertVectorData({
+    client,
+    collectionName: "documents",
+    id: "doc-1",
+    embedding: [0.1, 0.2, 0.3],
+    content: "stored as point payload",
+});
+
+const matches = await qdrant.getDataFromQuery({
+    client,
+    collectionName: "documents",
+    vector: [0.1, 0.2, 0.3],
+    limit: 5,
+});
+```

--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -16,24 +16,24 @@ const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY);
 const client = qdrant.createClient();
 
 await qdrant.createCollection({
-  client,
-  collectionName: "documents",
-  vectorSize: 1536,
-  distance: "Cosine",
+    client,
+    collectionName: "documents",
+    vectorSize: 1536,
+    distance: "Cosine",
 });
 
 await qdrant.insertVectorData({
-  client,
-  collectionName: "documents",
-  id: "doc-1",
-  embedding: [0.1, 0.2, 0.3],
-  content: "stored as point payload",
+    client,
+    collectionName: "documents",
+    id: "doc-1",
+    embedding: [0.1, 0.2, 0.3],
+    content: "stored as point payload",
 });
 
 const matches = await qdrant.getDataFromQuery({
-  client,
-  collectionName: "documents",
-  vector: [0.1, 0.2, 0.3],
-  limit: 5,
+    client,
+    collectionName: "documents",
+    vector: [0.1, 0.2, 0.3],
+    limit: 5,
 });
 ```

--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -16,24 +16,24 @@ const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY);
 const client = qdrant.createClient();
 
 await qdrant.createCollection({
-    client,
-    collectionName: "documents",
-    vectorSize: 1536,
-    distance: "Cosine",
+  client,
+  collectionName: "documents",
+  vectorSize: 1536,
+  distance: "Cosine",
 });
 
 await qdrant.insertVectorData({
-    client,
-    collectionName: "documents",
-    id: "doc-1",
-    embedding: [0.1, 0.2, 0.3],
-    content: "stored as point payload",
+  client,
+  collectionName: "documents",
+  id: "doc-1",
+  embedding: [0.1, 0.2, 0.3],
+  content: "stored as point payload",
 });
 
 const matches = await qdrant.getDataFromQuery({
-    client,
-    collectionName: "documents",
-    vector: [0.1, 0.2, 0.3],
-    limit: 5,
+  client,
+  collectionName: "documents",
+  vector: [0.1, 0.2, 0.3],
+  limit: 5,
 });
 ```

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -3,367 +3,360 @@ type QdrantFetch = (input: string, init?: RequestInit) => Promise<Response>;
 type QdrantPointId = string | number;
 
 interface QdrantClientOptions {
-  fetch?: QdrantFetch;
+    fetch?: QdrantFetch;
 }
 
 export interface QdrantClient {
-  url: string;
-  apiKey?: string;
-  fetch: QdrantFetch;
+    url: string;
+    apiKey?: string;
+    fetch: QdrantFetch;
 }
 
 interface QdrantResponse<T = any> {
-  result: T;
-  status?: string;
-  time?: number;
+    result: T;
+    status?: string;
+    time?: number;
 }
 
 interface QdrantRequestArgs {
-  client?: QdrantClient;
-  collectionName?: string;
-  tableName?: string;
+    client?: QdrantClient;
+    collectionName?: string;
+    tableName?: string;
 }
 
 interface CreateCollectionArgs extends QdrantRequestArgs {
-  vectors?: Record<string, any>;
-  vectorSize?: number;
-  distance?: string;
-  [key: string]: any;
+    vectors?: Record<string, any>;
+    vectorSize?: number;
+    distance?: string;
+    [key: string]: any;
 }
 
 interface InsertVectorDataArgs extends QdrantRequestArgs {
-  id?: QdrantPointId;
-  vector?: number[] | Record<string, number[]>;
-  embedding?: number[] | Record<string, number[]>;
-  payload?: Record<string, any>;
-  points?: Array<Record<string, any>>;
-  wait?: boolean;
-  [key: string]: any;
+    id?: QdrantPointId;
+    vector?: number[] | Record<string, number[]>;
+    embedding?: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+    points?: Array<Record<string, any>>;
+    wait?: boolean;
+    [key: string]: any;
 }
 
 interface GetDataFromQueryArgs extends QdrantRequestArgs {
-  vector?: number[] | Record<string, number[]>;
-  query?: number[] | Record<string, number[]>;
-  limit?: number;
-  filter?: Record<string, any>;
-  with_payload?: boolean | string[] | Record<string, any>;
-  with_vector?: boolean | string[] | Record<string, any>;
-  score_threshold?: number;
-  [key: string]: any;
+    vector?: number[] | Record<string, number[]>;
+    query?: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, any>;
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[] | Record<string, any>;
+    score_threshold?: number;
+    [key: string]: any;
 }
 
 interface GetDataArgs extends QdrantRequestArgs {
-  limit?: number;
-  offset?: QdrantPointId | Record<string, any>;
-  filter?: Record<string, any>;
-  with_payload?: boolean | string[] | Record<string, any>;
-  with_vector?: boolean | string[] | Record<string, any>;
+    limit?: number;
+    offset?: QdrantPointId | Record<string, any>;
+    filter?: Record<string, any>;
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[] | Record<string, any>;
 }
 
 interface GetDataByIdArgs extends QdrantRequestArgs {
-  id?: QdrantPointId;
-  ids?: QdrantPointId[];
-  with_payload?: boolean | string[] | Record<string, any>;
-  with_vector?: boolean | string[] | Record<string, any>;
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[] | Record<string, any>;
 }
 
 interface UpdateByIdArgs extends QdrantRequestArgs {
-  id: QdrantPointId;
-  updatedContent: Record<string, any>;
-  wait?: boolean;
+    id: QdrantPointId;
+    updatedContent: Record<string, any>;
+    wait?: boolean;
 }
 
 interface DeleteByIdArgs extends QdrantRequestArgs {
-  id?: QdrantPointId;
-  ids?: QdrantPointId[];
-  wait?: boolean;
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    wait?: boolean;
 }
 
 export class Qdrant {
-  QDRANT_URL: string;
-  QDRANT_API_KEY?: string;
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
 
-  constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
-    this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "";
-    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
-  }
-
-  createClient(options: QdrantClientOptions = {}): QdrantClient {
-    if (!this.QDRANT_URL) {
-      throw new Error("QDRANT_URL is required to create a Qdrant client");
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "";
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
     }
 
-    const fetchImplementation = options.fetch || globalThis.fetch;
-    if (!fetchImplementation) {
-      throw new Error("A fetch implementation is required to use Qdrant");
+    createClient(options: QdrantClientOptions = {}): QdrantClient {
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required to create a Qdrant client");
+        }
+
+        const fetchImplementation = options.fetch || globalThis.fetch;
+        if (!fetchImplementation) {
+            throw new Error("A fetch implementation is required to use Qdrant");
+        }
+
+        return {
+            url: this.QDRANT_URL.replace(/\/+$/, ""),
+            apiKey: this.QDRANT_API_KEY,
+            fetch: fetchImplementation.bind(globalThis),
+        };
     }
 
-    return {
-      url: this.QDRANT_URL.replace(/\/+$/, ""),
-      apiKey: this.QDRANT_API_KEY,
-      fetch: fetchImplementation.bind(globalThis),
-    };
-  }
+    async createCollection({
+        client,
+        collectionName,
+        tableName,
+        vectors,
+        vectorSize,
+        distance = "Cosine",
+        ...args
+    }: CreateCollectionArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        if (!vectors && !vectorSize && !args.size) {
+            throw new Error("vectorSize or vectors is required to create a Qdrant collection");
+        }
 
-  async createCollection({
-    client,
-    collectionName,
-    tableName,
-    vectors,
-    vectorSize,
-    distance = "Cosine",
-    ...args
-  }: CreateCollectionArgs): Promise<any> {
-    const collection = this.resolveCollectionName(collectionName, tableName);
-    if (!vectors && !vectorSize && !args.size) {
-      throw new Error(
-        "vectorSize or vectors is required to create a Qdrant collection",
-      );
+        const body = {
+            ...args,
+            vectors: vectors || {
+                size: vectorSize || args.size,
+                distance,
+            },
+        };
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}`,
+            body,
+        });
     }
 
-    const body = {
-      ...args,
-      vectors: vectors || {
-        size: vectorSize || args.size,
-        distance,
-      },
-    };
+    async insertVectorData({
+        client,
+        collectionName,
+        tableName,
+        id,
+        vector,
+        embedding,
+        payload,
+        points,
+        wait = true,
+        ...args
+    }: InsertVectorDataArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const pointVector = vector || embedding;
+        if (!points && (id === undefined || !pointVector)) {
+            throw new Error("id and vector or embedding are required to insert Qdrant data");
+        }
 
-    return this.request({
-      client,
-      method: "PUT",
-      path: `/collections/${encodeURIComponent(collection)}`,
-      body,
-    });
-  }
+        const body = {
+            points: points || [
+                {
+                    id,
+                    vector: pointVector,
+                    payload: payload || args,
+                },
+            ],
+        };
 
-  async insertVectorData({
-    client,
-    collectionName,
-    tableName,
-    id,
-    vector,
-    embedding,
-    payload,
-    points,
-    wait = true,
-    ...args
-  }: InsertVectorDataArgs): Promise<any> {
-    const collection = this.resolveCollectionName(collectionName, tableName);
-    const pointVector = vector || embedding;
-    if (!points && (id === undefined || !pointVector)) {
-      throw new Error(
-        "id and vector or embedding are required to insert Qdrant data",
-      );
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            query: { wait },
+            body,
+        });
     }
 
-    const body = {
-      points: points || [
-        {
-          id,
-          vector: pointVector,
-          payload: payload || args,
-        },
-      ],
-    };
+    async getDataFromQuery({
+        client,
+        collectionName,
+        tableName,
+        vector,
+        query,
+        limit = 10,
+        filter,
+        with_payload = true,
+        with_vector = false,
+        score_threshold,
+    }: GetDataFromQueryArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const queryVector = vector || query;
+        if (!queryVector) {
+            throw new Error("vector or query is required to search Qdrant data");
+        }
 
-    return this.request({
-      client,
-      method: "PUT",
-      path: `/collections/${encodeURIComponent(collection)}/points`,
-      query: { wait },
-      body,
-    });
-  }
+        const body = {
+            vector: queryVector,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            score_threshold,
+        };
 
-  async getDataFromQuery({
-    client,
-    collectionName,
-    tableName,
-    vector,
-    query,
-    limit = 10,
-    filter,
-    with_payload = true,
-    with_vector = false,
-    score_threshold,
-  }: GetDataFromQueryArgs): Promise<any> {
-    const collection = this.resolveCollectionName(collectionName, tableName);
-    const queryVector = vector || query;
-    if (!queryVector) {
-      throw new Error("vector or query is required to search Qdrant data");
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/search`,
+            body: this.compact(body),
+        });
     }
 
-    const body = {
-      vector: queryVector,
-      limit,
-      filter,
-      with_payload,
-      with_vector,
-      score_threshold,
-    };
-
-    return this.request({
-      client,
-      method: "POST",
-      path: `/collections/${encodeURIComponent(collection)}/points/search`,
-      body: this.compact(body),
-    });
-  }
-
-  async getData({
-    client,
-    collectionName,
-    tableName,
-    limit = 10,
-    offset,
-    filter,
-    with_payload = true,
-    with_vector = false,
-  }: GetDataArgs): Promise<any> {
-    const collection = this.resolveCollectionName(collectionName, tableName);
-    return this.request({
-      client,
-      method: "POST",
-      path: `/collections/${encodeURIComponent(collection)}/points/scroll`,
-      body: this.compact({
-        limit,
+    async getData({
+        client,
+        collectionName,
+        tableName,
+        limit = 10,
         offset,
         filter,
-        with_payload,
-        with_vector,
-      }),
-    });
-  }
-
-  async getDataById({
-    client,
-    collectionName,
-    tableName,
-    id,
-    ids,
-    with_payload = true,
-    with_vector = false,
-  }: GetDataByIdArgs): Promise<any> {
-    const collection = this.resolveCollectionName(collectionName, tableName);
-    const resolvedIds = ids || (id !== undefined ? [id] : []);
-    if (!resolvedIds.length) {
-      throw new Error("id or ids is required to retrieve Qdrant points");
+        with_payload = true,
+        with_vector = false,
+    }: GetDataArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/scroll`,
+            body: this.compact({
+                limit,
+                offset,
+                filter,
+                with_payload,
+                with_vector,
+            }),
+        });
     }
 
-    return this.request({
-      client,
-      method: "POST",
-      path: `/collections/${encodeURIComponent(collection)}/points`,
-      body: {
-        ids: resolvedIds,
-        with_payload,
-        with_vector,
-      },
-    });
-  }
+    async getDataById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        with_payload = true,
+        with_vector = false,
+    }: GetDataByIdArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to retrieve Qdrant points");
+        }
 
-  async updateById({
-    client,
-    collectionName,
-    tableName,
-    id,
-    updatedContent,
-    wait = true,
-  }: UpdateByIdArgs): Promise<any> {
-    const collection = this.resolveCollectionName(collectionName, tableName);
-    return this.request({
-      client,
-      method: "POST",
-      path: `/collections/${encodeURIComponent(collection)}/points/payload`,
-      query: { wait },
-      body: {
-        payload: updatedContent,
-        points: [id],
-      },
-    });
-  }
-
-  async deleteById({
-    client,
-    collectionName,
-    tableName,
-    id,
-    ids,
-    wait = true,
-  }: DeleteByIdArgs): Promise<any> {
-    const collection = this.resolveCollectionName(collectionName, tableName);
-    const resolvedIds = ids || (id !== undefined ? [id] : []);
-    if (!resolvedIds.length) {
-      throw new Error("id or ids is required to delete Qdrant points");
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            body: {
+                ids: resolvedIds,
+                with_payload,
+                with_vector,
+            },
+        });
     }
 
-    return this.request({
-      client,
-      method: "POST",
-      path: `/collections/${encodeURIComponent(collection)}/points/delete`,
-      query: { wait },
-      body: {
-        points: resolvedIds,
-      },
-    });
-  }
-
-  private async request({
-    client,
-    method,
-    path,
-    query,
-    body,
-  }: {
-    client?: QdrantClient;
-    method: string;
-    path: string;
-    query?: Record<string, string | number | boolean | undefined>;
-    body?: Record<string, any>;
-  }): Promise<any> {
-    const resolvedClient = client || this.createClient();
-    const url = new URL(`${resolvedClient.url}${path}`);
-
-    Object.entries(query || {}).forEach(([key, value]) => {
-      if (value !== undefined) {
-        url.searchParams.set(key, String(value));
-      }
-    });
-
-    const response = await resolvedClient.fetch(url.toString(), {
-      method,
-      headers: this.compact({
-        "Content-Type": "application/json",
-        "api-key": resolvedClient.apiKey,
-      }) as HeadersInit,
-      body: body ? JSON.stringify(body) : undefined,
-    });
-
-    const payload = (await response.json()) as QdrantResponse;
-    if (!response.ok) {
-      throw new Error(
-        `Qdrant request failed with status ${response.status}: ${JSON.stringify(payload)}`,
-      );
+    async updateById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        updatedContent,
+        wait = true,
+    }: UpdateByIdArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/payload`,
+            query: { wait },
+            body: {
+                payload: updatedContent,
+                points: [id],
+            },
+        });
     }
 
-    return payload.result ?? payload;
-  }
+    async deleteById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        wait = true,
+    }: DeleteByIdArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to delete Qdrant points");
+        }
 
-  private resolveCollectionName(
-    collectionName?: string,
-    tableName?: string,
-  ): string {
-    const collection = collectionName || tableName;
-    if (!collection) {
-      throw new Error("collectionName or tableName is required");
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/delete`,
+            query: { wait },
+            body: {
+                points: resolvedIds,
+            },
+        });
     }
-    return collection;
-  }
 
-  private compact<T extends Record<string, any>>(value: T): Partial<T> {
-    return Object.fromEntries(
-      Object.entries(value).filter(([, entry]) => entry !== undefined),
-    ) as Partial<T>;
-  }
+    private async request({
+        client,
+        method,
+        path,
+        query,
+        body,
+    }: {
+        client?: QdrantClient;
+        method: string;
+        path: string;
+        query?: Record<string, string | number | boolean | undefined>;
+        body?: Record<string, any>;
+    }): Promise<any> {
+        const resolvedClient = client || this.createClient();
+        const url = new URL(`${resolvedClient.url}${path}`);
+
+        Object.entries(query || {}).forEach(([key, value]) => {
+            if (value !== undefined) {
+                url.searchParams.set(key, String(value));
+            }
+        });
+
+        const response = await resolvedClient.fetch(url.toString(), {
+            method,
+            headers: this.compact({
+                "Content-Type": "application/json",
+                "api-key": resolvedClient.apiKey,
+            }) as HeadersInit,
+            body: body ? JSON.stringify(body) : undefined,
+        });
+
+        const payload = (await response.json()) as QdrantResponse;
+        if (!response.ok) {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(payload)}`
+            );
+        }
+
+        return payload.result ?? payload;
+    }
+
+    private resolveCollectionName(collectionName?: string, tableName?: string): string {
+        const collection = collectionName || tableName;
+        if (!collection) {
+            throw new Error("collectionName or tableName is required");
+        }
+        return collection;
+    }
+
+    private compact<T extends Record<string, any>>(value: T): Partial<T> {
+        return Object.fromEntries(
+            Object.entries(value).filter(([, entry]) => entry !== undefined)
+        ) as Partial<T>;
+    }
 }

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,362 @@
+type QdrantFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+type QdrantPointId = string | number;
+
+interface QdrantClientOptions {
+    fetch?: QdrantFetch;
+}
+
+export interface QdrantClient {
+    url: string;
+    apiKey?: string;
+    fetch: QdrantFetch;
+}
+
+interface QdrantResponse<T = any> {
+    result: T;
+    status?: string;
+    time?: number;
+}
+
+interface QdrantRequestArgs {
+    client?: QdrantClient;
+    collectionName?: string;
+    tableName?: string;
+}
+
+interface CreateCollectionArgs extends QdrantRequestArgs {
+    vectors?: Record<string, any>;
+    vectorSize?: number;
+    distance?: string;
+    [key: string]: any;
+}
+
+interface InsertVectorDataArgs extends QdrantRequestArgs {
+    id?: QdrantPointId;
+    vector?: number[] | Record<string, number[]>;
+    embedding?: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+    points?: Array<Record<string, any>>;
+    wait?: boolean;
+    [key: string]: any;
+}
+
+interface GetDataFromQueryArgs extends QdrantRequestArgs {
+    vector?: number[] | Record<string, number[]>;
+    query?: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, any>;
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[] | Record<string, any>;
+    score_threshold?: number;
+    [key: string]: any;
+}
+
+interface GetDataArgs extends QdrantRequestArgs {
+    limit?: number;
+    offset?: QdrantPointId | Record<string, any>;
+    filter?: Record<string, any>;
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[] | Record<string, any>;
+}
+
+interface GetDataByIdArgs extends QdrantRequestArgs {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[] | Record<string, any>;
+}
+
+interface UpdateByIdArgs extends QdrantRequestArgs {
+    id: QdrantPointId;
+    updatedContent: Record<string, any>;
+    wait?: boolean;
+}
+
+interface DeleteByIdArgs extends QdrantRequestArgs {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "";
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(options: QdrantClientOptions = {}): QdrantClient {
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required to create a Qdrant client");
+        }
+
+        const fetchImplementation = options.fetch || globalThis.fetch;
+        if (!fetchImplementation) {
+            throw new Error("A fetch implementation is required to use Qdrant");
+        }
+
+        return {
+            url: this.QDRANT_URL.replace(/\/+$/, ""),
+            apiKey: this.QDRANT_API_KEY,
+            fetch: fetchImplementation.bind(globalThis),
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        tableName,
+        vectors,
+        vectorSize,
+        distance = "Cosine",
+        ...args
+    }: CreateCollectionArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        if (!vectors && !vectorSize && !args.size) {
+            throw new Error("vectorSize or vectors is required to create a Qdrant collection");
+        }
+
+        const body = {
+            ...args,
+            vectors: vectors || {
+                size: vectorSize || args.size,
+                distance,
+            },
+        };
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}`,
+            body,
+        });
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        tableName,
+        id,
+        vector,
+        embedding,
+        payload,
+        points,
+        wait = true,
+        ...args
+    }: InsertVectorDataArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const pointVector = vector || embedding;
+        if (!points && (id === undefined || !pointVector)) {
+            throw new Error("id and vector or embedding are required to insert Qdrant data");
+        }
+
+        const body = {
+            points: points || [
+                {
+                    id,
+                    vector: pointVector,
+                    payload: payload || args,
+                },
+            ],
+        };
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            query: { wait },
+            body,
+        });
+    }
+
+    async getDataFromQuery({
+        client,
+        collectionName,
+        tableName,
+        vector,
+        query,
+        limit = 10,
+        filter,
+        with_payload = true,
+        with_vector = false,
+        score_threshold,
+    }: GetDataFromQueryArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const queryVector = vector || query;
+        if (!queryVector) {
+            throw new Error("vector or query is required to search Qdrant data");
+        }
+
+        const body = {
+            vector: queryVector,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            score_threshold,
+        };
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/search`,
+            body: this.compact(body),
+        });
+    }
+
+    async getData({
+        client,
+        collectionName,
+        tableName,
+        limit = 10,
+        offset,
+        filter,
+        with_payload = true,
+        with_vector = false,
+    }: GetDataArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/scroll`,
+            body: this.compact({
+                limit,
+                offset,
+                filter,
+                with_payload,
+                with_vector,
+            }),
+        });
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        with_payload = true,
+        with_vector = false,
+    }: GetDataByIdArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to retrieve Qdrant points");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            body: {
+                ids: resolvedIds,
+                with_payload,
+                with_vector,
+            },
+        });
+    }
+
+    async updateById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        updatedContent,
+        wait = true,
+    }: UpdateByIdArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/payload`,
+            query: { wait },
+            body: {
+                payload: updatedContent,
+                points: [id],
+            },
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        wait = true,
+    }: DeleteByIdArgs): Promise<any> {
+        const collection = this.resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to delete Qdrant points");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/delete`,
+            query: { wait },
+            body: {
+                points: resolvedIds,
+            },
+        });
+    }
+
+    private async request({
+        client,
+        method,
+        path,
+        query,
+        body,
+    }: {
+        client?: QdrantClient;
+        method: string;
+        path: string;
+        query?: Record<string, string | number | boolean | undefined>;
+        body?: Record<string, any>;
+    }): Promise<any> {
+        const resolvedClient = client || this.createClient();
+        const url = new URL(`${resolvedClient.url}${path}`);
+
+        Object.entries(query || {}).forEach(([key, value]) => {
+            if (value !== undefined) {
+                url.searchParams.set(key, String(value));
+            }
+        });
+
+        const response = await resolvedClient.fetch(url.toString(), {
+            method,
+            headers: this.compact({
+                "Content-Type": "application/json",
+                "api-key": resolvedClient.apiKey,
+            }) as HeadersInit,
+            body: body ? JSON.stringify(body) : undefined,
+        });
+
+        const payload = (await response.json()) as QdrantResponse;
+        if (!response.ok) {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(payload)}`
+            );
+        }
+
+        return payload.result ?? payload;
+    }
+
+    private resolveCollectionName(collectionName?: string, tableName?: string): string {
+        const collection = collectionName || tableName;
+        if (!collection) {
+            throw new Error("collectionName or tableName is required");
+        }
+        return collection;
+    }
+
+    private compact<T extends Record<string, any>>(value: T): Partial<T> {
+        return Object.fromEntries(
+            Object.entries(value).filter(([, entry]) => entry !== undefined)
+        ) as Partial<T>;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -3,360 +3,367 @@ type QdrantFetch = (input: string, init?: RequestInit) => Promise<Response>;
 type QdrantPointId = string | number;
 
 interface QdrantClientOptions {
-    fetch?: QdrantFetch;
+  fetch?: QdrantFetch;
 }
 
 export interface QdrantClient {
-    url: string;
-    apiKey?: string;
-    fetch: QdrantFetch;
+  url: string;
+  apiKey?: string;
+  fetch: QdrantFetch;
 }
 
 interface QdrantResponse<T = any> {
-    result: T;
-    status?: string;
-    time?: number;
+  result: T;
+  status?: string;
+  time?: number;
 }
 
 interface QdrantRequestArgs {
-    client?: QdrantClient;
-    collectionName?: string;
-    tableName?: string;
+  client?: QdrantClient;
+  collectionName?: string;
+  tableName?: string;
 }
 
 interface CreateCollectionArgs extends QdrantRequestArgs {
-    vectors?: Record<string, any>;
-    vectorSize?: number;
-    distance?: string;
-    [key: string]: any;
+  vectors?: Record<string, any>;
+  vectorSize?: number;
+  distance?: string;
+  [key: string]: any;
 }
 
 interface InsertVectorDataArgs extends QdrantRequestArgs {
-    id?: QdrantPointId;
-    vector?: number[] | Record<string, number[]>;
-    embedding?: number[] | Record<string, number[]>;
-    payload?: Record<string, any>;
-    points?: Array<Record<string, any>>;
-    wait?: boolean;
-    [key: string]: any;
+  id?: QdrantPointId;
+  vector?: number[] | Record<string, number[]>;
+  embedding?: number[] | Record<string, number[]>;
+  payload?: Record<string, any>;
+  points?: Array<Record<string, any>>;
+  wait?: boolean;
+  [key: string]: any;
 }
 
 interface GetDataFromQueryArgs extends QdrantRequestArgs {
-    vector?: number[] | Record<string, number[]>;
-    query?: number[] | Record<string, number[]>;
-    limit?: number;
-    filter?: Record<string, any>;
-    with_payload?: boolean | string[] | Record<string, any>;
-    with_vector?: boolean | string[] | Record<string, any>;
-    score_threshold?: number;
-    [key: string]: any;
+  vector?: number[] | Record<string, number[]>;
+  query?: number[] | Record<string, number[]>;
+  limit?: number;
+  filter?: Record<string, any>;
+  with_payload?: boolean | string[] | Record<string, any>;
+  with_vector?: boolean | string[] | Record<string, any>;
+  score_threshold?: number;
+  [key: string]: any;
 }
 
 interface GetDataArgs extends QdrantRequestArgs {
-    limit?: number;
-    offset?: QdrantPointId | Record<string, any>;
-    filter?: Record<string, any>;
-    with_payload?: boolean | string[] | Record<string, any>;
-    with_vector?: boolean | string[] | Record<string, any>;
+  limit?: number;
+  offset?: QdrantPointId | Record<string, any>;
+  filter?: Record<string, any>;
+  with_payload?: boolean | string[] | Record<string, any>;
+  with_vector?: boolean | string[] | Record<string, any>;
 }
 
 interface GetDataByIdArgs extends QdrantRequestArgs {
-    id?: QdrantPointId;
-    ids?: QdrantPointId[];
-    with_payload?: boolean | string[] | Record<string, any>;
-    with_vector?: boolean | string[] | Record<string, any>;
+  id?: QdrantPointId;
+  ids?: QdrantPointId[];
+  with_payload?: boolean | string[] | Record<string, any>;
+  with_vector?: boolean | string[] | Record<string, any>;
 }
 
 interface UpdateByIdArgs extends QdrantRequestArgs {
-    id: QdrantPointId;
-    updatedContent: Record<string, any>;
-    wait?: boolean;
+  id: QdrantPointId;
+  updatedContent: Record<string, any>;
+  wait?: boolean;
 }
 
 interface DeleteByIdArgs extends QdrantRequestArgs {
-    id?: QdrantPointId;
-    ids?: QdrantPointId[];
-    wait?: boolean;
+  id?: QdrantPointId;
+  ids?: QdrantPointId[];
+  wait?: boolean;
 }
 
 export class Qdrant {
-    QDRANT_URL: string;
-    QDRANT_API_KEY?: string;
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
 
-    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
-        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "";
-        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+  constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+    this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "";
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+  }
+
+  createClient(options: QdrantClientOptions = {}): QdrantClient {
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required to create a Qdrant client");
     }
 
-    createClient(options: QdrantClientOptions = {}): QdrantClient {
-        if (!this.QDRANT_URL) {
-            throw new Error("QDRANT_URL is required to create a Qdrant client");
-        }
-
-        const fetchImplementation = options.fetch || globalThis.fetch;
-        if (!fetchImplementation) {
-            throw new Error("A fetch implementation is required to use Qdrant");
-        }
-
-        return {
-            url: this.QDRANT_URL.replace(/\/+$/, ""),
-            apiKey: this.QDRANT_API_KEY,
-            fetch: fetchImplementation.bind(globalThis),
-        };
+    const fetchImplementation = options.fetch || globalThis.fetch;
+    if (!fetchImplementation) {
+      throw new Error("A fetch implementation is required to use Qdrant");
     }
 
-    async createCollection({
-        client,
-        collectionName,
-        tableName,
-        vectors,
-        vectorSize,
-        distance = "Cosine",
-        ...args
-    }: CreateCollectionArgs): Promise<any> {
-        const collection = this.resolveCollectionName(collectionName, tableName);
-        if (!vectors && !vectorSize && !args.size) {
-            throw new Error("vectorSize or vectors is required to create a Qdrant collection");
-        }
+    return {
+      url: this.QDRANT_URL.replace(/\/+$/, ""),
+      apiKey: this.QDRANT_API_KEY,
+      fetch: fetchImplementation.bind(globalThis),
+    };
+  }
 
-        const body = {
-            ...args,
-            vectors: vectors || {
-                size: vectorSize || args.size,
-                distance,
-            },
-        };
-
-        return this.request({
-            client,
-            method: "PUT",
-            path: `/collections/${encodeURIComponent(collection)}`,
-            body,
-        });
+  async createCollection({
+    client,
+    collectionName,
+    tableName,
+    vectors,
+    vectorSize,
+    distance = "Cosine",
+    ...args
+  }: CreateCollectionArgs): Promise<any> {
+    const collection = this.resolveCollectionName(collectionName, tableName);
+    if (!vectors && !vectorSize && !args.size) {
+      throw new Error(
+        "vectorSize or vectors is required to create a Qdrant collection",
+      );
     }
 
-    async insertVectorData({
-        client,
-        collectionName,
-        tableName,
-        id,
-        vector,
-        embedding,
-        payload,
-        points,
-        wait = true,
-        ...args
-    }: InsertVectorDataArgs): Promise<any> {
-        const collection = this.resolveCollectionName(collectionName, tableName);
-        const pointVector = vector || embedding;
-        if (!points && (id === undefined || !pointVector)) {
-            throw new Error("id and vector or embedding are required to insert Qdrant data");
-        }
+    const body = {
+      ...args,
+      vectors: vectors || {
+        size: vectorSize || args.size,
+        distance,
+      },
+    };
 
-        const body = {
-            points: points || [
-                {
-                    id,
-                    vector: pointVector,
-                    payload: payload || args,
-                },
-            ],
-        };
+    return this.request({
+      client,
+      method: "PUT",
+      path: `/collections/${encodeURIComponent(collection)}`,
+      body,
+    });
+  }
 
-        return this.request({
-            client,
-            method: "PUT",
-            path: `/collections/${encodeURIComponent(collection)}/points`,
-            query: { wait },
-            body,
-        });
+  async insertVectorData({
+    client,
+    collectionName,
+    tableName,
+    id,
+    vector,
+    embedding,
+    payload,
+    points,
+    wait = true,
+    ...args
+  }: InsertVectorDataArgs): Promise<any> {
+    const collection = this.resolveCollectionName(collectionName, tableName);
+    const pointVector = vector || embedding;
+    if (!points && (id === undefined || !pointVector)) {
+      throw new Error(
+        "id and vector or embedding are required to insert Qdrant data",
+      );
     }
 
-    async getDataFromQuery({
-        client,
-        collectionName,
-        tableName,
-        vector,
-        query,
-        limit = 10,
-        filter,
-        with_payload = true,
-        with_vector = false,
-        score_threshold,
-    }: GetDataFromQueryArgs): Promise<any> {
-        const collection = this.resolveCollectionName(collectionName, tableName);
-        const queryVector = vector || query;
-        if (!queryVector) {
-            throw new Error("vector or query is required to search Qdrant data");
-        }
+    const body = {
+      points: points || [
+        {
+          id,
+          vector: pointVector,
+          payload: payload || args,
+        },
+      ],
+    };
 
-        const body = {
-            vector: queryVector,
-            limit,
-            filter,
-            with_payload,
-            with_vector,
-            score_threshold,
-        };
+    return this.request({
+      client,
+      method: "PUT",
+      path: `/collections/${encodeURIComponent(collection)}/points`,
+      query: { wait },
+      body,
+    });
+  }
 
-        return this.request({
-            client,
-            method: "POST",
-            path: `/collections/${encodeURIComponent(collection)}/points/search`,
-            body: this.compact(body),
-        });
+  async getDataFromQuery({
+    client,
+    collectionName,
+    tableName,
+    vector,
+    query,
+    limit = 10,
+    filter,
+    with_payload = true,
+    with_vector = false,
+    score_threshold,
+  }: GetDataFromQueryArgs): Promise<any> {
+    const collection = this.resolveCollectionName(collectionName, tableName);
+    const queryVector = vector || query;
+    if (!queryVector) {
+      throw new Error("vector or query is required to search Qdrant data");
     }
 
-    async getData({
-        client,
-        collectionName,
-        tableName,
-        limit = 10,
+    const body = {
+      vector: queryVector,
+      limit,
+      filter,
+      with_payload,
+      with_vector,
+      score_threshold,
+    };
+
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${encodeURIComponent(collection)}/points/search`,
+      body: this.compact(body),
+    });
+  }
+
+  async getData({
+    client,
+    collectionName,
+    tableName,
+    limit = 10,
+    offset,
+    filter,
+    with_payload = true,
+    with_vector = false,
+  }: GetDataArgs): Promise<any> {
+    const collection = this.resolveCollectionName(collectionName, tableName);
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${encodeURIComponent(collection)}/points/scroll`,
+      body: this.compact({
+        limit,
         offset,
         filter,
-        with_payload = true,
-        with_vector = false,
-    }: GetDataArgs): Promise<any> {
-        const collection = this.resolveCollectionName(collectionName, tableName);
-        return this.request({
-            client,
-            method: "POST",
-            path: `/collections/${encodeURIComponent(collection)}/points/scroll`,
-            body: this.compact({
-                limit,
-                offset,
-                filter,
-                with_payload,
-                with_vector,
-            }),
-        });
+        with_payload,
+        with_vector,
+      }),
+    });
+  }
+
+  async getDataById({
+    client,
+    collectionName,
+    tableName,
+    id,
+    ids,
+    with_payload = true,
+    with_vector = false,
+  }: GetDataByIdArgs): Promise<any> {
+    const collection = this.resolveCollectionName(collectionName, tableName);
+    const resolvedIds = ids || (id !== undefined ? [id] : []);
+    if (!resolvedIds.length) {
+      throw new Error("id or ids is required to retrieve Qdrant points");
     }
 
-    async getDataById({
-        client,
-        collectionName,
-        tableName,
-        id,
-        ids,
-        with_payload = true,
-        with_vector = false,
-    }: GetDataByIdArgs): Promise<any> {
-        const collection = this.resolveCollectionName(collectionName, tableName);
-        const resolvedIds = ids || (id !== undefined ? [id] : []);
-        if (!resolvedIds.length) {
-            throw new Error("id or ids is required to retrieve Qdrant points");
-        }
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${encodeURIComponent(collection)}/points`,
+      body: {
+        ids: resolvedIds,
+        with_payload,
+        with_vector,
+      },
+    });
+  }
 
-        return this.request({
-            client,
-            method: "POST",
-            path: `/collections/${encodeURIComponent(collection)}/points`,
-            body: {
-                ids: resolvedIds,
-                with_payload,
-                with_vector,
-            },
-        });
+  async updateById({
+    client,
+    collectionName,
+    tableName,
+    id,
+    updatedContent,
+    wait = true,
+  }: UpdateByIdArgs): Promise<any> {
+    const collection = this.resolveCollectionName(collectionName, tableName);
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${encodeURIComponent(collection)}/points/payload`,
+      query: { wait },
+      body: {
+        payload: updatedContent,
+        points: [id],
+      },
+    });
+  }
+
+  async deleteById({
+    client,
+    collectionName,
+    tableName,
+    id,
+    ids,
+    wait = true,
+  }: DeleteByIdArgs): Promise<any> {
+    const collection = this.resolveCollectionName(collectionName, tableName);
+    const resolvedIds = ids || (id !== undefined ? [id] : []);
+    if (!resolvedIds.length) {
+      throw new Error("id or ids is required to delete Qdrant points");
     }
 
-    async updateById({
-        client,
-        collectionName,
-        tableName,
-        id,
-        updatedContent,
-        wait = true,
-    }: UpdateByIdArgs): Promise<any> {
-        const collection = this.resolveCollectionName(collectionName, tableName);
-        return this.request({
-            client,
-            method: "POST",
-            path: `/collections/${encodeURIComponent(collection)}/points/payload`,
-            query: { wait },
-            body: {
-                payload: updatedContent,
-                points: [id],
-            },
-        });
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${encodeURIComponent(collection)}/points/delete`,
+      query: { wait },
+      body: {
+        points: resolvedIds,
+      },
+    });
+  }
+
+  private async request({
+    client,
+    method,
+    path,
+    query,
+    body,
+  }: {
+    client?: QdrantClient;
+    method: string;
+    path: string;
+    query?: Record<string, string | number | boolean | undefined>;
+    body?: Record<string, any>;
+  }): Promise<any> {
+    const resolvedClient = client || this.createClient();
+    const url = new URL(`${resolvedClient.url}${path}`);
+
+    Object.entries(query || {}).forEach(([key, value]) => {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    });
+
+    const response = await resolvedClient.fetch(url.toString(), {
+      method,
+      headers: this.compact({
+        "Content-Type": "application/json",
+        "api-key": resolvedClient.apiKey,
+      }) as HeadersInit,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const payload = (await response.json()) as QdrantResponse;
+    if (!response.ok) {
+      throw new Error(
+        `Qdrant request failed with status ${response.status}: ${JSON.stringify(payload)}`,
+      );
     }
 
-    async deleteById({
-        client,
-        collectionName,
-        tableName,
-        id,
-        ids,
-        wait = true,
-    }: DeleteByIdArgs): Promise<any> {
-        const collection = this.resolveCollectionName(collectionName, tableName);
-        const resolvedIds = ids || (id !== undefined ? [id] : []);
-        if (!resolvedIds.length) {
-            throw new Error("id or ids is required to delete Qdrant points");
-        }
+    return payload.result ?? payload;
+  }
 
-        return this.request({
-            client,
-            method: "POST",
-            path: `/collections/${encodeURIComponent(collection)}/points/delete`,
-            query: { wait },
-            body: {
-                points: resolvedIds,
-            },
-        });
+  private resolveCollectionName(
+    collectionName?: string,
+    tableName?: string,
+  ): string {
+    const collection = collectionName || tableName;
+    if (!collection) {
+      throw new Error("collectionName or tableName is required");
     }
+    return collection;
+  }
 
-    private async request({
-        client,
-        method,
-        path,
-        query,
-        body,
-    }: {
-        client?: QdrantClient;
-        method: string;
-        path: string;
-        query?: Record<string, string | number | boolean | undefined>;
-        body?: Record<string, any>;
-    }): Promise<any> {
-        const resolvedClient = client || this.createClient();
-        const url = new URL(`${resolvedClient.url}${path}`);
-
-        Object.entries(query || {}).forEach(([key, value]) => {
-            if (value !== undefined) {
-                url.searchParams.set(key, String(value));
-            }
-        });
-
-        const response = await resolvedClient.fetch(url.toString(), {
-            method,
-            headers: this.compact({
-                "Content-Type": "application/json",
-                "api-key": resolvedClient.apiKey,
-            }) as HeadersInit,
-            body: body ? JSON.stringify(body) : undefined,
-        });
-
-        const payload = (await response.json()) as QdrantResponse;
-        if (!response.ok) {
-            throw new Error(
-                `Qdrant request failed with status ${response.status}: ${JSON.stringify(payload)}`
-            );
-        }
-
-        return payload.result ?? payload;
-    }
-
-    private resolveCollectionName(collectionName?: string, tableName?: string): string {
-        const collection = collectionName || tableName;
-        if (!collection) {
-            throw new Error("collectionName or tableName is required");
-        }
-        return collection;
-    }
-
-    private compact<T extends Record<string, any>>(value: T): Partial<T> {
-        return Object.fromEntries(
-            Object.entries(value).filter(([, entry]) => entry !== undefined)
-        ) as Partial<T>;
-    }
+  private compact<T extends Record<string, any>>(value: T): Partial<T> {
+    return Object.fromEntries(
+      Object.entries(value).filter(([, entry]) => entry !== undefined),
+    ) as Partial<T>;
+  }
 }

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -6,190 +6,186 @@ const MOCK_QDRANT_URL = "https://qdrant.example.com";
 const MOCK_QDRANT_API_KEY = "mock-api-key";
 
 function createFetchMock(result: unknown = { ok: true }) {
-  return vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    json: async () => ({ result }),
-  });
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ result }),
+    });
 }
 
 function parseBody(fetchMock: ReturnType<typeof createFetchMock>) {
-  const init = fetchMock.mock.calls[0][1] as RequestInit;
-  return JSON.parse(init.body as string);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    return JSON.parse(init.body as string);
 }
 
 describe("Qdrant", () => {
-  let qdrant: Qdrant;
+    let qdrant: Qdrant;
 
-  beforeEach(() => {
-    qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
-  });
-
-  it("creates collections through the Qdrant REST API", async () => {
-    const fetchMock = createFetchMock({ acknowledged: true });
-    const client = qdrant.createClient({ fetch: fetchMock });
-
-    await qdrant.createCollection({
-      client,
-      collectionName: "documents",
-      vectorSize: 1536,
-      distance: "Cosine",
+    beforeEach(() => {
+        qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://qdrant.example.com/collections/documents",
-      expect.objectContaining({
-        method: "PUT",
-        headers: expect.objectContaining({
-          "api-key": MOCK_QDRANT_API_KEY,
-        }),
-      }),
-    );
-    expect(parseBody(fetchMock)).toEqual({
-      vectors: {
-        size: 1536,
-        distance: "Cosine",
-      },
+    it("creates collections through the Qdrant REST API", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+            distance: "Cosine",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents",
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "api-key": MOCK_QDRANT_API_KEY,
+                }),
+            })
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
     });
-  });
 
-  it("upserts vector payloads using the existing insertVectorData shape", async () => {
-    const fetchMock = createFetchMock({ operation_id: 1 });
-    const client = qdrant.createClient({ fetch: fetchMock });
+    it("upserts vector payloads using the existing insertVectorData shape", async () => {
+        const fetchMock = createFetchMock({ operation_id: 1 });
+        const client = qdrant.createClient({ fetch: fetchMock });
 
-    await qdrant.insertVectorData({
-      client,
-      tableName: "documents",
-      id: 42,
-      content: "Qdrant supports direct REST inserts",
-      embedding: [0.1, 0.2, 0.3],
-    });
-
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      "https://qdrant.example.com/collections/documents/points?wait=true",
-    );
-    expect(parseBody(fetchMock)).toEqual({
-      points: [
-        {
-          id: 42,
-          vector: [0.1, 0.2, 0.3],
-          payload: {
+        await qdrant.insertVectorData({
+            client,
+            tableName: "documents",
+            id: 42,
             content: "Qdrant supports direct REST inserts",
-          },
-        },
-      ],
-    });
-  });
+            embedding: [0.1, 0.2, 0.3],
+        });
 
-  it("searches by vector and returns the Qdrant result payload", async () => {
-    const fetchMock = createFetchMock([{ id: 7, score: 0.98 }]);
-    const client = qdrant.createClient({ fetch: fetchMock });
-
-    const result = await qdrant.getDataFromQuery({
-      client,
-      collectionName: "documents",
-      vector: [0.4, 0.5],
-      limit: 3,
-      filter: { must: [{ key: "source", match: { value: "docs" } }] },
-    });
-
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      "https://qdrant.example.com/collections/documents/points/search",
-    );
-    expect(parseBody(fetchMock)).toEqual({
-      vector: [0.4, 0.5],
-      limit: 3,
-      filter: { must: [{ key: "source", match: { value: "docs" } }] },
-      with_payload: true,
-      with_vector: false,
-    });
-    expect(result).toEqual([{ id: 7, score: 0.98 }]);
-  });
-
-  it("scrolls collection points with payloads enabled", async () => {
-    const fetchMock = createFetchMock({
-      points: [{ id: 1 }],
-      next_page_offset: null,
-    });
-    const client = qdrant.createClient({ fetch: fetchMock });
-
-    await qdrant.getData({
-      client,
-      collectionName: "documents",
-      limit: 2,
-      filter: { must_not: [{ key: "archived", match: { value: true } }] },
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example.com/collections/documents/points?wait=true"
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            points: [
+                {
+                    id: 42,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: {
+                        content: "Qdrant supports direct REST inserts",
+                    },
+                },
+            ],
+        });
     });
 
-    expect(fetchMock.mock.calls[0][0]).toBe(
-      "https://qdrant.example.com/collections/documents/points/scroll",
-    );
-    expect(parseBody(fetchMock)).toEqual({
-      limit: 2,
-      filter: { must_not: [{ key: "archived", match: { value: true } }] },
-      with_payload: true,
-      with_vector: false,
+    it("searches by vector and returns the Qdrant result payload", async () => {
+        const fetchMock = createFetchMock([{ id: 7, score: 0.98 }]);
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "documents",
+            vector: [0.4, 0.5],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+        });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example.com/collections/documents/points/search"
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            vector: [0.4, 0.5],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+            with_payload: true,
+            with_vector: false,
+        });
+        expect(result).toEqual([{ id: 7, score: 0.98 }]);
     });
-  });
 
-  it("retrieves, updates, and deletes points by id", async () => {
-    const fetchMock = createFetchMock({ acknowledged: true });
-    const client = qdrant.createClient({ fetch: fetchMock });
+    it("scrolls collection points with payloads enabled", async () => {
+        const fetchMock = createFetchMock({
+            points: [{ id: 1 }],
+            next_page_offset: null,
+        });
+        const client = qdrant.createClient({ fetch: fetchMock });
 
-    await qdrant.getDataById({ client, tableName: "documents", id: "doc-1" });
-    await qdrant.updateById({
-      client,
-      tableName: "documents",
-      id: "doc-1",
-      updatedContent: { status: "reviewed" },
+        await qdrant.getData({
+            client,
+            collectionName: "documents",
+            limit: 2,
+            filter: { must_not: [{ key: "archived", match: { value: true } }] },
+        });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example.com/collections/documents/points/scroll"
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            limit: 2,
+            filter: { must_not: [{ key: "archived", match: { value: true } }] },
+            with_payload: true,
+            with_vector: false,
+        });
     });
-    await qdrant.deleteById({ client, tableName: "documents", id: "doc-1" });
 
-    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
-      "https://qdrant.example.com/collections/documents/points",
-      "https://qdrant.example.com/collections/documents/points/payload?wait=true",
-      "https://qdrant.example.com/collections/documents/points/delete?wait=true",
-    ]);
-    expect(
-      JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string),
-    ).toEqual({
-      payload: { status: "reviewed" },
-      points: ["doc-1"],
+    it("retrieves, updates, and deletes points by id", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.getDataById({ client, tableName: "documents", id: "doc-1" });
+        await qdrant.updateById({
+            client,
+            tableName: "documents",
+            id: "doc-1",
+            updatedContent: { status: "reviewed" },
+        });
+        await qdrant.deleteById({ client, tableName: "documents", id: "doc-1" });
+
+        expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+            "https://qdrant.example.com/collections/documents/points",
+            "https://qdrant.example.com/collections/documents/points/payload?wait=true",
+            "https://qdrant.example.com/collections/documents/points/delete?wait=true",
+        ]);
+        expect(JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string)).toEqual({
+            payload: { status: "reviewed" },
+            points: ["doc-1"],
+        });
+        expect(JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string)).toEqual({
+            points: ["doc-1"],
+        });
     });
-    expect(
-      JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string),
-    ).toEqual({
-      points: ["doc-1"],
+
+    it("throws a useful error when Qdrant returns a non-2xx response", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 401,
+            json: async () => ({ status: "error", result: null }),
+        });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await expect(
+            qdrant.getDataFromQuery({
+                client,
+                collectionName: "documents",
+                vector: [0.1, 0.2],
+            })
+        ).rejects.toThrow("Qdrant request failed with status 401");
     });
-  });
 
-  it("throws a useful error when Qdrant returns a non-2xx response", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: async () => ({ status: "error", result: null }),
+    it("validates required point data before making REST calls", async () => {
+        const fetchMock = createFetchMock();
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await expect(
+            qdrant.insertVectorData({
+                client,
+                collectionName: "documents",
+                content: "missing id and vector",
+            })
+        ).rejects.toThrow("id and vector or embedding are required");
+        expect(fetchMock).not.toHaveBeenCalled();
     });
-    const client = qdrant.createClient({ fetch: fetchMock });
-
-    await expect(
-      qdrant.getDataFromQuery({
-        client,
-        collectionName: "documents",
-        vector: [0.1, 0.2],
-      }),
-    ).rejects.toThrow("Qdrant request failed with status 401");
-  });
-
-  it("validates required point data before making REST calls", async () => {
-    const fetchMock = createFetchMock();
-    const client = qdrant.createClient({ fetch: fetchMock });
-
-    await expect(
-      qdrant.insertVectorData({
-        client,
-        collectionName: "documents",
-        content: "missing id and vector",
-      }),
-    ).rejects.toThrow("id and vector or embedding are required");
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
 });

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -6,183 +6,190 @@ const MOCK_QDRANT_URL = "https://qdrant.example.com";
 const MOCK_QDRANT_API_KEY = "mock-api-key";
 
 function createFetchMock(result: unknown = { ok: true }) {
-    return vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ result }),
-    });
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ result }),
+  });
 }
 
 function parseBody(fetchMock: ReturnType<typeof createFetchMock>) {
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
-    return JSON.parse(init.body as string);
+  const init = fetchMock.mock.calls[0][1] as RequestInit;
+  return JSON.parse(init.body as string);
 }
 
 describe("Qdrant", () => {
-    let qdrant: Qdrant;
+  let qdrant: Qdrant;
 
-    beforeEach(() => {
-        qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+  beforeEach(() => {
+    qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+  });
+
+  it("creates collections through the Qdrant REST API", async () => {
+    const fetchMock = createFetchMock({ acknowledged: true });
+    const client = qdrant.createClient({ fetch: fetchMock });
+
+    await qdrant.createCollection({
+      client,
+      collectionName: "documents",
+      vectorSize: 1536,
+      distance: "Cosine",
     });
 
-    it("creates collections through the Qdrant REST API", async () => {
-        const fetchMock = createFetchMock({ acknowledged: true });
-        const client = qdrant.createClient({ fetch: fetchMock });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/documents",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          "api-key": MOCK_QDRANT_API_KEY,
+        }),
+      }),
+    );
+    expect(parseBody(fetchMock)).toEqual({
+      vectors: {
+        size: 1536,
+        distance: "Cosine",
+      },
+    });
+  });
 
-        await qdrant.createCollection({
-            client,
-            collectionName: "documents",
-            vectorSize: 1536,
-            distance: "Cosine",
-        });
+  it("upserts vector payloads using the existing insertVectorData shape", async () => {
+    const fetchMock = createFetchMock({ operation_id: 1 });
+    const client = qdrant.createClient({ fetch: fetchMock });
 
-        expect(fetchMock).toHaveBeenCalledWith(
-            "https://qdrant.example.com/collections/documents",
-            expect.objectContaining({
-                method: "PUT",
-                headers: expect.objectContaining({
-                    "api-key": MOCK_QDRANT_API_KEY,
-                }),
-            })
-        );
-        expect(parseBody(fetchMock)).toEqual({
-            vectors: {
-                size: 1536,
-                distance: "Cosine",
-            },
-        });
+    await qdrant.insertVectorData({
+      client,
+      tableName: "documents",
+      id: 42,
+      content: "Qdrant supports direct REST inserts",
+      embedding: [0.1, 0.2, 0.3],
     });
 
-    it("upserts vector payloads using the existing insertVectorData shape", async () => {
-        const fetchMock = createFetchMock({ operation_id: 1 });
-        const client = qdrant.createClient({ fetch: fetchMock });
-
-        await qdrant.insertVectorData({
-            client,
-            tableName: "documents",
-            id: 42,
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://qdrant.example.com/collections/documents/points?wait=true",
+    );
+    expect(parseBody(fetchMock)).toEqual({
+      points: [
+        {
+          id: 42,
+          vector: [0.1, 0.2, 0.3],
+          payload: {
             content: "Qdrant supports direct REST inserts",
-            embedding: [0.1, 0.2, 0.3],
-        });
+          },
+        },
+      ],
+    });
+  });
 
-        expect(fetchMock.mock.calls[0][0]).toBe(
-            "https://qdrant.example.com/collections/documents/points?wait=true"
-        );
-        expect(parseBody(fetchMock)).toEqual({
-            points: [
-                {
-                    id: 42,
-                    vector: [0.1, 0.2, 0.3],
-                    payload: {
-                        content: "Qdrant supports direct REST inserts",
-                    },
-                },
-            ],
-        });
+  it("searches by vector and returns the Qdrant result payload", async () => {
+    const fetchMock = createFetchMock([{ id: 7, score: 0.98 }]);
+    const client = qdrant.createClient({ fetch: fetchMock });
+
+    const result = await qdrant.getDataFromQuery({
+      client,
+      collectionName: "documents",
+      vector: [0.4, 0.5],
+      limit: 3,
+      filter: { must: [{ key: "source", match: { value: "docs" } }] },
     });
 
-    it("searches by vector and returns the Qdrant result payload", async () => {
-        const fetchMock = createFetchMock([{ id: 7, score: 0.98 }]);
-        const client = qdrant.createClient({ fetch: fetchMock });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://qdrant.example.com/collections/documents/points/search",
+    );
+    expect(parseBody(fetchMock)).toEqual({
+      vector: [0.4, 0.5],
+      limit: 3,
+      filter: { must: [{ key: "source", match: { value: "docs" } }] },
+      with_payload: true,
+      with_vector: false,
+    });
+    expect(result).toEqual([{ id: 7, score: 0.98 }]);
+  });
 
-        const result = await qdrant.getDataFromQuery({
-            client,
-            collectionName: "documents",
-            vector: [0.4, 0.5],
-            limit: 3,
-            filter: { must: [{ key: "source", match: { value: "docs" } }] },
-        });
+  it("scrolls collection points with payloads enabled", async () => {
+    const fetchMock = createFetchMock({
+      points: [{ id: 1 }],
+      next_page_offset: null,
+    });
+    const client = qdrant.createClient({ fetch: fetchMock });
 
-        expect(fetchMock.mock.calls[0][0]).toBe(
-            "https://qdrant.example.com/collections/documents/points/search"
-        );
-        expect(parseBody(fetchMock)).toEqual({
-            vector: [0.4, 0.5],
-            limit: 3,
-            filter: { must: [{ key: "source", match: { value: "docs" } }] },
-            with_payload: true,
-            with_vector: false,
-        });
-        expect(result).toEqual([{ id: 7, score: 0.98 }]);
+    await qdrant.getData({
+      client,
+      collectionName: "documents",
+      limit: 2,
+      filter: { must_not: [{ key: "archived", match: { value: true } }] },
     });
 
-    it("scrolls collection points with payloads enabled", async () => {
-        const fetchMock = createFetchMock({ points: [{ id: 1 }], next_page_offset: null });
-        const client = qdrant.createClient({ fetch: fetchMock });
-
-        await qdrant.getData({
-            client,
-            collectionName: "documents",
-            limit: 2,
-            filter: { must_not: [{ key: "archived", match: { value: true } }] },
-        });
-
-        expect(fetchMock.mock.calls[0][0]).toBe(
-            "https://qdrant.example.com/collections/documents/points/scroll"
-        );
-        expect(parseBody(fetchMock)).toEqual({
-            limit: 2,
-            filter: { must_not: [{ key: "archived", match: { value: true } }] },
-            with_payload: true,
-            with_vector: false,
-        });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://qdrant.example.com/collections/documents/points/scroll",
+    );
+    expect(parseBody(fetchMock)).toEqual({
+      limit: 2,
+      filter: { must_not: [{ key: "archived", match: { value: true } }] },
+      with_payload: true,
+      with_vector: false,
     });
+  });
 
-    it("retrieves, updates, and deletes points by id", async () => {
-        const fetchMock = createFetchMock({ acknowledged: true });
-        const client = qdrant.createClient({ fetch: fetchMock });
+  it("retrieves, updates, and deletes points by id", async () => {
+    const fetchMock = createFetchMock({ acknowledged: true });
+    const client = qdrant.createClient({ fetch: fetchMock });
 
-        await qdrant.getDataById({ client, tableName: "documents", id: "doc-1" });
-        await qdrant.updateById({
-            client,
-            tableName: "documents",
-            id: "doc-1",
-            updatedContent: { status: "reviewed" },
-        });
-        await qdrant.deleteById({ client, tableName: "documents", id: "doc-1" });
-
-        expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
-            "https://qdrant.example.com/collections/documents/points",
-            "https://qdrant.example.com/collections/documents/points/payload?wait=true",
-            "https://qdrant.example.com/collections/documents/points/delete?wait=true",
-        ]);
-        expect(JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string)).toEqual({
-            payload: { status: "reviewed" },
-            points: ["doc-1"],
-        });
-        expect(JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string)).toEqual({
-            points: ["doc-1"],
-        });
+    await qdrant.getDataById({ client, tableName: "documents", id: "doc-1" });
+    await qdrant.updateById({
+      client,
+      tableName: "documents",
+      id: "doc-1",
+      updatedContent: { status: "reviewed" },
     });
+    await qdrant.deleteById({ client, tableName: "documents", id: "doc-1" });
 
-    it("throws a useful error when Qdrant returns a non-2xx response", async () => {
-        const fetchMock = vi.fn().mockResolvedValue({
-            ok: false,
-            status: 401,
-            json: async () => ({ status: "error", result: null }),
-        });
-        const client = qdrant.createClient({ fetch: fetchMock });
-
-        await expect(
-            qdrant.getDataFromQuery({
-                client,
-                collectionName: "documents",
-                vector: [0.1, 0.2],
-            })
-        ).rejects.toThrow("Qdrant request failed with status 401");
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://qdrant.example.com/collections/documents/points",
+      "https://qdrant.example.com/collections/documents/points/payload?wait=true",
+      "https://qdrant.example.com/collections/documents/points/delete?wait=true",
+    ]);
+    expect(
+      JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string),
+    ).toEqual({
+      payload: { status: "reviewed" },
+      points: ["doc-1"],
     });
-
-    it("validates required point data before making REST calls", async () => {
-        const fetchMock = createFetchMock();
-        const client = qdrant.createClient({ fetch: fetchMock });
-
-        await expect(
-            qdrant.insertVectorData({
-                client,
-                collectionName: "documents",
-                content: "missing id and vector",
-            })
-        ).rejects.toThrow("id and vector or embedding are required");
-        expect(fetchMock).not.toHaveBeenCalled();
+    expect(
+      JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string),
+    ).toEqual({
+      points: ["doc-1"],
     });
+  });
+
+  it("throws a useful error when Qdrant returns a non-2xx response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ status: "error", result: null }),
+    });
+    const client = qdrant.createClient({ fetch: fetchMock });
+
+    await expect(
+      qdrant.getDataFromQuery({
+        client,
+        collectionName: "documents",
+        vector: [0.1, 0.2],
+      }),
+    ).rejects.toThrow("Qdrant request failed with status 401");
+  });
+
+  it("validates required point data before making REST calls", async () => {
+    const fetchMock = createFetchMock();
+    const client = qdrant.createClient({ fetch: fetchMock });
+
+    await expect(
+      qdrant.insertVectorData({
+        client,
+        collectionName: "documents",
+        content: "missing id and vector",
+      }),
+    ).rejects.toThrow("id and vector or embedding are required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+const MOCK_QDRANT_URL = "https://qdrant.example.com";
+const MOCK_QDRANT_API_KEY = "mock-api-key";
+
+function createFetchMock(result: unknown = { ok: true }) {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ result }),
+    });
+}
+
+function parseBody(fetchMock: ReturnType<typeof createFetchMock>) {
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    return JSON.parse(init.body as string);
+}
+
+describe("Qdrant", () => {
+    let qdrant: Qdrant;
+
+    beforeEach(() => {
+        qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+    });
+
+    it("creates collections through the Qdrant REST API", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+            distance: "Cosine",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents",
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "api-key": MOCK_QDRANT_API_KEY,
+                }),
+            })
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
+    });
+
+    it("upserts vector payloads using the existing insertVectorData shape", async () => {
+        const fetchMock = createFetchMock({ operation_id: 1 });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.insertVectorData({
+            client,
+            tableName: "documents",
+            id: 42,
+            content: "Qdrant supports direct REST inserts",
+            embedding: [0.1, 0.2, 0.3],
+        });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example.com/collections/documents/points?wait=true"
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            points: [
+                {
+                    id: 42,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: {
+                        content: "Qdrant supports direct REST inserts",
+                    },
+                },
+            ],
+        });
+    });
+
+    it("searches by vector and returns the Qdrant result payload", async () => {
+        const fetchMock = createFetchMock([{ id: 7, score: 0.98 }]);
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "documents",
+            vector: [0.4, 0.5],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+        });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example.com/collections/documents/points/search"
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            vector: [0.4, 0.5],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+            with_payload: true,
+            with_vector: false,
+        });
+        expect(result).toEqual([{ id: 7, score: 0.98 }]);
+    });
+
+    it("scrolls collection points with payloads enabled", async () => {
+        const fetchMock = createFetchMock({ points: [{ id: 1 }], next_page_offset: null });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.getData({
+            client,
+            collectionName: "documents",
+            limit: 2,
+            filter: { must_not: [{ key: "archived", match: { value: true } }] },
+        });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example.com/collections/documents/points/scroll"
+        );
+        expect(parseBody(fetchMock)).toEqual({
+            limit: 2,
+            filter: { must_not: [{ key: "archived", match: { value: true } }] },
+            with_payload: true,
+            with_vector: false,
+        });
+    });
+
+    it("retrieves, updates, and deletes points by id", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.getDataById({ client, tableName: "documents", id: "doc-1" });
+        await qdrant.updateById({
+            client,
+            tableName: "documents",
+            id: "doc-1",
+            updatedContent: { status: "reviewed" },
+        });
+        await qdrant.deleteById({ client, tableName: "documents", id: "doc-1" });
+
+        expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+            "https://qdrant.example.com/collections/documents/points",
+            "https://qdrant.example.com/collections/documents/points/payload?wait=true",
+            "https://qdrant.example.com/collections/documents/points/delete?wait=true",
+        ]);
+        expect(JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string)).toEqual({
+            payload: { status: "reviewed" },
+            points: ["doc-1"],
+        });
+        expect(JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string)).toEqual({
+            points: ["doc-1"],
+        });
+    });
+
+    it("throws a useful error when Qdrant returns a non-2xx response", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 401,
+            json: async () => ({ status: "error", result: null }),
+        });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await expect(
+            qdrant.getDataFromQuery({
+                client,
+                collectionName: "documents",
+                vector: [0.1, 0.2],
+            })
+        ).rejects.toThrow("Qdrant request failed with status 401");
+    });
+
+    it("validates required point data before making REST calls", async () => {
+        const fetchMock = createFetchMock();
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await expect(
+            qdrant.insertVectorData({
+                client,
+                collectionName: "documents",
+                content: "missing id and vector",
+            })
+        ).rejects.toThrow("id and vector or embedding are required");
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/deleteById.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/deleteById.test.ts
@@ -1,18 +1,19 @@
 import { Supabase } from "../../../../../dist/vector-db/src/lib/supabase/supabase.js";
+import { describe, expect, it, vi } from "vitest";
 
 const MOCK_SUPABASE_API_KEY = "mock-api-key";
 const MOCK_SUPABASE_URL = "https://mock-supabase.co";
 
 // Mock the deleteById method of the Supabase class
-jest.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
+vi.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
     return {
-        Supabase: jest.fn().mockImplementation(() => ({
-            createClient: jest.fn(() => ({
+        Supabase: vi.fn().mockImplementation(() => ({
+            createClient: vi.fn(() => ({
                 // Mock client methods
-                from: jest.fn().mockReturnThis(),
+                from: vi.fn().mockReturnThis(),
             })),
 
-            deleteById: jest.fn().mockImplementation(async ({ client, tableName, id }) => {
+            deleteById: vi.fn().mockImplementation(async ({ client, tableName, id }) => {
                 // Mock response for a successful deletion
                 const mockResponse = {
                     status: 200,

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/getData.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/getData.test.ts
@@ -1,16 +1,17 @@
 import { Supabase } from "../../../../../dist/vector-db/src/lib/supabase/supabase.js";
+import { describe, expect, it, vi } from "vitest";
 const MOCK_SUPABASE_API_KEY = "mock-api-key";
 const MOCK_SUPABASE_URL = "https://mock-supabase.co";
 
 // Mock the getDataFromQuery method of the Supabase class
-jest.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
+vi.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
     return {
-        Supabase: jest.fn().mockImplementation(() => ({
-            createClient: jest.fn(() => ({
+        Supabase: vi.fn().mockImplementation(() => ({
+            createClient: vi.fn(() => ({
                 // Mock client methods
-                from: jest.fn().mockReturnThis(),
+                from: vi.fn().mockReturnThis(),
             })),
-            getData: jest.fn().mockImplementation(async ({ client, tableName, columns }) => {
+            getData: vi.fn().mockImplementation(async ({ client, tableName, columns }) => {
                 // Mock response data
                 const responseData = [{ id: 1, content: "Sample content" }];
 

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/getDataById.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/getDataById.test.ts
@@ -1,17 +1,18 @@
 import { Supabase } from "../../../../../dist/vector-db/src/lib/supabase/supabase.js";
+import { describe, expect, it, vi } from "vitest";
 
 const MOCK_SUPABASE_API_KEY = "mock-api-key";
 const MOCK_SUPABASE_URL = "https://mock-supabase.co";
 
 // Mock the getDataById method of the Supabase class
-jest.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
+vi.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
     return {
-        Supabase: jest.fn().mockImplementation(() => ({
-            createClient: jest.fn(() => ({
+        Supabase: vi.fn().mockImplementation(() => ({
+            createClient: vi.fn(() => ({
                 // Mock client methods
-                from: jest.fn().mockReturnThis(),
+                from: vi.fn().mockReturnThis(),
             })),
-            getDataById: jest.fn().mockImplementation(async ({ client, tableName, id }) => {
+            getDataById: vi.fn().mockImplementation(async ({ client, tableName, id }) => {
                 // Assuming 'id' corresponds to the index of the data in the mock data array
                 const mockData = [
                     { id: 546, content: "Mocked content for id 546" },

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/getDataFromQuery.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/getDataFromQuery.test.ts
@@ -1,17 +1,18 @@
 import { Supabase } from "../../../../../dist/vector-db/src/lib/supabase/supabase.js";
+import { describe, expect, it, vi } from "vitest";
 
 const MOCK_SUPABASE_API_KEY = "mock-api-key";
 const MOCK_SUPABASE_URL = "https://mock-supabase.co";
 
 // Mock the getDataFromQuery method of the Supabase class
-jest.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
+vi.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
     return {
-        Supabase: jest.fn().mockImplementation(() => ({
-            createClient: jest.fn(() => ({
+        Supabase: vi.fn().mockImplementation(() => ({
+            createClient: vi.fn(() => ({
                 // Mock client methods
-                from: jest.fn().mockReturnThis(),
+                from: vi.fn().mockReturnThis(),
             })),
-            getDataFromQuery: jest
+            getDataFromQuery: vi
                 .fn()
                 .mockImplementation(async ({ client, functionNameToCall, args }) => {
                     // Mock response data

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/insertVectorData.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/insertVectorData.test.ts
@@ -1,17 +1,18 @@
 import { Supabase } from "../../../../../dist/vector-db/src/lib/supabase/supabase.js";
+import { describe, expect, it, vi } from "vitest";
 
 const MOCK_SUPABASE_API_KEY = "mock-api-key";
 const MOCK_SUPABASE_URL = "https://mock-supabase.co";
 
 // Mock the Supabase class to return a mock client
-jest.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
+vi.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
     return {
-        Supabase: jest.fn().mockImplementation(() => ({
-            createClient: jest.fn(() => ({
+        Supabase: vi.fn().mockImplementation(() => ({
+            createClient: vi.fn(() => ({
                 // Mock client methods
-                from: jest.fn().mockReturnThis(),
+                from: vi.fn().mockReturnThis(),
             })),
-            insertVectorData: jest
+            insertVectorData: vi
                 .fn()
                 .mockImplementation(async ({ tableName, content, embedding }) => {
                     // Assuming content is a string and embedding is an array of length 1536

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/updateById.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/supabase/updateById.test.ts
@@ -1,17 +1,18 @@
 import { Supabase } from "../../../../../dist/vector-db/src/lib/supabase/supabase.js";
+import { describe, expect, it, vi } from "vitest";
 
 const MOCK_SUPABASE_API_KEY = "mock-api-key";
 const MOCK_SUPABASE_URL = "https://mock-supabase.co";
 // Mock the updateById method of the Supabase class
-jest.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
+vi.mock("../../../../../dist/vector-db/src/lib/supabase/supabase.js", () => {
     return {
-        Supabase: jest.fn().mockImplementation(() => ({
-            createClient: jest.fn(() => ({
+        Supabase: vi.fn().mockImplementation(() => ({
+            createClient: vi.fn(() => ({
                 // Mock client methods
-                from: jest.fn().mockReturnThis(),
+                from: vi.fn().mockReturnThis(),
             })),
 
-            updateById: jest
+            updateById: vi
                 .fn()
                 .mockImplementation(async ({ client, tableName, id, updatedContent }) => {
                     // Mock response for a successful update


### PR DESCRIPTION
## Issue
Closes #273
/claim #273

## Summary
Adds dependency-free Qdrant vector database support to the JavaScript SDK. The new `Qdrant` client uses Qdrant's REST API directly, keeps the existing `vector-db` package shape, and exports alongside `Supabase` from `@arakoodev/edgechains.js/vector-db`.

## What changed
- Added `Qdrant` under `src/vector-db/src/lib/qdrant/`
- Supports collection creation, point upsert, vector search, scroll/list, point retrieve, payload update, and delete-by-id
- Supports `QDRANT_URL` / `QDRANT_API_KEY` env fallbacks and injected `fetch` for tests
- Added mocked-fetch Vitest coverage for REST URLs, methods, headers, request bodies, result handling, validation, and non-2xx errors
- Added a README usage example
- Updated the existing Supabase vector-db tests from Jest globals to Vitest imports so the full vector-db test suite runs under the repository's current test runner

## Acceptance criteria
- [x] Uses Qdrant REST API directly without Qdrant npm packages
- [x] Wraps Qdrant operations in EdgeChains-style vector-db classes
- [x] Exports Qdrant from the JavaScript SDK vector-db entrypoint
- [x] Adds tests covering the new Qdrant behavior
- [x] Keeps the full vector-db test suite green under Vitest
- [x] Includes local validation evidence

## Verification
Run from `JS/edgechains/arakoodev`:

```bash
PATH=$HOME/.local/node/node-v22.22.3-linux-x64/bin:$PATH npx vitest run src/vector-db/src/tests
PATH=$HOME/.local/node/node-v22.22.3-linux-x64/bin:$PATH npm run build
PATH=$HOME/.local/node/node-v22.22.3-linux-x64/bin:$PATH npx prettier --tab-width 4 --print-width 100 --trailing-comma es5 --check README.md src/vector-db/src/index.ts src/vector-db/src/lib/qdrant/qdrant.ts src/vector-db/src/tests/qdrant/qdrant.test.ts src/vector-db/src/tests/supabase/*.test.ts
git diff --check
```

Local result:
- Full vector-db test suite passes: 7 files, 14 tests
- `npm run build` passes
- Prettier check passes
- `git diff --check` passes

## Demo
The vector-db test suite is the demo path for this SDK change: it uses injected mocked clients to exercise Qdrant create collection, upsert, search, scroll, retrieve, update, delete, validation, and error handling without requiring a live Qdrant server or credentials. The Qdrant tests assert exact REST URLs, HTTP methods, headers, request bodies, and returned result shapes.
