### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,299 @@
+type FetchLike = typeof fetch;
+
+interface QdrantClient {
+  url: string;
+  apiKey?: string;
+  fetch: FetchLike;
+}
+
+interface ArgsObject {
+  [key: string]: any;
+}
+
+interface ClientArg {
+  client: QdrantClient;
+}
+
+interface CollectionArg extends ClientArg {
+  tableName: string;
+}
+
+interface CreateCollectionArgs extends CollectionArg {
+  vectorSize?: number;
+  distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+  vectors?: ArgsObject;
+}
+
+interface InsertVectorDataArgs extends CollectionArg {
+  id?: string | number;
+  vector?: number[];
+  embedding?: number[];
+  payload?: ArgsObject;
+  [key: string]: any;
+}
+
+interface QueryArgs extends CollectionArg {
+  vector?: number[];
+  embedding?: number[];
+  limit?: number;
+  filter?: ArgsObject;
+  with_payload?: boolean | ArgsObject;
+  with_vector?: boolean | string[];
+  score_threshold?: number;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+  private fetchImpl: FetchLike;
+
+  constructor(
+    QDRANT_URL?: string,
+    QDRANT_API_KEY?: string,
+    fetchImpl: FetchLike = fetch,
+  ) {
+    this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(
+      /\/+$/,
+      "",
+    );
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    this.fetchImpl = fetchImpl;
+  }
+
+  createClient(): QdrantClient {
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required to create a Qdrant client");
+    }
+
+    return {
+      url: this.QDRANT_URL,
+      apiKey: this.QDRANT_API_KEY,
+      fetch: this.fetchImpl,
+    };
+  }
+
+  async createCollection({
+    client,
+    tableName,
+    vectorSize,
+    distance = "Cosine",
+    vectors,
+  }: CreateCollectionArgs): Promise<any> {
+    if (!vectors && !vectorSize) {
+      throw new Error(
+        "vectorSize or vectors is required to create a Qdrant collection",
+      );
+    }
+
+    return this.request(
+      client,
+      "PUT",
+      `/collections/${encodeURIComponent(tableName)}`,
+      {
+        vectors: vectors || {
+          size: vectorSize,
+          distance,
+        },
+      },
+    );
+  }
+
+  async insertVectorData({
+    client,
+    tableName,
+    id,
+    vector,
+    embedding,
+    payload,
+    ...args
+  }: InsertVectorDataArgs): Promise<any> {
+    const pointVector = vector || embedding;
+    if (!pointVector) {
+      throw new Error(
+        "vector or embedding is required to insert data into Qdrant",
+      );
+    }
+
+    return this.request(
+      client,
+      "PUT",
+      `/collections/${encodeURIComponent(tableName)}/points`,
+      {
+        points: [
+          {
+            id: id || this.createId(),
+            vector: pointVector,
+            payload: payload || args,
+          },
+        ],
+      },
+    );
+  }
+
+  async getDataFromQuery({
+    client,
+    tableName,
+    vector,
+    embedding,
+    limit = 5,
+    filter,
+    with_payload = true,
+    with_vector = false,
+    score_threshold,
+  }: QueryArgs): Promise<any> {
+    const queryVector = vector || embedding;
+    if (!queryVector) {
+      throw new Error("vector or embedding is required to search Qdrant");
+    }
+
+    return this.request(
+      client,
+      "POST",
+      `/collections/${encodeURIComponent(tableName)}/points/search`,
+      {
+        vector: queryVector,
+        limit,
+        filter,
+        with_payload,
+        with_vector,
+        score_threshold,
+      },
+    );
+  }
+
+  async getData({
+    client,
+    tableName,
+    limit = 10,
+    offset,
+    filter,
+    with_payload = true,
+    with_vector = false,
+  }: CollectionArg & {
+    limit?: number;
+    offset?: string | number;
+    filter?: ArgsObject;
+    with_payload?: boolean | ArgsObject;
+    with_vector?: boolean | string[];
+  }): Promise<any> {
+    return this.request(
+      client,
+      "POST",
+      `/collections/${encodeURIComponent(tableName)}/points/scroll`,
+      {
+        limit,
+        offset,
+        filter,
+        with_payload,
+        with_vector,
+      },
+    );
+  }
+
+  async getDataById({
+    client,
+    tableName,
+    id,
+    with_payload = true,
+    with_vector = false,
+  }: CollectionArg & {
+    id: string | number;
+    with_payload?: boolean | ArgsObject;
+    with_vector?: boolean | string[];
+  }): Promise<any> {
+    return this.request(
+      client,
+      "POST",
+      `/collections/${encodeURIComponent(tableName)}/points`,
+      {
+        ids: [id],
+        with_payload,
+        with_vector,
+      },
+    );
+  }
+
+  async updateById({
+    client,
+    tableName,
+    id,
+    updatedContent,
+  }: CollectionArg & {
+    id: string | number;
+    updatedContent: ArgsObject;
+  }): Promise<any> {
+    return this.request(
+      client,
+      "POST",
+      `/collections/${encodeURIComponent(tableName)}/points/payload`,
+      {
+        payload: updatedContent,
+        points: [id],
+      },
+    );
+  }
+
+  async deleteById({
+    client,
+    tableName,
+    id,
+  }: CollectionArg & {
+    id: string | number;
+  }): Promise<any> {
+    return this.request(
+      client,
+      "POST",
+      `/collections/${encodeURIComponent(tableName)}/points/delete`,
+      {
+        points: [id],
+      },
+    );
+  }
+
+  private async request(
+    client: QdrantClient,
+    method: string,
+    path: string,
+    body?: ArgsObject,
+  ) {
+    const response = await client.fetch(`${client.url}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        ...(client.apiKey ? { "api-key": client.apiKey } : {}),
+      },
+      body: body ? JSON.stringify(this.removeUndefined(body)) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : undefined;
+
+    if (!response.ok) {
+      throw new Error(
+        `Qdrant request failed with status ${response.status}: ${text || response.statusText}`,
+      );
+    }
+
+    return data;
+  }
+
+  private removeUndefined(value: any): any {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.removeUndefined(item));
+    }
+
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.entries(value)
+          .filter(([, entryValue]) => entryValue !== undefined)
+          .map(([key, entryValue]) => [key, this.removeUndefined(entryValue)]),
+      );
+    }
+
+    return value;
+  }
+
+  private createId() {
+    return globalThis.crypto?.randomUUID?.() || `point-${Date.now()}`;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+function createFetchMock(result: any = { result: true }) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => JSON.stringify(result),
+  });
+}
+
+describe("Qdrant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a collection with vector configuration", async () => {
+    const fetchMock = createFetchMock();
+    const qdrant = new Qdrant("http://localhost:6333", "test-key", fetchMock);
+    const client = qdrant.createClient();
+
+    await qdrant.createCollection({
+      client,
+      tableName: "documents",
+      vectorSize: 1536,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:6333/collections/documents",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({ "api-key": "test-key" }),
+        body: JSON.stringify({ vectors: { size: 1536, distance: "Cosine" } }),
+      }),
+    );
+  });
+
+  it("upserts vector data with payload using the REST API", async () => {
+    const fetchMock = createFetchMock();
+    const qdrant = new Qdrant("http://localhost:6333", undefined, fetchMock);
+    const client = qdrant.createClient();
+
+    await qdrant.insertVectorData({
+      client,
+      tableName: "documents",
+      id: 1,
+      content: "hello",
+      embedding: [0.1, 0.2, 0.3],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:6333/collections/documents/points",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          points: [
+            {
+              id: 1,
+              vector: [0.1, 0.2, 0.3],
+              payload: { content: "hello" },
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("searches points from an embedding", async () => {
+    const fetchMock = createFetchMock({ result: [{ id: 1, score: 0.99 }] });
+    const qdrant = new Qdrant("http://localhost:6333", undefined, fetchMock);
+    const client = qdrant.createClient();
+
+    const result = await qdrant.getDataFromQuery({
+      client,
+      tableName: "documents",
+      embedding: [0.1, 0.2, 0.3],
+      limit: 3,
+    });
+
+    expect(result).toEqual({ result: [{ id: 1, score: 0.99 }] });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:6333/collections/documents/points/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          vector: [0.1, 0.2, 0.3],
+          limit: 3,
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+  });
+
+  it("retrieves, updates, and deletes points by id", async () => {
+    const fetchMock = createFetchMock();
+    const qdrant = new Qdrant("http://localhost:6333", undefined, fetchMock);
+    const client = qdrant.createClient();
+
+    await qdrant.getDataById({ client, tableName: "documents", id: "doc-1" });
+    await qdrant.updateById({
+      client,
+      tableName: "documents",
+      id: "doc-1",
+      updatedContent: { source: "manual" },
+    });
+    await qdrant.deleteById({ client, tableName: "documents", id: "doc-1" });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://localhost:6333/collections/documents/points",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          ids: ["doc-1"],
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:6333/collections/documents/points/payload",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          payload: { source: "manual" },
+          points: ["doc-1"],
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "http://localhost:6333/collections/documents/points/delete",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ points: ["doc-1"] }),
+      }),
+    );
+  });
+
+  it("throws a useful error when Qdrant returns an error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      text: async () => JSON.stringify({ status: { error: "bad vector" } }),
+    });
+    const qdrant = new Qdrant("http://localhost:6333", undefined, fetchMock);
+    const client = qdrant.createClient();
+
+    await expect(
+      qdrant.getDataFromQuery({
+        client,
+        tableName: "documents",
+        vector: [0.1],
+      }),
+    ).rejects.toThrow("Qdrant request failed with status 400");
+  });
+});


### PR DESCRIPTION
### Summary
- Adds a dependency-free Qdrant REST client under the existing JS vector-db package.
- Exports Qdrant alongside Supabase from @arakoodev/edgechains.js/vector-db.
- Supports collection creation, point upsert, vector search, scroll, retrieve by id, payload update, and delete by id.
- Adds mocked Vitest coverage for Qdrant request shapes and error handling.

### Proof
- npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts -> 5 passed
- PowerShell equivalent of npm run build on Windows: if (Test-Path dist) { Remove-Item -Recurse -Force dist }; npx tsc -b -> passed
- git diff --check -> passed

/claim #273