### PR TITLE
Add SmartRouter for JS SDK provider routing

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,23 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+    SmartRouter,
+    posthogCallback,
+    sentryCallback,
+    statusFromError,
+} from "./lib/router/index.js";
+export type {
+    CompletionRequest,
+    CompletionResponse,
+    DeploymentSnapshot,
+    Message,
+    Provider,
+    RouterCallback,
+    RouterDeployment,
+    RouterModelGroup,
+    RouterOptions,
+    RoutingStrategy,
+    StreamChunk,
+    Usage,
+} from "./lib/router/index.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/README.md
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/README.md
@@ -1,0 +1,135 @@
+# SmartRouter
+
+`SmartRouter` is a LiteLLM-style router for EdgeChains' JS SDK. It provides one completion interface across OpenAI, Google PaLM/Gemini, and Cohere while keeping provider deployments healthy under rate limits.
+
+## Why this replaces direct endpoint calls
+
+Direct provider calls fail the whole request when a single key or deployment is rate-limited. `SmartRouter` keeps a small in-memory state per deployment and routes to the best eligible deployment for each call:
+
+1. match the requested model group
+2. skip deployments in 429 cooldown
+3. skip deployments over RPM/TPM limits
+4. choose by `least-tokens`, `latency`, `cost`, `weighted`, or `priority`
+5. retry transient 5xx/connection errors in-place with jittered backoff
+6. fail over to the next deployment or configured fallback group
+
+## Usage
+
+```ts
+import { SmartRouter, posthogCallback, sentryCallback } from "@arakoodev/edgechains.js/ai";
+
+const router = new SmartRouter({
+    strategy: "least-tokens",
+    retries: 2,
+    fallbackAttempts: 8,
+    modelGroups: [
+        {
+            name: "fast-chat",
+            fallbacks: ["cheap-chat"],
+            deployments: [
+                {
+                    id: "openai-primary",
+                    provider: "openai",
+                    model: "gpt-4o",
+                    apiKey: process.env.OPENAI_API_KEY,
+                    rpmLimit: 3000,
+                    tpmLimit: 90_000,
+                    cost: { input: 0.000005, output: 0.000015 },
+                },
+                {
+                    id: "gemini-primary",
+                    provider: "gemini",
+                    model: "gemini-pro",
+                    apiKey: process.env.GEMINI_API_KEY,
+                    latencyMs: 400,
+                    weight: 2,
+                },
+            ],
+        },
+        {
+            name: "cheap-chat",
+            strategy: "cost",
+            deployments: [
+                {
+                    id: "cohere-backup",
+                    provider: "cohere",
+                    model: "command",
+                    apiKey: process.env.COHERE_API_KEY,
+                    cost: { input: 0.0000015, output: 0.000002 },
+                },
+            ],
+        },
+    ],
+});
+
+const response = await router.completion({
+    model: "fast-chat",
+    messages: [{ role: "user", content: "Summarize EdgeChains" }],
+});
+
+console.log(response.content, response.usage, response.deployment_id);
+```
+
+## Streaming
+
+```ts
+for await (const chunk of router.stream({ model: "fast-chat", prompt: "Stream this" })) {
+    if (chunk.delta) process.stdout.write(chunk.delta);
+}
+```
+
+OpenAI and Gemini streaming are consumed as SSE. Cohere streaming supports SSE and JSON-line responses. PaLM `generateText` does not expose a stable streaming API, so PaLM deployments emit the full response as one chunk plus a final `done` chunk to preserve one caller shape.
+
+## Jsonnet configuration
+
+EdgeChains favors jsonnet for configuration. The router intentionally accepts plain objects so a jsonnet file can compile directly into the router config without adding a jsonnet runtime dependency to every consumer.
+
+```jsonnet
+{
+    strategy: "least-tokens",
+    retries: 2,
+    modelGroups: [
+        {
+            name: "chat",
+            fallbacks: ["backup"],
+            deployments: [
+                {
+                    id: "openai-a",
+                    provider: "openai",
+                    model: "gpt-4o",
+                    apiKeyEnv: "OPENAI_API_KEY",
+                    rpmLimit: 3000,
+                    tpmLimit: 90000,
+                },
+            ],
+        },
+        {
+            name: "backup",
+            deployments: [
+                {
+                    id: "cohere-a",
+                    provider: "cohere",
+                    model: "command",
+                    apiKeyEnv: "COHERE_API_KEY",
+                },
+            ],
+        },
+    ],
+}
+```
+
+```ts
+const config = JSON.parse(renderedJsonnet);
+const router = SmartRouter.fromConfig(config);
+```
+
+## Observability
+
+The router ships dependency-free Sentry and PostHog adapters. Pass clients from the application; the SDK does not import those packages.
+
+```ts
+router.addCallback(sentryCallback(Sentry));
+router.addCallback(posthogCallback(posthog, { distinctId: "prod" }));
+```
+
+Callbacks are isolated: callback errors are logged and never break the routed completion.

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/callbacks/posthog.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/callbacks/posthog.ts
@@ -1,0 +1,61 @@
+import type { FailureContext, FallbackContext, RouterCallback, SuccessContext } from "../types.js";
+
+export interface PostHogLike {
+    capture(event: { distinctId: string; event: string; properties?: Record<string, unknown> }): unknown;
+}
+
+export interface PostHogCallbackOptions {
+    distinctId?: string;
+}
+
+export function posthogCallback(client: PostHogLike, options: PostHogCallbackOptions = {}): RouterCallback {
+    const distinctId = options.distinctId ?? "edgechains-smart-router";
+    return {
+        on_success: (ctx: SuccessContext) => {
+            client.capture({
+                distinctId,
+                event: "edgechains.smart_router.success",
+                properties: {
+                    provider: ctx.provider,
+                    model: ctx.model,
+                    deployment_id: ctx.deployment_id,
+                    group: ctx.group,
+                    duration_ms: ctx.duration_ms,
+                    prompt_tokens: ctx.response.usage.prompt_tokens,
+                    completion_tokens: ctx.response.usage.completion_tokens,
+                    total_tokens: ctx.response.usage.total_tokens,
+                },
+            });
+        },
+        on_failure: (ctx: FailureContext) => {
+            client.capture({
+                distinctId,
+                event: "edgechains.smart_router.failure",
+                properties: {
+                    provider: ctx.provider,
+                    model: ctx.model,
+                    deployment_id: ctx.deployment_id,
+                    group: ctx.group,
+                    status: ctx.status,
+                    duration_ms: ctx.duration_ms,
+                    error_message: ctx.error.message,
+                },
+            });
+        },
+        on_fallback: (ctx: FallbackContext) => {
+            client.capture({
+                distinctId,
+                event: "edgechains.smart_router.fallback",
+                properties: {
+                    provider: ctx.provider,
+                    model: ctx.model,
+                    deployment_id: ctx.deployment_id,
+                    group: ctx.group,
+                    status: ctx.status,
+                    cooldown_until: ctx.cooldown_until,
+                    next_group: ctx.next_group,
+                },
+            });
+        },
+    };
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/callbacks/sentry.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/callbacks/sentry.ts
@@ -1,0 +1,38 @@
+import type { FailureContext, RouterCallback, SuccessContext } from "../types.js";
+
+export interface SentryLike {
+    captureException(error: unknown, context?: unknown): unknown;
+    addBreadcrumb?(breadcrumb: unknown): void;
+}
+
+export function sentryCallback(sentry: SentryLike): RouterCallback {
+    return {
+        on_success: (ctx: SuccessContext) => {
+            sentry.addBreadcrumb?.({
+                category: "edgechains.smart_router",
+                level: "info",
+                message: `completion ok ${ctx.provider}:${ctx.model}`,
+                data: {
+                    deployment_id: ctx.deployment_id,
+                    group: ctx.group,
+                    duration_ms: ctx.duration_ms,
+                    total_tokens: ctx.response.usage.total_tokens,
+                },
+            });
+        },
+        on_failure: (ctx: FailureContext) => {
+            sentry.captureException(ctx.error, {
+                tags: {
+                    "edgechains.provider": ctx.provider,
+                    "edgechains.model": ctx.model,
+                    "edgechains.deployment_id": ctx.deployment_id,
+                    "edgechains.group": ctx.group,
+                },
+                extra: {
+                    status: ctx.status,
+                    duration_ms: ctx.duration_ms,
+                },
+            });
+        },
+    };
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/index.ts
@@ -1,0 +1,28 @@
+export { SmartRouter, statusFromError } from "./smart-router.js";
+export { sentryCallback } from "./callbacks/sentry.js";
+export { posthogCallback } from "./callbacks/posthog.js";
+export type { SentryLike } from "./callbacks/sentry.js";
+export type { PostHogCallbackOptions, PostHogLike } from "./callbacks/posthog.js";
+export type {
+    CompletionRequest,
+    CompletionResponse,
+    DeploymentCost,
+    DeploymentSnapshot,
+    FailureContext,
+    FallbackContext,
+    Message,
+    NormalizedDeployment,
+    Provider,
+    RouteContext,
+    RouterCallback,
+    RouterDeployment,
+    RouterHttpClient,
+    RouterHttpResponse,
+    RouterLogger,
+    RouterModelGroup,
+    RouterOptions,
+    RoutingStrategy,
+    StreamChunk,
+    SuccessContext,
+    Usage,
+} from "./types.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/providers/cohere.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/providers/cohere.ts
@@ -1,0 +1,120 @@
+import type {
+    CompletionRequest,
+    CompletionResponse,
+    Message,
+    NormalizedDeployment,
+    RouterHttpClient,
+    StreamChunk,
+    Usage,
+} from "../types.js";
+import { parseSSE } from "../sse.js";
+
+const COHERE_CHAT_URL = "https://api.cohere.ai/v1/chat";
+
+function messagesFromRequest(request: CompletionRequest): Message[] {
+    if (request.messages?.length) return request.messages;
+    return [{ role: request.role || "user", content: request.prompt || "" }];
+}
+
+function buildBody(request: CompletionRequest, deployment: NormalizedDeployment, stream: boolean) {
+    const messages = messagesFromRequest(request);
+    const userMessages = messages.filter((message) => message.role === "user");
+    const message = request.prompt ?? userMessages[userMessages.length - 1]?.content ?? "";
+    const maxTokens = request.max_tokens ?? request.maxTokens ?? 256;
+
+    return {
+        model: deployment.model,
+        message,
+        chat_history: messages
+            .slice(0, -1)
+            .filter((item) => item.role !== "system")
+            .map((item) => ({
+                role: item.role === "assistant" ? "CHATBOT" : "USER",
+                message: item.content,
+            })),
+        max_tokens: maxTokens,
+        temperature: request.temperature ?? 0.7,
+        stream,
+    };
+}
+
+function headers(deployment: NormalizedDeployment): Record<string, string> {
+    return {
+        Authorization: `Bearer ${deployment.apiKey}`,
+        "Content-Type": "application/json",
+        ...(deployment.headers ?? {}),
+    };
+}
+
+function usageFromMeta(meta: any): Usage {
+    const tokens = meta?.tokens ?? {};
+    const billed = meta?.billed_units ?? {};
+    const prompt_tokens = tokens.input_tokens ?? billed.input_tokens ?? 0;
+    const completion_tokens = tokens.output_tokens ?? billed.output_tokens ?? 0;
+    return {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens: prompt_tokens + completion_tokens,
+    };
+}
+
+export async function cohereCompletion(
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+): Promise<CompletionResponse> {
+    const response = await http.post<any>(deployment.baseUrl || COHERE_CHAT_URL, buildBody(request, deployment, false), {
+        headers: headers(deployment),
+        timeout: deployment.timeoutMs,
+    });
+
+    const data = response.data;
+    return {
+        content: data?.text ?? "",
+        usage: usageFromMeta(data?.meta),
+        provider: deployment.provider,
+        model: deployment.model,
+        deployment_id: deployment.id,
+        finish_reason: data?.finish_reason,
+        raw: data,
+    };
+}
+
+export async function* cohereStream(
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+): AsyncGenerator<StreamChunk> {
+    const response = await http.post<any>(deployment.baseUrl || COHERE_CHAT_URL, buildBody(request, deployment, true), {
+        headers: headers(deployment),
+        timeout: deployment.timeoutMs,
+        responseType: "stream",
+    });
+
+    let content = "";
+    let usage: Usage | undefined;
+    for await (const event of parseSSE(response.data)) {
+        const data = event as any;
+        if (data?.event_type === "stream-end") usage = usageFromMeta(data?.response?.meta);
+        const delta = data?.text ?? data?.delta?.message?.content?.text ?? "";
+        if (!delta) continue;
+        content += delta;
+        yield {
+            delta,
+            content,
+            provider: deployment.provider,
+            model: deployment.model,
+            deployment_id: deployment.id,
+            raw: data,
+        };
+    }
+
+    yield {
+        done: true,
+        content,
+        usage: usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        provider: deployment.provider,
+        model: deployment.model,
+        deployment_id: deployment.id,
+    };
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/providers/google.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/providers/google.ts
@@ -1,0 +1,169 @@
+import type {
+    CompletionRequest,
+    CompletionResponse,
+    Message,
+    NormalizedDeployment,
+    RouterHttpClient,
+    StreamChunk,
+    Usage,
+} from "../types.js";
+import { parseSSE } from "../sse.js";
+
+function messagesFromRequest(request: CompletionRequest): Message[] {
+    if (request.messages?.length) return request.messages;
+    return [{ role: request.role || "user", content: request.prompt || "" }];
+}
+
+function promptFromRequest(request: CompletionRequest): string {
+    return messagesFromRequest(request)
+        .map((message) => message.content)
+        .join("\n");
+}
+
+function isGeminiModel(model: string): boolean {
+    return model.startsWith("gemini") || model.includes("gemini");
+}
+
+function completionUrl(deployment: NormalizedDeployment, stream: boolean): string {
+    if (deployment.baseUrl) return deployment.baseUrl;
+    const encodedModel = encodeURIComponent(deployment.model);
+    const key = encodeURIComponent(deployment.apiKey);
+    if (isGeminiModel(deployment.model)) {
+        const method = stream ? "streamGenerateContent" : "generateContent";
+        return `https://generativelanguage.googleapis.com/v1beta/models/${encodedModel}:${method}?key=${key}`;
+    }
+    return `https://generativelanguage.googleapis.com/v1beta2/models/${encodedModel}:generateText?key=${key}`;
+}
+
+function buildBody(request: CompletionRequest, deployment: NormalizedDeployment) {
+    const maxTokens = request.max_tokens ?? request.maxTokens ?? 256;
+    if (isGeminiModel(deployment.model)) {
+        return {
+            contents: messagesFromRequest(request).map((message) => ({
+                role: message.role === "assistant" ? "model" : "user",
+                parts: [{ text: message.content }],
+            })),
+            generationConfig: {
+                maxOutputTokens: maxTokens,
+                temperature: request.temperature ?? 0.7,
+                ...(request.stop ? { stopSequences: Array.isArray(request.stop) ? request.stop : [request.stop] } : {}),
+            },
+        };
+    }
+
+    return {
+        prompt: { text: promptFromRequest(request) },
+        maxOutputTokens: maxTokens,
+        temperature: request.temperature ?? 0.7,
+        ...(request.stop ? { stopSequences: Array.isArray(request.stop) ? request.stop : [request.stop] } : {}),
+    };
+}
+
+function headers(deployment: NormalizedDeployment): Record<string, string> {
+    return {
+        "Content-Type": "application/json",
+        ...(deployment.baseUrl ? { "x-goog-api-key": deployment.apiKey } : {}),
+        ...(deployment.headers ?? {}),
+    };
+}
+
+function usageFrom(data: any, content: string): Usage {
+    const prompt_tokens = data?.usageMetadata?.promptTokenCount ?? 0;
+    const completion_tokens = data?.usageMetadata?.candidatesTokenCount ?? data?.usageMetadata?.completionTokenCount ?? 0;
+    const total_tokens = data?.usageMetadata?.totalTokenCount ?? prompt_tokens + completion_tokens;
+
+    if (total_tokens > 0) return { prompt_tokens, completion_tokens, total_tokens };
+
+    // PaLM generateText historically does not always return usage; keep a
+    // conservative estimate so router TPM accounting still moves forward.
+    const estimated = Math.max(1, Math.ceil(content.length / 4));
+    return { prompt_tokens: 0, completion_tokens: estimated, total_tokens: estimated };
+}
+
+function contentFrom(data: any): string {
+    return (
+        data?.candidates?.[0]?.content?.parts?.map((part: any) => part.text).join("") ??
+        data?.candidates?.[0]?.output ??
+        data?.candidates?.[0]?.text ??
+        ""
+    );
+}
+
+export async function googleCompletion(
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+): Promise<CompletionResponse> {
+    const response = await http.post<any>(completionUrl(deployment, false), buildBody(request, deployment), {
+        headers: headers(deployment),
+        timeout: deployment.timeoutMs,
+    });
+
+    const data = response.data;
+    const content = contentFrom(data);
+    return {
+        content,
+        usage: usageFrom(data, content),
+        provider: deployment.provider,
+        model: deployment.model,
+        deployment_id: deployment.id,
+        finish_reason: data?.candidates?.[0]?.finishReason,
+        raw: data,
+    };
+}
+
+export async function* googleStream(
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+): AsyncGenerator<StreamChunk> {
+    // PaLM generateText does not expose a stable streaming endpoint. For PaLM
+    // deployments, emit the full completion as one chunk so callers can keep a
+    // single streaming interface. Gemini uses streamGenerateContent.
+    if (!isGeminiModel(deployment.model)) {
+        const response = await googleCompletion(http, deployment, request);
+        yield {
+            delta: response.content,
+            content: response.content,
+            provider: deployment.provider,
+            model: deployment.model,
+            deployment_id: deployment.id,
+            raw: response.raw,
+        };
+        yield { ...response, done: true };
+        return;
+    }
+
+    const response = await http.post<any>(completionUrl(deployment, true), buildBody(request, deployment), {
+        headers: headers(deployment),
+        timeout: deployment.timeoutMs,
+        responseType: "stream",
+    });
+
+    let content = "";
+    let usage: Usage | undefined;
+    for await (const event of parseSSE(response.data)) {
+        const data = event as any;
+        const delta = contentFrom(data);
+        if (data?.usageMetadata) usage = usageFrom(data, delta);
+        if (!delta) continue;
+        content += delta;
+        yield {
+            delta,
+            content,
+            provider: deployment.provider,
+            model: deployment.model,
+            deployment_id: deployment.id,
+            raw: data,
+        };
+    }
+
+    yield {
+        done: true,
+        content,
+        usage: usage ?? { prompt_tokens: 0, completion_tokens: Math.ceil(content.length / 4), total_tokens: Math.ceil(content.length / 4) },
+        provider: deployment.provider,
+        model: deployment.model,
+        deployment_id: deployment.id,
+    };
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/providers/openai.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/providers/openai.ts
@@ -1,0 +1,117 @@
+import type {
+    CompletionRequest,
+    CompletionResponse,
+    Message,
+    NormalizedDeployment,
+    RouterHttpClient,
+    StreamChunk,
+    Usage,
+} from "../types.js";
+import { parseSSE } from "../sse.js";
+
+const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
+
+function messagesFromRequest(request: CompletionRequest): Message[] {
+    if (request.messages?.length) return request.messages;
+    return [
+        {
+            role: request.role || "user",
+            content: request.prompt || "",
+        },
+    ];
+}
+
+function buildBody(request: CompletionRequest, deployment: NormalizedDeployment, stream: boolean) {
+    const maxTokens = request.max_tokens ?? request.maxTokens ?? 256;
+    return {
+        model: deployment.model,
+        messages: messagesFromRequest(request),
+        max_tokens: maxTokens,
+        temperature: request.temperature ?? 0.7,
+        stream,
+        ...(request.stop ? { stop: request.stop } : {}),
+        ...(request.tools ? { tools: request.tools } : {}),
+        ...(request.functions ? { functions: request.functions } : {}),
+        ...(request.function_call ? { function_call: request.function_call } : {}),
+    };
+}
+
+function headers(deployment: NormalizedDeployment): Record<string, string> {
+    return {
+        Authorization: `Bearer ${deployment.apiKey}`,
+        "content-type": "application/json",
+        ...(deployment.organization ? { "OpenAI-Organization": deployment.organization } : {}),
+        ...(deployment.headers ?? {}),
+    };
+}
+
+function usageFrom(data: any): Usage {
+    return {
+        prompt_tokens: data?.usage?.prompt_tokens ?? 0,
+        completion_tokens: data?.usage?.completion_tokens ?? 0,
+        total_tokens: data?.usage?.total_tokens ?? 0,
+    };
+}
+
+export async function openaiCompletion(
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+): Promise<CompletionResponse> {
+    const response = await http.post<any>(deployment.baseUrl || OPENAI_CHAT_URL, buildBody(request, deployment, false), {
+        headers: headers(deployment),
+        timeout: deployment.timeoutMs,
+    });
+
+    const data = response.data;
+    const choice = data?.choices?.[0];
+    return {
+        content: choice?.message?.content ?? "",
+        usage: usageFrom(data),
+        provider: deployment.provider,
+        model: deployment.model,
+        deployment_id: deployment.id,
+        finish_reason: choice?.finish_reason,
+        raw: data,
+    };
+}
+
+export async function* openaiStream(
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+): AsyncGenerator<StreamChunk> {
+    const response = await http.post<any>(deployment.baseUrl || OPENAI_CHAT_URL, buildBody(request, deployment, true), {
+        headers: headers(deployment),
+        timeout: deployment.timeoutMs,
+        responseType: "stream",
+    });
+
+    let content = "";
+    let usage: Usage | undefined;
+
+    for await (const event of parseSSE(response.data)) {
+        const data = event as any;
+        const delta = data?.choices?.[0]?.delta?.content ?? "";
+        if (data?.usage) usage = usageFrom(data);
+        if (!delta) continue;
+        content += delta;
+        yield {
+            delta,
+            content,
+            provider: deployment.provider,
+            model: deployment.model,
+            deployment_id: deployment.id,
+            raw: data,
+        };
+    }
+
+    yield {
+        done: true,
+        content,
+        usage: usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        provider: deployment.provider,
+        model: deployment.model,
+        deployment_id: deployment.id,
+    };
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/smart-router.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/smart-router.ts
@@ -1,0 +1,625 @@
+import axios from "axios";
+
+import { cohereCompletion, cohereStream } from "./providers/cohere.js";
+import { googleCompletion, googleStream } from "./providers/google.js";
+import { openaiCompletion, openaiStream } from "./providers/openai.js";
+import type {
+    CompletionRequest,
+    CompletionResponse,
+    DeploymentSnapshot,
+    FailureContext,
+    FallbackContext,
+    NormalizedDeployment,
+    Provider,
+    ProviderCompletion,
+    ProviderStream,
+    RouteContext,
+    RouterCallback,
+    RouterDeployment,
+    RouterHttpClient,
+    RouterLogger,
+    RouterModelGroup,
+    RouterOptions,
+    RoutingStrategy,
+    StreamChunk,
+    SuccessContext,
+    Usage,
+} from "./types.js";
+
+interface DeploymentState {
+    deployment: NormalizedDeployment;
+    window: number;
+    requests_this_minute: number;
+    tokens_this_minute: number;
+    cumulative_tokens: number;
+    successes: number;
+    failures: number;
+    cooldown_until: number;
+    latency_ms: number;
+}
+
+interface NormalizedGroup {
+    name: string;
+    strategy: RoutingStrategy;
+    fallbacks: string[];
+    priority: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_COOLDOWN_MS = 60_000;
+const DEFAULT_RETRIES = 2;
+const DEFAULT_FALLBACK_ATTEMPTS = 8;
+const DEFAULT_BACKOFF_BASE_MS = 200;
+const DEFAULT_BACKOFF_MAX_MS = 4_000;
+const DEFAULT_LATENCY_MS = 1_000;
+
+const noopLogger: RouterLogger = {};
+
+/**
+ * LiteLLM-style router for EdgeChains AI calls.
+ *
+ * It accepts model groups / deployments, exposes a single `completion()` API,
+ * tracks RPM/TPM/token usage, cools deployments on 429, retries transient
+ * provider failures with backoff, and falls back across ordered groups.
+ */
+export class SmartRouter {
+    private readonly states: DeploymentState[] = [];
+    private readonly groups = new Map<string, NormalizedGroup>();
+    private readonly callbacks: RouterCallback[] = [];
+    private readonly http: RouterHttpClient;
+    private readonly logger: RouterLogger;
+    private readonly strategy: RoutingStrategy;
+    private readonly timeoutMs: number;
+    private readonly retries: number;
+    private readonly fallbackAttempts: number;
+    private readonly cooldownMs: number;
+    private readonly backoffBaseMs: number;
+    private readonly backoffMaxMs: number;
+    private readonly random: () => number;
+    private readonly now: () => number;
+    private readonly sleep: (ms: number) => Promise<void>;
+    private roundRobinCursor = 0;
+
+    constructor(options: RouterOptions = {}) {
+        this.strategy = options.strategy ?? "least-tokens";
+        this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+        this.retries = options.retries ?? DEFAULT_RETRIES;
+        this.fallbackAttempts = options.fallbackAttempts ?? DEFAULT_FALLBACK_ATTEMPTS;
+        this.cooldownMs = options.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+        this.backoffBaseMs = options.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
+        this.backoffMaxMs = options.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
+        this.logger = options.logger ?? noopLogger;
+        this.random = options.random ?? Math.random;
+        this.now = options.now ?? Date.now;
+        this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+        this.http = options.httpClient ?? axios.create({ timeout: this.timeoutMs });
+
+        for (const callback of options.callbacks ?? []) this.addCallback(callback);
+        this.registerGroups(options.modelGroups ?? options.modelGroupsFromJsonnet ?? []);
+        this.registerDeployments(options.deployments ?? options.model_list ?? []);
+    }
+
+    /** Build a router from jsonnet output parsed into plain JavaScript. */
+    static fromConfig(config: RouterOptions): SmartRouter {
+        return new SmartRouter(config);
+    }
+
+    registerGroups(groups: RouterModelGroup[]): void {
+        for (const group of groups) {
+            this.groups.set(group.name, {
+                name: group.name,
+                strategy: group.strategy ?? this.strategy,
+                fallbacks: group.fallbacks ?? [],
+                priority: group.priority ?? 100,
+            });
+            this.registerDeployments(group.deployments.map((deployment) => ({ ...deployment, group: deployment.group ?? group.name })));
+        }
+    }
+
+    registerDeployments(deployments: RouterDeployment[]): void {
+        for (const deployment of deployments) this.register(deployment);
+    }
+
+    register(deployment: RouterDeployment): string {
+        const normalized = this.normalizeDeployment(deployment);
+        this.states.push({
+            deployment: normalized,
+            window: this.currentWindow(),
+            requests_this_minute: 0,
+            tokens_this_minute: 0,
+            cumulative_tokens: 0,
+            successes: 0,
+            failures: 0,
+            cooldown_until: 0,
+            latency_ms: normalized.latencyMs,
+        });
+
+        if (!this.groups.has(normalized.group)) {
+            this.groups.set(normalized.group, {
+                name: normalized.group,
+                strategy: this.strategy,
+                fallbacks: [],
+                priority: normalized.priority,
+            });
+        }
+
+        return normalized.id;
+    }
+
+    addCallback(callback: RouterCallback): void {
+        this.callbacks.push(callback);
+    }
+
+    /** OpenAI-compatible completion interface. */
+    async completion(request: CompletionRequest): Promise<CompletionResponse> {
+        if (request.stream) throw new Error("completion() does not return streams; use stream() instead");
+
+        let lastError: Error | null = null;
+        let attempts = 0;
+
+        for (const groupName of this.groupOrder(request.model)) {
+            const triedInGroup = new Set<string>();
+
+            while (attempts < this.fallbackAttempts) {
+                const state = this.pickDeployment(groupName, request, triedInGroup);
+                if (!state) break;
+
+                triedInGroup.add(state.deployment.id);
+                attempts += 1;
+
+                const result = await this.runDeployment(state, groupName, attempts, request);
+                if (result.ok) return result.response;
+
+                lastError = result.error;
+                if (!this.shouldRouteAway(result.error)) throw result.error;
+            }
+        }
+
+        throw lastError ?? new Error("SmartRouter: no eligible deployment available");
+    }
+
+    /** Alias retained for existing `chat`-style usage. */
+    async chat(request: CompletionRequest): Promise<CompletionResponse> {
+        return this.completion(request);
+    }
+
+    async *stream(request: CompletionRequest): AsyncGenerator<StreamChunk> {
+        let lastError: Error | null = null;
+        let attempts = 0;
+
+        for (const groupName of this.groupOrder(request.model)) {
+            const triedInGroup = new Set<string>();
+
+            while (attempts < this.fallbackAttempts) {
+                const state = this.pickDeployment(groupName, request, triedInGroup);
+                if (!state) break;
+
+                triedInGroup.add(state.deployment.id);
+                attempts += 1;
+
+                const start = this.now();
+                const context = this.context(state, groupName, attempts, request);
+                await this.fireStart(context);
+                this.logger.info?.("SmartRouter stream start", this.safeLog({ ...context }));
+
+                let yielded = false;
+                let content = "";
+                let finalUsage: Usage | undefined;
+
+                try {
+                    const adapter = this.streamAdapterFor(state.deployment.provider);
+                    for await (const chunk of adapter(this.http, state.deployment, { ...request, stream: true })) {
+                        yielded = true;
+                        if (chunk.delta) content += chunk.delta;
+                        if (chunk.done && chunk.usage && chunk.usage.total_tokens > 0) finalUsage = chunk.usage;
+                        yield chunk;
+                    }
+
+                    const usage = finalUsage ?? this.estimateUsage(request, content);
+                    this.recordSuccess(state, usage, this.now() - start);
+                    await this.fireSuccess({
+                        ...context,
+                        duration_ms: this.now() - start,
+                        response: {
+                            content,
+                            usage,
+                            provider: state.deployment.provider,
+                            model: state.deployment.model,
+                            deployment_id: state.deployment.id,
+                        },
+                    });
+                    return;
+                } catch (err) {
+                    const error = toError(err);
+                    lastError = error;
+                    const status = statusFromError(error);
+                    this.recordFailure(state, error);
+                    const failure = { ...context, duration_ms: this.now() - start, error, status };
+                    await this.fireFailure(failure);
+                    await this.fireFallback({
+                        ...failure,
+                        cooldown_until: state.cooldown_until || undefined,
+                        next_group: this.nextGroupAfter(groupName, request.model),
+                    });
+
+                    // If some stream bytes already reached the caller, do not
+                    // silently replay the prompt on another provider; duplicated
+                    // partial output is worse than surfacing the stream error.
+                    if (yielded || !this.shouldRouteAway(error)) throw error;
+                }
+            }
+        }
+
+        throw lastError ?? new Error("SmartRouter: no eligible deployment available");
+    }
+
+    getDeploymentState(deploymentId: string): DeploymentSnapshot | null {
+        const state = this.states.find((candidate) => candidate.deployment.id === deploymentId);
+        if (!state) return null;
+        this.rolloverIfStale(state);
+        return {
+            id: state.deployment.id,
+            group: state.deployment.group,
+            provider: state.deployment.provider,
+            model: state.deployment.model,
+            priority: state.deployment.priority,
+            weight: state.deployment.weight,
+            requests_this_minute: state.requests_this_minute,
+            tokens_this_minute: state.tokens_this_minute,
+            cumulative_tokens: state.cumulative_tokens,
+            successes: state.successes,
+            failures: state.failures,
+            cooldown_until: state.cooldown_until,
+            latency_ms: Math.round(state.latency_ms),
+        };
+    }
+
+    getUsage(deploymentId: string): Pick<DeploymentSnapshot, "requests_this_minute" | "tokens_this_minute" | "cumulative_tokens"> | null {
+        const snapshot = this.getDeploymentState(deploymentId);
+        if (!snapshot) return null;
+        return {
+            requests_this_minute: snapshot.requests_this_minute,
+            tokens_this_minute: snapshot.tokens_this_minute,
+            cumulative_tokens: snapshot.cumulative_tokens,
+        };
+    }
+
+    listDeployments(): DeploymentSnapshot[] {
+        return this.states
+            .map((state) => this.getDeploymentState(state.deployment.id))
+            .filter((snapshot): snapshot is DeploymentSnapshot => snapshot !== null);
+    }
+
+    private async runDeployment(
+        state: DeploymentState,
+        groupName: string,
+        attempt: number,
+        request: CompletionRequest
+    ): Promise<{ ok: true; response: CompletionResponse } | { ok: false; error: Error }> {
+        const context = this.context(state, groupName, attempt, request);
+        const adapter = this.completionAdapterFor(state.deployment.provider);
+
+        for (let retryAttempt = 0; retryAttempt <= this.retries; retryAttempt++) {
+            const start = this.now();
+            await this.fireStart(context);
+            this.logger.info?.("SmartRouter completion start", this.safeLog({ ...context, retryAttempt }));
+
+            try {
+                const response = await adapter(this.http, state.deployment, request);
+                this.recordSuccess(state, response.usage, this.now() - start);
+                await this.fireSuccess({ ...context, duration_ms: this.now() - start, response });
+                this.logger.info?.("SmartRouter completion success", this.safeLog({
+                    ...context,
+                    duration_ms: this.now() - start,
+                    total_tokens: response.usage.total_tokens,
+                }));
+                return { ok: true, response };
+            } catch (err) {
+                const error = toError(err);
+                const status = statusFromError(error);
+                this.recordFailure(state, error);
+                const failure: FailureContext = { ...context, duration_ms: this.now() - start, error, status };
+                await this.fireFailure(failure);
+                this.logger.warn?.("SmartRouter completion failure", this.safeLog({ ...failure, message: error.message }));
+
+                if (this.isRateLimit(error)) {
+                    await this.fireFallback({
+                        ...failure,
+                        cooldown_until: state.cooldown_until,
+                        next_group: this.nextGroupAfter(groupName, request.model),
+                    });
+                    return { ok: false, error };
+                }
+
+                if (!this.isRetryableInPlace(error) || retryAttempt >= this.retries) {
+                    await this.fireFallback({
+                        ...failure,
+                        cooldown_until: state.cooldown_until || undefined,
+                        next_group: this.nextGroupAfter(groupName, request.model),
+                    });
+                    return { ok: false, error };
+                }
+
+                await this.sleep(this.backoffDelay(retryAttempt));
+            }
+        }
+
+        return { ok: false, error: new Error("SmartRouter: retry loop exhausted") };
+    }
+
+    private normalizeDeployment(deployment: RouterDeployment): NormalizedDeployment {
+        const apiKey = deployment.apiKey ?? deployment.api_key ?? readEnv(deployment.apiKeyEnv) ?? "";
+        const group = deployment.group ?? deployment.model;
+        const id = deployment.id ?? `${group}:${deployment.provider}:${deployment.model}:${this.states.length}`;
+        const rpmLimit = deployment.rpmLimit ?? deployment.rpm_limit;
+        const tpmLimit = deployment.tpmLimit ?? deployment.tpm_limit;
+
+        return {
+            ...deployment,
+            id,
+            group,
+            apiKey,
+            api_key: apiKey,
+            priority: deployment.priority ?? 100,
+            weight: deployment.weight ?? 1,
+            rpmLimit,
+            rpm_limit: rpmLimit,
+            tpmLimit,
+            tpm_limit: tpmLimit,
+            cooldownMs: deployment.cooldownMs ?? this.cooldownMs,
+            timeoutMs: deployment.timeoutMs ?? this.timeoutMs,
+            latencyMs: deployment.latencyMs ?? DEFAULT_LATENCY_MS,
+        };
+    }
+
+    private groupOrder(model?: string): string[] {
+        const allGroups = [...this.groups.values()].sort((a, b) => a.priority - b.priority);
+        if (!model) return allGroups.map((group) => group.name);
+
+        const directGroup = this.groups.get(model);
+        if (directGroup) return this.expandFallbacks(directGroup.name);
+
+        const modelGroups = allGroups
+            .filter((group) => this.states.some((state) => state.deployment.group === group.name && state.deployment.model === model))
+            .map((group) => group.name);
+
+        return modelGroups.length > 0 ? modelGroups : [model];
+    }
+
+    private expandFallbacks(groupName: string, seen = new Set<string>()): string[] {
+        if (seen.has(groupName)) return [];
+        seen.add(groupName);
+        const group = this.groups.get(groupName);
+        if (!group) return [groupName];
+        return [groupName, ...group.fallbacks.flatMap((fallback) => this.expandFallbacks(fallback, seen))];
+    }
+
+    private nextGroupAfter(groupName: string, model?: string): string | undefined {
+        const order = this.groupOrder(model);
+        const index = order.indexOf(groupName);
+        return index >= 0 ? order[index + 1] : undefined;
+    }
+
+    private pickDeployment(groupName: string, request: CompletionRequest, tried: Set<string>): DeploymentState | null {
+        const group = this.groups.get(groupName);
+        const strategy = group?.strategy ?? this.strategy;
+        const estimatedTokens = this.estimatePromptTokens(request) + (request.max_tokens ?? request.maxTokens ?? 0);
+        const candidates = this.states.filter((state) => {
+            this.rolloverIfStale(state);
+            if (tried.has(state.deployment.id)) return false;
+            if (state.deployment.group !== groupName && state.deployment.model !== groupName) return false;
+            if (request.model && !this.groups.has(request.model) && state.deployment.model !== request.model) return false;
+            if (state.cooldown_until > this.now()) return false;
+            if (state.deployment.rpmLimit && state.requests_this_minute >= state.deployment.rpmLimit) return false;
+            if (state.deployment.tpmLimit && state.tokens_this_minute + estimatedTokens > state.deployment.tpmLimit) return false;
+            return true;
+        });
+
+        if (candidates.length === 0) return null;
+        candidates.sort((a, b) => a.deployment.priority - b.deployment.priority);
+        const bestPriority = candidates[0].deployment.priority;
+        const samePriority = candidates.filter((state) => state.deployment.priority === bestPriority);
+
+        if (strategy === "weighted") return this.weightedPick(samePriority);
+        if (strategy === "latency") return samePriority.sort((a, b) => a.latency_ms - b.latency_ms)[0];
+        if (strategy === "cost") return samePriority.sort((a, b) => this.estimatedCost(a, request) - this.estimatedCost(b, request))[0];
+        if (strategy === "priority") return samePriority[0];
+
+        return samePriority.sort((a, b) => {
+            const minuteDiff = a.tokens_this_minute - b.tokens_this_minute;
+            if (minuteDiff !== 0) return minuteDiff;
+            return a.cumulative_tokens - b.cumulative_tokens;
+        })[0];
+    }
+
+    private weightedPick(candidates: DeploymentState[]): DeploymentState {
+        const total = candidates.reduce((sum, state) => sum + Math.max(0, state.deployment.weight), 0);
+        if (total <= 0) return candidates[0];
+        let cursor = this.random() * total;
+        for (const state of candidates) {
+            cursor -= Math.max(0, state.deployment.weight);
+            if (cursor <= 0) return state;
+        }
+        this.roundRobinCursor = (this.roundRobinCursor + 1) % candidates.length;
+        return candidates[this.roundRobinCursor];
+    }
+
+    private estimatedCost(state: DeploymentState, request: CompletionRequest): number {
+        const input = this.estimatePromptTokens(request);
+        const output = request.max_tokens ?? request.maxTokens ?? 256;
+        return input * (state.deployment.cost?.input ?? 0) + output * (state.deployment.cost?.output ?? 0);
+    }
+
+    private recordSuccess(state: DeploymentState, usage: Usage, durationMs: number): void {
+        this.rolloverIfStale(state);
+        const totalTokens = Math.max(usage.total_tokens, 0);
+        state.requests_this_minute += 1;
+        state.tokens_this_minute += totalTokens;
+        state.cumulative_tokens += totalTokens;
+        state.successes += 1;
+        state.latency_ms = state.latency_ms * 0.8 + durationMs * 0.2;
+    }
+
+    private recordFailure(state: DeploymentState, error: Error): void {
+        this.rolloverIfStale(state);
+        state.requests_this_minute += 1;
+        state.failures += 1;
+        if (this.isRateLimit(error)) {
+            state.cooldown_until = this.now() + this.cooldownFor(error, state.deployment);
+        }
+    }
+
+    private rolloverIfStale(state: DeploymentState): void {
+        const window = this.currentWindow();
+        if (state.window === window) return;
+        state.window = window;
+        state.requests_this_minute = 0;
+        state.tokens_this_minute = 0;
+    }
+
+    private currentWindow(): number {
+        return Math.floor(this.now() / 60_000);
+    }
+
+    private context(
+        state: DeploymentState,
+        group: string,
+        attempt: number,
+        request: CompletionRequest
+    ): RouteContext {
+        return {
+            request,
+            provider: state.deployment.provider,
+            model: state.deployment.model,
+            deployment_id: state.deployment.id,
+            group,
+            attempt,
+        };
+    }
+
+    private completionAdapterFor(provider: Provider): ProviderCompletion {
+        switch (provider) {
+            case "openai":
+                return openaiCompletion;
+            case "cohere":
+                return cohereCompletion;
+            case "google_palm":
+            case "gemini":
+            case "google":
+                return googleCompletion;
+        }
+    }
+
+    private streamAdapterFor(provider: Provider): ProviderStream {
+        switch (provider) {
+            case "openai":
+                return openaiStream;
+            case "cohere":
+                return cohereStream;
+            case "google_palm":
+            case "gemini":
+            case "google":
+                return googleStream;
+        }
+    }
+
+    private shouldRouteAway(error: Error): boolean {
+        return this.isRateLimit(error) || this.isRetryableInPlace(error);
+    }
+
+    private isRateLimit(error: Error): boolean {
+        return statusFromError(error) === 429;
+    }
+
+    private isRetryableInPlace(error: Error): boolean {
+        const status = statusFromError(error);
+        return status === undefined || status === 408 || status === 409 || status >= 500;
+    }
+
+    private cooldownFor(error: Error, deployment: NormalizedDeployment): number {
+        const retryAfter = retryAfterMs(error);
+        return retryAfter ?? deployment.cooldownMs;
+    }
+
+    private backoffDelay(attempt: number): number {
+        const exponential = Math.min(this.backoffMaxMs, this.backoffBaseMs * 2 ** attempt);
+        const jitter = Math.floor(this.random() * exponential * 0.25);
+        return exponential + jitter;
+    }
+
+    private estimatePromptTokens(request: CompletionRequest): number {
+        if (request.estimated_prompt_tokens) return request.estimated_prompt_tokens;
+        const text = request.prompt ?? request.messages?.map((message) => message.content).join("\n") ?? "";
+        return Math.max(1, Math.ceil(text.length / 4));
+    }
+
+    private estimateUsage(request: CompletionRequest, content: string): Usage {
+        const prompt_tokens = this.estimatePromptTokens(request);
+        const completion_tokens = Math.max(1, Math.ceil(content.length / 4));
+        return { prompt_tokens, completion_tokens, total_tokens: prompt_tokens + completion_tokens };
+    }
+
+    private safeLog(details: Record<string, unknown>): Record<string, unknown> {
+        const { request, error, ...rest } = details as Record<string, unknown> & { request?: CompletionRequest; error?: Error };
+        return {
+            ...rest,
+            prompt_present: Boolean(request?.prompt),
+            message_count: request?.messages?.length ?? 0,
+            error_message: error?.message,
+        };
+    }
+
+    private async fireStart(ctx: RouteContext): Promise<void> {
+        await this.fire("on_start", ctx);
+    }
+
+    private async fireSuccess(ctx: SuccessContext): Promise<void> {
+        await this.fire("on_success", ctx);
+    }
+
+    private async fireFailure(ctx: FailureContext): Promise<void> {
+        await this.fire("on_failure", ctx);
+    }
+
+    private async fireFallback(ctx: FallbackContext): Promise<void> {
+        await this.fire("on_fallback", ctx);
+    }
+
+    private async fire(name: keyof RouterCallback, ctx: RouteContext | SuccessContext | FailureContext | FallbackContext): Promise<void> {
+        for (const callback of this.callbacks) {
+            const fn = callback[name] as ((context: any) => void | Promise<void>) | undefined;
+            if (!fn) continue;
+            try {
+                await fn(ctx);
+            } catch (err) {
+                this.logger.warn?.("SmartRouter callback failed", { callback: name, error: toError(err).message });
+            }
+        }
+    }
+}
+
+function readEnv(name?: string): string | undefined {
+    if (!name) return undefined;
+    const env = (globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }).process?.env;
+    return env?.[name];
+}
+
+function toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+}
+
+export function statusFromError(error: Error): number | undefined {
+    return (error as any)?.response?.status ?? (error as any)?.status;
+}
+
+function retryAfterMs(error: Error): number | undefined {
+    const headers = (error as any)?.response?.headers ?? {};
+    const raw = headers["retry-after"] ?? headers["Retry-After"];
+    if (!raw) return undefined;
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    const seconds = Number(value);
+    if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+    const date = Date.parse(String(value));
+    if (Number.isFinite(date)) return Math.max(0, date - Date.now());
+    return undefined;
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/sse.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/sse.ts
@@ -1,0 +1,108 @@
+async function* toAsyncText(input: unknown): AsyncGenerator<string> {
+    if (typeof input === "string") {
+        yield input;
+        return;
+    }
+
+    if (input instanceof Uint8Array) {
+        yield new TextDecoder().decode(input);
+        return;
+    }
+
+    const maybeReadable = input as { getReader?: () => { read: () => Promise<{ done: boolean; value?: Uint8Array }> } };
+    if (maybeReadable?.getReader) {
+        const reader = maybeReadable.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) yield decoder.decode(value, { stream: true });
+        }
+        return;
+    }
+
+    const maybeAsync = input as AsyncIterable<unknown>;
+    if (maybeAsync?.[Symbol.asyncIterator]) {
+        for await (const chunk of maybeAsync) {
+            if (typeof chunk === "string") {
+                yield chunk;
+            } else if (chunk instanceof Uint8Array) {
+                yield new TextDecoder().decode(chunk);
+            } else if (typeof (chunk as { toString?: () => string })?.toString === "function") {
+                yield (chunk as { toString: () => string }).toString();
+            } else {
+                yield String(chunk);
+            }
+        }
+        return;
+    }
+
+    if (input != null) yield String(input);
+}
+
+export async function* parseSSE(input: unknown): AsyncGenerator<unknown> {
+    let buffer = "";
+
+    for await (const text of toAsyncText(input)) {
+        buffer += text;
+        const events = buffer.split(/\n\s*\n/);
+        buffer = events.pop() ?? "";
+
+        for (const event of events) {
+            const data = event
+                .split(/\r?\n/)
+                .filter((line) => line.trim().startsWith("data:"))
+                .map((line) => line.replace(/^\s*data:\s?/, ""))
+                .join("\n")
+                .trim();
+
+            if (!data || data === "[DONE]") continue;
+            try {
+                yield JSON.parse(data);
+            } catch {
+                yield data;
+            }
+        }
+    }
+
+    const tail = buffer.trim();
+    if (!tail) return;
+
+    for (const line of tail.split(/\r?\n/)) {
+        const cleaned = line.replace(/^\s*data:\s?/, "").trim();
+        if (!cleaned || cleaned === "[DONE]") continue;
+        try {
+            yield JSON.parse(cleaned);
+        } catch {
+            yield cleaned;
+        }
+    }
+}
+
+export async function* parseJsonLines(input: unknown): AsyncGenerator<unknown> {
+    let buffer = "";
+
+    for await (const text of toAsyncText(input)) {
+        buffer += text;
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || trimmed === "[DONE]") continue;
+            try {
+                yield JSON.parse(trimmed);
+            } catch {
+                yield trimmed;
+            }
+        }
+    }
+
+    const tail = buffer.trim();
+    if (!tail || tail === "[DONE]") return;
+    try {
+        yield JSON.parse(tail);
+    } catch {
+        yield tail;
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/router/types.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/router/types.ts
@@ -1,0 +1,219 @@
+import type { role } from "../../types/index.js";
+
+export type Provider = "openai" | "google_palm" | "gemini" | "google" | "cohere";
+
+export type RoutingStrategy =
+    | "least-tokens"
+    | "latency"
+    | "cost"
+    | "weighted"
+    | "priority";
+
+export interface Message {
+    role: role;
+    content: string;
+    name?: string;
+}
+
+export interface Usage {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+}
+
+export interface DeploymentCost {
+    /** Cost per input token in USD, not per thousand or million. */
+    input?: number;
+    /** Cost per output token in USD, not per thousand or million. */
+    output?: number;
+}
+
+export interface RouterDeployment {
+    id?: string;
+    /** Logical model group. Requests for this name route inside this group first. */
+    group?: string;
+    provider: Provider;
+    model: string;
+    apiKey?: string;
+    api_key?: string;
+    apiKeyEnv?: string;
+    baseUrl?: string;
+    headers?: Record<string, string>;
+    organization?: string;
+    priority?: number;
+    weight?: number;
+    rpmLimit?: number;
+    rpm_limit?: number;
+    tpmLimit?: number;
+    tpm_limit?: number;
+    cooldownMs?: number;
+    timeoutMs?: number;
+    latencyMs?: number;
+    cost?: DeploymentCost;
+}
+
+export interface RouterModelGroup {
+    name: string;
+    deployments: RouterDeployment[];
+    fallbacks?: string[];
+    strategy?: RoutingStrategy;
+    priority?: number;
+}
+
+export interface CompletionRequest {
+    /** Logical group name or provider model name. Omit to route across all groups. */
+    model?: string;
+    messages?: Message[];
+    prompt?: string;
+    role?: role;
+    max_tokens?: number;
+    maxTokens?: number;
+    temperature?: number;
+    stream?: boolean;
+    stop?: string | string[];
+    tools?: unknown[];
+    functions?: unknown[];
+    function_call?: unknown;
+    metadata?: Record<string, unknown>;
+    /** Estimated prompt tokens used for TPM preflight and cost routing. */
+    estimated_prompt_tokens?: number;
+}
+
+export interface CompletionResponse {
+    content: string;
+    usage: Usage;
+    provider: Provider;
+    model: string;
+    deployment_id: string;
+    finish_reason?: string;
+    raw?: unknown;
+}
+
+export interface StreamChunk {
+    delta?: string;
+    content?: string;
+    done?: boolean;
+    usage?: Usage;
+    provider: Provider;
+    model: string;
+    deployment_id: string;
+    raw?: unknown;
+}
+
+export interface RouterHttpResponse<T = unknown> {
+    data: T;
+    status?: number;
+    headers?: Record<string, string | number | undefined>;
+}
+
+export interface RouterHttpClient {
+    post<T = unknown>(
+        url: string,
+        data?: unknown,
+        config?: {
+            headers?: Record<string, string>;
+            timeout?: number;
+            responseType?: "arraybuffer" | "blob" | "document" | "json" | "text" | "stream";
+        }
+    ): Promise<RouterHttpResponse<T>>;
+}
+
+export interface RouterLogger {
+    info?(message: string, details?: Record<string, unknown>): void;
+    warn?(message: string, details?: Record<string, unknown>): void;
+    error?(message: string, details?: Record<string, unknown>): void;
+}
+
+export interface RouteContext {
+    request: CompletionRequest;
+    provider: Provider;
+    model: string;
+    deployment_id: string;
+    group: string;
+    attempt: number;
+    duration_ms?: number;
+}
+
+export interface SuccessContext extends RouteContext {
+    response: CompletionResponse;
+}
+
+export interface FailureContext extends RouteContext {
+    error: Error;
+    status?: number;
+}
+
+export interface FallbackContext extends FailureContext {
+    cooldown_until?: number;
+    next_group?: string;
+}
+
+export interface RouterCallback {
+    on_start?: (ctx: RouteContext) => void | Promise<void>;
+    on_success?: (ctx: SuccessContext) => void | Promise<void>;
+    on_failure?: (ctx: FailureContext) => void | Promise<void>;
+    on_fallback?: (ctx: FallbackContext) => void | Promise<void>;
+}
+
+export interface RouterOptions {
+    deployments?: RouterDeployment[];
+    modelGroups?: RouterModelGroup[];
+    model_list?: RouterDeployment[];
+    modelGroupsFromJsonnet?: RouterModelGroup[];
+    strategy?: RoutingStrategy;
+    timeoutMs?: number;
+    /** Retries on the same deployment for 5xx/connection-style transient errors. */
+    retries?: number;
+    /** Maximum distinct deployments tried before surfacing the final error. */
+    fallbackAttempts?: number;
+    cooldownMs?: number;
+    backoffBaseMs?: number;
+    backoffMaxMs?: number;
+    logger?: RouterLogger;
+    callbacks?: RouterCallback[];
+    httpClient?: RouterHttpClient;
+    random?: () => number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+}
+
+export interface DeploymentSnapshot {
+    id: string;
+    group: string;
+    provider: Provider;
+    model: string;
+    priority: number;
+    weight: number;
+    requests_this_minute: number;
+    tokens_this_minute: number;
+    cumulative_tokens: number;
+    successes: number;
+    failures: number;
+    cooldown_until: number;
+    latency_ms: number;
+}
+
+export type ProviderCompletion = (
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+) => Promise<CompletionResponse>;
+
+export type ProviderStream = (
+    http: RouterHttpClient,
+    deployment: NormalizedDeployment,
+    request: CompletionRequest
+) => AsyncGenerator<StreamChunk>;
+
+export interface NormalizedDeployment extends RouterDeployment {
+    id: string;
+    group: string;
+    apiKey: string;
+    priority: number;
+    weight: number;
+    rpmLimit?: number;
+    tpmLimit?: number;
+    cooldownMs: number;
+    timeoutMs: number;
+    latencyMs: number;
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/router/smart-router.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/router/smart-router.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { SmartRouter } from "../../lib/router/smart-router.js";
+import type { RouterHttpClient, RouterHttpResponse } from "../../lib/router/types.js";
+import { posthogCallback } from "../../lib/router/callbacks/posthog.js";
+
+type Reply = RouterHttpResponse | Error;
+
+class MockHttpClient implements RouterHttpClient {
+    calls: Array<{ url: string; data: unknown; config: unknown }> = [];
+    private replies: Reply[];
+
+    constructor(replies: Reply[]) {
+        this.replies = [...replies];
+    }
+
+    async post<T = unknown>(url: string, data?: unknown, config?: unknown): Promise<RouterHttpResponse<T>> {
+        this.calls.push({ url, data, config });
+        const reply = this.replies.shift();
+        if (!reply) throw new Error("No mock response queued");
+        if (reply instanceof Error) throw reply;
+        return reply as RouterHttpResponse<T>;
+    }
+}
+
+function openAiResponse(content: string, total_tokens = 10): RouterHttpResponse {
+    return {
+        data: {
+            choices: [{ message: { content }, finish_reason: "stop" }],
+            usage: {
+                prompt_tokens: Math.floor(total_tokens / 2),
+                completion_tokens: Math.ceil(total_tokens / 2),
+                total_tokens,
+            },
+        },
+    };
+}
+
+function axiosError(status: number, headers: Record<string, string> = {}): Error {
+    const error = new Error(`HTTP ${status}`) as Error & { response?: unknown };
+    error.response = { status, headers, data: { error: { message: `HTTP ${status}` } } };
+    return error;
+}
+
+describe("SmartRouter", () => {
+    it("cools a 429 deployment and fails over to the next deployment in the same group", async () => {
+        const now = vi.fn(() => 1_000);
+        const http = new MockHttpClient([axiosError(429, { "retry-after": "2" }), openAiResponse("ok", 12)]);
+        const router = new SmartRouter({
+            now,
+            sleep: async () => undefined,
+            httpClient: http,
+            modelGroups: [
+                {
+                    name: "gpt-prod",
+                    deployments: [
+                        { id: "openai-a", provider: "openai", model: "gpt-4o", apiKey: "a" },
+                        { id: "openai-b", provider: "openai", model: "gpt-4o", apiKey: "b" },
+                    ],
+                },
+            ],
+        });
+
+        const result = await router.completion({ model: "gpt-prod", prompt: "hello" });
+
+        expect(result.deployment_id).toBe("openai-b");
+        expect(result.content).toBe("ok");
+        expect(router.getDeploymentState("openai-a")?.cooldown_until).toBe(3_000);
+        expect(http.calls).toHaveLength(2);
+    });
+
+    it("retries transient 5xx failures in place before using a fallback deployment", async () => {
+        const http = new MockHttpClient([axiosError(500), openAiResponse("retried", 8)]);
+        const router = new SmartRouter({
+            retries: 1,
+            random: () => 0,
+            sleep: async () => undefined,
+            httpClient: http,
+            deployments: [
+                { id: "openai-a", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "a" },
+                { id: "openai-b", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "b" },
+            ],
+        });
+
+        const result = await router.completion({ model: "gpt-prod", prompt: "hello" });
+
+        expect(result.deployment_id).toBe("openai-a");
+        expect(result.content).toBe("retried");
+        expect(http.calls).toHaveLength(2);
+    });
+
+    it("falls back across ordered model groups when the primary group is exhausted", async () => {
+        const http = new MockHttpClient([axiosError(500), axiosError(500), { data: { text: "fallback", meta: { tokens: { input_tokens: 2, output_tokens: 3 } } } }]);
+        const router = new SmartRouter({
+            retries: 1,
+            sleep: async () => undefined,
+            httpClient: http,
+            modelGroups: [
+                {
+                    name: "primary",
+                    fallbacks: ["backup"],
+                    deployments: [{ id: "p1", provider: "openai", model: "gpt-4o", apiKey: "p" }],
+                },
+                {
+                    name: "backup",
+                    deployments: [{ id: "b1", provider: "cohere", model: "command", apiKey: "c" }],
+                },
+            ],
+        });
+
+        const result = await router.completion({ model: "primary", prompt: "hello" });
+
+        expect(result.deployment_id).toBe("b1");
+        expect(result.provider).toBe("cohere");
+        expect(result.content).toBe("fallback");
+    });
+
+    it("routes by least tokens used while respecting RPM and TPM preflight limits", async () => {
+        const http = new MockHttpClient([openAiResponse("one", 90), openAiResponse("two", 5)]);
+        const router = new SmartRouter({
+            httpClient: http,
+            deployments: [
+                { id: "a", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "a", tpmLimit: 100 },
+                { id: "b", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "b", tpmLimit: 100 },
+            ],
+        });
+
+        const first = await router.completion({ model: "gpt-prod", prompt: "hello", max_tokens: 5 });
+        const second = await router.completion({ model: "gpt-prod", prompt: "hello", max_tokens: 5 });
+
+        expect(first.deployment_id).toBe("a");
+        expect(second.deployment_id).toBe("b");
+        expect(router.getUsage("a")?.cumulative_tokens).toBe(90);
+        expect(router.getUsage("b")?.cumulative_tokens).toBe(5);
+    });
+
+    it("supports cost and latency strategies without extra dependencies", async () => {
+        const http = new MockHttpClient([openAiResponse("cheap", 5), openAiResponse("fast", 5)]);
+        const costRouter = new SmartRouter({
+            strategy: "cost",
+            httpClient: http,
+            deployments: [
+                { id: "expensive", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "a", cost: { input: 1, output: 1 } },
+                { id: "cheap", group: "gpt-prod", provider: "openai", model: "gpt-4o-mini", apiKey: "b", cost: { input: 0.01, output: 0.01 } },
+            ],
+        });
+        expect((await costRouter.completion({ model: "gpt-prod", prompt: "hello" })).deployment_id).toBe("cheap");
+
+        const latencyRouter = new SmartRouter({
+            strategy: "latency",
+            httpClient: http,
+            deployments: [
+                { id: "slow", group: "fast-prod", provider: "openai", model: "gpt-4o", apiKey: "a", latencyMs: 2_000 },
+                { id: "fast", group: "fast-prod", provider: "openai", model: "gpt-4o", apiKey: "b", latencyMs: 200 },
+            ],
+        });
+        expect((await latencyRouter.completion({ model: "fast-prod", prompt: "hello" })).deployment_id).toBe("fast");
+    });
+
+    it("normalizes Google/Gemini and Cohere provider responses", async () => {
+        const http = new MockHttpClient([
+            {
+                data: {
+                    candidates: [{ content: { parts: [{ text: "gemini" }] }, finishReason: "STOP" }],
+                    usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 3, totalTokenCount: 5 },
+                },
+            },
+            {
+                data: {
+                    text: "cohere",
+                    meta: { tokens: { input_tokens: 4, output_tokens: 6 } },
+                },
+            },
+        ]);
+        const router = new SmartRouter({
+            httpClient: http,
+            deployments: [
+                { id: "g", group: "gemini", provider: "gemini", model: "gemini-pro", apiKey: "g" },
+                { id: "c", group: "cohere", provider: "cohere", model: "command", apiKey: "c" },
+            ],
+        });
+
+        const gemini = await router.completion({ model: "gemini", prompt: "hello" });
+        const cohere = await router.completion({ model: "cohere", prompt: "hello" });
+
+        expect(gemini.content).toBe("gemini");
+        expect(gemini.usage.total_tokens).toBe(5);
+        expect(cohere.content).toBe("cohere");
+        expect(cohere.usage.total_tokens).toBe(10);
+    });
+
+    it("streams OpenAI SSE chunks and records final usage", async () => {
+        const http = new MockHttpClient([
+            {
+                data: 'data: {"choices":[{"delta":{"content":"he"}}]}\n\ndata: {"choices":[{"delta":{"content":"llo"}}]}\n\ndata: [DONE]\n\n',
+            },
+        ]);
+        const router = new SmartRouter({
+            httpClient: http,
+            deployments: [{ id: "a", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "a" }],
+        });
+
+        const chunks = [];
+        for await (const chunk of router.stream({ model: "gpt-prod", prompt: "hello" })) chunks.push(chunk);
+
+        expect(chunks.map((chunk) => chunk.delta).filter(Boolean).join("")).toBe("hello");
+        expect(chunks[chunks.length - 1].done).toBe(true);
+        expect(router.getUsage("a")?.cumulative_tokens).toBeGreaterThan(0);
+    });
+
+    it("emits PostHog-compatible success/failure/fallback callbacks without hard dependencies", async () => {
+        const events: unknown[] = [];
+        const http = new MockHttpClient([axiosError(429), openAiResponse("ok", 4)]);
+        const router = new SmartRouter({
+            httpClient: http,
+            callbacks: [posthogCallback({ capture: (event) => events.push(event) })],
+            deployments: [
+                { id: "a", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "a" },
+                { id: "b", group: "gpt-prod", provider: "openai", model: "gpt-4o", apiKey: "b" },
+            ],
+        });
+
+        await router.completion({ model: "gpt-prod", prompt: "hello" });
+
+        expect(events).toHaveLength(3);
+        expect((events[0] as any).event).toBe("edgechains.smart_router.failure");
+        expect((events[1] as any).event).toBe("edgechains.smart_router.fallback");
+        expect((events[2] as any).event).toBe("edgechains.smart_router.success");
+    });
+});

--- a/JS/edgechains/examples/smart-router/jsonnet/router.jsonnet
+++ b/JS/edgechains/examples/smart-router/jsonnet/router.jsonnet
@@ -1,0 +1,42 @@
+{
+    strategy: "least-tokens",
+    retries: 2,
+    fallbackAttempts: 8,
+    modelGroups: [
+        {
+            name: "chat",
+            fallbacks: ["backup"],
+            deployments: [
+                {
+                    id: "openai-primary",
+                    provider: "openai",
+                    model: "gpt-4o",
+                    apiKeyEnv: "OPENAI_API_KEY",
+                    rpmLimit: 3000,
+                    tpmLimit: 90000,
+                    cost: { input: 0.000005, output: 0.000015 },
+                },
+                {
+                    id: "gemini-primary",
+                    provider: "gemini",
+                    model: "gemini-pro",
+                    apiKeyEnv: "GEMINI_API_KEY",
+                    latencyMs: 400,
+                    weight: 2,
+                },
+            ],
+        },
+        {
+            name: "backup",
+            strategy: "cost",
+            deployments: [
+                {
+                    id: "cohere-backup",
+                    provider: "cohere",
+                    model: "command",
+                    apiKeyEnv: "COHERE_API_KEY",
+                },
+            ],
+        },
+    ],
+}

--- a/JS/edgechains/examples/smart-router/package.json
+++ b/JS/edgechains/examples/smart-router/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "edgechains-smart-router-example",
+    "type": "module",
+    "scripts": {
+        "start": "ts-node src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "latest",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/smart-router/src/index.ts
+++ b/JS/edgechains/examples/smart-router/src/index.ts
@@ -1,0 +1,52 @@
+import { SmartRouter } from "@arakoodev/edgechains.js/ai";
+
+const router = new SmartRouter({
+    strategy: "least-tokens",
+    modelGroups: [
+        {
+            name: "chat",
+            fallbacks: ["backup"],
+            deployments: [
+                {
+                    id: "openai-primary",
+                    provider: "openai",
+                    model: "gpt-4o",
+                    apiKey: process.env.OPENAI_API_KEY,
+                    rpmLimit: 3000,
+                    tpmLimit: 90_000,
+                },
+                {
+                    id: "gemini-primary",
+                    provider: "gemini",
+                    model: "gemini-pro",
+                    apiKey: process.env.GEMINI_API_KEY,
+                    latencyMs: 400,
+                },
+            ],
+        },
+        {
+            name: "backup",
+            strategy: "cost",
+            deployments: [
+                {
+                    id: "cohere-backup",
+                    provider: "cohere",
+                    model: "command",
+                    apiKey: process.env.COHERE_API_KEY,
+                },
+            ],
+        },
+    ],
+});
+
+const response = await router.completion({
+    model: "chat",
+    messages: [{ role: "user", content: "Explain EdgeChains in one sentence." }],
+});
+
+console.log({
+    content: response.content,
+    usage: response.usage,
+    provider: response.provider,
+    deployment: response.deployment_id,
+});


### PR DESCRIPTION
## Summary

Fixes #286.

Adds a SmartRouter for the JS SDK with:

- OpenAI, Google PaLM/Gemini, and Cohere provider adapters
- model groups with ordered fallbacks
- rate-limit cooldown and automatic failover for 429 responses
- transient 5xx/network retries with exponential backoff and jitter
- least-token, latency, cost, weighted, and priority routing strategies
- streaming via async generators
- normalized token usage accounting
- Sentry and PostHog callback adapters without hard dependencies
- Jsonnet-friendly configuration example
- mocked Vitest coverage for router behavior and providers

## Development note

AI-assisted tooling was used during development. The contributor reviewed the resulting changes, ran the listed verification, and is responsible for the submitted work.

## Verification

- `npx vitest run src/ai/src/tests/router/smart-router.test.ts`: 8 passed
- `npm run build`: passed
- `git diff --check`: passed

/claim #286
