### PR TITLE
Fix Gemini generation config and add palm2 example

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
 import { retry } from "@lifeomic/attempt";
-const url = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
+const baseUrl = "https://generativelanguage.googleapis.com/v1/models";
 
-interface GeminiAIConstructionOptions {
+export interface GeminiAIConstructionOptions {
     apiKey?: string;
 }
 
-type SafetyRating = {
+export type SafetyRating = {
     category:
         | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
         | "HARM_CATEGORY_HATE_SPEECH"
@@ -15,36 +15,36 @@ type SafetyRating = {
     probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
 };
 
-type ContentPart = {
+export type ContentPart = {
     text: string;
 };
 
-type Content = {
+export type Content = {
     parts: ContentPart[];
     role: string;
 };
 
-type Candidate = {
+export type Candidate = {
     content: Content;
     finishReason: string;
     index: number;
     safetyRatings: SafetyRating[];
 };
 
-type UsageMetadata = {
+export type UsageMetadata = {
     promptTokenCount: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
 };
 
-type Response = {
+export type GeminiAIResponse = {
     candidates: Candidate[];
     usageMetadata: UsageMetadata;
 };
 
 type responseMimeType = "text/plain" | "application/json";
 
-interface GeminiAIChatOptions {
+export interface GeminiAIChatOptions {
     model?: string;
     max_output_tokens?: number;
     temperature?: number;
@@ -60,8 +60,10 @@ export class GeminiAI {
         this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
     }
 
-    async chat(chatOptions: GeminiAIChatOptions): Promise<Response> {
-        let data = JSON.stringify({
+    async chat(chatOptions: GeminiAIChatOptions): Promise<GeminiAIResponse> {
+        const model = chatOptions.model || "gemini-pro";
+        const url = `${baseUrl}/${model}:generateContent`;
+        const data = {
             contents: [
                 {
                     role: "user",
@@ -72,9 +74,14 @@ export class GeminiAI {
                     ],
                 },
             ],
-        });
+            generationConfig: {
+                temperature: chatOptions.temperature || 0.7,
+                responseMimeType: chatOptions.responseType || "text/plain",
+                maxOutputTokens: chatOptions.max_output_tokens || 1024,
+            },
+        };
 
-        let config = {
+        const config = {
             method: "post",
             maxBodyLength: Infinity,
             url,
@@ -82,10 +89,7 @@ export class GeminiAI {
                 "Content-Type": "application/json",
                 "x-goog-api-key": this.apiKey,
             },
-            temperature: chatOptions.temperature || "0.7",
-            responseMimeType: chatOptions.responseType || "text/plain",
-            max_output_tokens: chatOptions.max_output_tokens || 1024,
-            data: data,
+            data,
         };
         return await retry(
             async () => {

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
@@ -1,0 +1,63 @@
+import axios from "axios";
+import { describe, expect, test, vi } from "vitest";
+import { GeminiAI } from "../../lib/gemini/gemini";
+
+vi.mock("axios");
+
+describe("GeminiAI", () => {
+    test("sends prompt and generation config to the Gemini endpoint", async () => {
+        const mockResponse = {
+            candidates: [
+                {
+                    content: {
+                        role: "model",
+                        parts: [{ text: "Hello from Gemini" }],
+                    },
+                    finishReason: "STOP",
+                    index: 0,
+                    safetyRatings: [],
+                },
+            ],
+            usageMetadata: {
+                promptTokenCount: 3,
+                candidatesTokenCount: 4,
+                totalTokenCount: 7,
+            },
+        };
+
+        vi.mocked(axios.request).mockResolvedValueOnce({ data: mockResponse });
+
+        const gemini = new GeminiAI({ apiKey: "test-key" });
+        const response = await gemini.chat({
+            prompt: "Say hello",
+            model: "gemini-pro",
+            max_output_tokens: 64,
+            temperature: 0.2,
+            responseType: "application/json",
+        });
+
+        expect(response).toEqual(mockResponse);
+        expect(axios.request).toHaveBeenCalledWith({
+            method: "post",
+            maxBodyLength: Infinity,
+            url: "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent",
+            headers: {
+                "Content-Type": "application/json",
+                "x-goog-api-key": "test-key",
+            },
+            data: {
+                contents: [
+                    {
+                        role: "user",
+                        parts: [{ text: "Say hello" }],
+                    },
+                ],
+                generationConfig: {
+                    temperature: 0.2,
+                    responseMimeType: "application/json",
+                    maxOutputTokens: 64,
+                },
+            },
+        });
+    });
+});

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,11 @@
+local promptTemplate = |||
+  You are a helpful assistant.
+  Answer this question clearly: {question}
+|||;
+
+{
+  model: "gemini-pro",
+  prompt: std.strReplace(promptTemplate, "{question}", std.extVar("question")),
+  max_output_tokens: 128,
+  temperature: 0.2,
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "palm2-chat",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node --experimental-wasm-modules ./dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,15 @@
+import { GeminiAI } from "@arakoodev/edgechains.js/ai";
+import Jsonnet from "@arakoodev/jsonnet";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const jsonnet = new Jsonnet();
+
+jsonnet.extString("question", process.argv.slice(2).join(" ") || "What is EdgeChains?");
+const promptConfig = JSON.parse(jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet")));
+
+const gemini = new GeminiAI({ apiKey: process.env.GEMINI_API_KEY });
+const response = await gemini.chat(promptConfig);
+
+console.log(JSON.stringify(response, null, 2));

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "dist",
+        "strict": true,
+        "esModuleInterop": true
+    },
+    "include": ["src"]
+}

--- a/JS/edgechains/testcases/palm2/basic.jsonnet
+++ b/JS/edgechains/testcases/palm2/basic.jsonnet
@@ -1,0 +1,11 @@
+local promptTemplate = |||
+  You are a helpful assistant.
+  Answer this question clearly: {question}
+|||;
+
+{
+  model: "gemini-pro",
+  prompt: std.strReplace(promptTemplate, "{question}", std.extVar("question")),
+  max_output_tokens: 128,
+  temperature: 0.2,
+}


### PR DESCRIPTION
## Summary

/claim #279

This PR tightens the existing Gemini/PaLM-compatible JS SDK support by:
- sending Gemini generation settings in the Google `generationConfig` request body instead of on the Axios config object
- supporting configurable Gemini model names in the request URL
- exporting Gemini request/response TypeScript interfaces
- adding a mocked `testcases/palm2`-focused Vitest test for the request shape
- adding a Jsonnet prompt testcase under `JS/edgechains/testcases/palm2`
- adding a small Jsonnet-driven `palm2-chat` example

## Validation

- `node node_modules/vitest/vitest.mjs run src/ai/src/tests/palm2/gemini.test.ts`
- `node node_modules/typescript/bin/tsc -b`

Note: `npm install` initially failed on Windows because the esbuild install script returned `Access is denied`; reran dependency install with `--ignore-scripts` and then validated the targeted test and TypeScript build locally.