### PR TITLE
Add AWS Comprehend redactor utility

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,15 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
+export { AWSComprehendRedactor } from "./lib/aws-comprehend/comprehend-redactor.js";
+export type {
+    AWSComprehendRedactorOptions,
+    ComprehendClient,
+    ComprehendPiiEntity,
+    ComprehendPiiEntityType,
+    DetectPiiEntitiesResponse,
+    EndpointLike,
+    ObservableLike,
+} from "./lib/aws-comprehend/comprehend-redactor.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend-redactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend-redactor.ts
@@ -1,0 +1,128 @@
+export type ComprehendPiiEntityType =
+    | "BANK_ACCOUNT_NUMBER"
+    | "BANK_ROUTING"
+    | "CREDIT_DEBIT_NUMBER"
+    | "CREDIT_DEBIT_CVV"
+    | "CREDIT_DEBIT_EXPIRY"
+    | "PIN"
+    | "EMAIL"
+    | "ADDRESS"
+    | "NAME"
+    | "PHONE"
+    | "SSN"
+    | "DATE_TIME"
+    | "PASSPORT_NUMBER"
+    | "DRIVER_ID"
+    | "URL"
+    | "AGE"
+    | "USERNAME"
+    | "PASSWORD"
+    | "AWS_ACCESS_KEY"
+    | "AWS_SECRET_KEY"
+    | "IP_ADDRESS"
+    | "MAC_ADDRESS"
+    | "ALL";
+
+export interface ComprehendPiiEntity {
+    Type: ComprehendPiiEntityType;
+    Score: number;
+    BeginOffset: number;
+    EndOffset: number;
+}
+
+export interface DetectPiiEntitiesResponse {
+    Entities: ComprehendPiiEntity[];
+}
+
+export interface ComprehendClient {
+    detectPiiEntities(text: string, languageCode: string): Promise<DetectPiiEntitiesResponse>;
+}
+
+export interface AWSComprehendRedactorOptions {
+    client: ComprehendClient;
+    languageCode?: string;
+    minScore?: number;
+    replacement?: "placeholder" | "mask";
+    allowedTypes?: ComprehendPiiEntityType[];
+}
+
+export interface EndpointLike<TInput, TOutput> {
+    chat(options: TInput): Promise<TOutput>;
+}
+
+export interface ObservableLike<T> {
+    subscribe(observer: (value: T) => void): unknown;
+}
+
+export class AWSComprehendRedactor {
+    private readonly client: ComprehendClient;
+    private readonly languageCode: string;
+    private readonly minScore: number;
+    private readonly replacement: "placeholder" | "mask";
+    private readonly allowedTypes?: Set<ComprehendPiiEntityType>;
+
+    constructor(options: AWSComprehendRedactorOptions) {
+        this.client = options.client;
+        this.languageCode = options.languageCode || "en";
+        this.minScore = options.minScore ?? 0;
+        this.replacement = options.replacement || "placeholder";
+        this.allowedTypes = options.allowedTypes ? new Set(options.allowedTypes) : undefined;
+    }
+
+    async redactText(text: string): Promise<string> {
+        const response = await this.client.detectPiiEntities(text, this.languageCode);
+        const entities = response.Entities.filter((entity) => this.shouldRedact(entity)).sort(
+            (a, b) => b.BeginOffset - a.BeginOffset
+        );
+
+        return entities.reduce((redacted, entity) => {
+            const replacement =
+                this.replacement === "mask"
+                    ? "*".repeat(entity.EndOffset - entity.BeginOffset)
+                    : `[${entity.Type}]`;
+            return redacted.slice(0, entity.BeginOffset) + replacement + redacted.slice(entity.EndOffset);
+        }, text);
+    }
+
+    async redactPromptOptions<T extends { prompt?: string; messages?: Array<{ content: string }> }>(
+        options: T
+    ): Promise<T> {
+        const nextOptions = { ...options };
+        if (nextOptions.prompt) {
+            nextOptions.prompt = await this.redactText(nextOptions.prompt);
+        }
+        if (nextOptions.messages) {
+            nextOptions.messages = await Promise.all(
+                nextOptions.messages.map(async (message) => ({
+                    ...message,
+                    content: await this.redactText(message.content),
+                }))
+            );
+        }
+        return nextOptions;
+    }
+
+    chainEndpoint<TInput extends { prompt?: string; messages?: Array<{ content: string }> }, TOutput>(
+        endpoint: EndpointLike<TInput, TOutput>
+    ): EndpointLike<TInput, TOutput> {
+        return {
+            chat: async (options: TInput) => endpoint.chat(await this.redactPromptOptions(options)),
+        };
+    }
+
+    mapObservable<T extends { prompt?: string; messages?: Array<{ content: string }> }>(
+        source: ObservableLike<T>
+    ): ObservableLike<Promise<T>> {
+        return {
+            subscribe: (observer: (value: Promise<T>) => void) =>
+                source.subscribe((value) => observer(this.redactPromptOptions(value))),
+        };
+    }
+
+    private shouldRedact(entity: ComprehendPiiEntity): boolean {
+        if (entity.Score < this.minScore) {
+            return false;
+        }
+        return !this.allowedTypes || this.allowedTypes.has(entity.Type);
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/comprehend-redactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/comprehend-redactor.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from "vitest";
+import { AWSComprehendRedactor } from "../../lib/aws-comprehend/comprehend-redactor";
+
+describe("AWSComprehendRedactor", () => {
+    test("redacts detected PII with entity placeholders", async () => {
+        const client = {
+            detectPiiEntities: vi.fn().mockResolvedValue({
+                Entities: [
+                    { Type: "EMAIL", Score: 0.99, BeginOffset: 14, EndOffset: 27 },
+                    { Type: "PHONE", Score: 0.75, BeginOffset: 43, EndOffset: 55 },
+                ],
+            }),
+        };
+        const redactor = new AWSComprehendRedactor({ client, minScore: 0.8 });
+
+        await expect(redactor.redactText("Contact me at a@example.com or call 555-123-4567")).resolves.toBe(
+            "Contact me at [EMAIL] or call 555-123-4567"
+        );
+        expect(client.detectPiiEntities).toHaveBeenCalledWith(
+            "Contact me at a@example.com or call 555-123-4567",
+            "en"
+        );
+    });
+
+    test("redacts prompt options before calling a chained endpoint", async () => {
+        const client = {
+            detectPiiEntities: vi.fn().mockResolvedValue({
+                Entities: [{ Type: "NAME", Score: 0.95, BeginOffset: 9, EndOffset: 13 }],
+            }),
+        };
+        const endpoint = {
+            chat: vi.fn().mockResolvedValue({ content: "ok" }),
+        };
+        const redactor = new AWSComprehendRedactor({ client, replacement: "mask" });
+
+        const chained = redactor.chainEndpoint(endpoint);
+        const result = await chained.chat({ prompt: "My name: John" });
+
+        expect(result).toEqual({ content: "ok" });
+        expect(endpoint.chat).toHaveBeenCalledWith({ prompt: "My name: ****" });
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,5 @@
+{
+  prompt: "Please summarize this customer message: " + std.extVar("customer_message"),
+  minScore: 0.8,
+  replacement: "placeholder",
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "aws-comprehend-redaction",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node ./dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,24 @@
+import { AWSComprehendRedactor, type ComprehendClient } from "@arakoodev/edgechains.js/ai";
+import Jsonnet from "@arakoodev/jsonnet";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const jsonnet = new Jsonnet();
+
+jsonnet.extString("customer_message", "My name is John and my email is john@example.com.");
+const config = JSON.parse(jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet")));
+
+const mockComprehendClient: ComprehendClient = {
+    detectPiiEntities: async () => ({
+        Entities: [{ Type: "EMAIL", Score: 0.99, BeginOffset: 57, EndOffset: 73 }],
+    }),
+};
+
+const redactor = new AWSComprehendRedactor({
+    client: mockComprehendClient,
+    minScore: config.minScore,
+    replacement: config.replacement,
+});
+
+console.log(await redactor.redactPromptOptions({ prompt: config.prompt }));

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "dist",
+        "strict": true,
+        "esModuleInterop": true
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
## Summary

/claim #290

This PR adds a focused AWS Comprehend PII redaction utility for the JS SDK:
- adds `AWSComprehendRedactor` with a Comprehend-compatible client interface
- supports direct text redaction for prompt strings and chat message content
- provides `chainEndpoint()` so existing endpoint-style `chat()` calls can be wrapped after redaction
- provides an Observable-like mapping helper for pipeline-style usage
- exports the redactor and related types from the AI package
- adds mocked Vitest coverage for redaction and endpoint chaining
- adds a Jsonnet-driven `aws-comprehend-redaction` example

## Validation

- `node node_modules/vitest/vitest.mjs run src/ai/src/tests/aws-comprehend/comprehend-redactor.test.ts`
- `node node_modules/typescript/bin/tsc -b`

Note: the example uses a mock Comprehend-compatible client so maintainers can run it without AWS credentials; production callers can pass a real AWS Comprehend adapter implementing `detectPiiEntities()`.