### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,327 @@
+type QdrantFetch = typeof fetch;
+
+interface QdrantClient {
+  url: string;
+  apiKey?: string;
+  collectionName?: string;
+  request: <T = any>(path: string, init?: RequestInit) => Promise<T>;
+}
+
+interface QdrantClientOptions {
+  collectionName?: string;
+}
+
+interface InsertVectorDataArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  id?: string | number;
+  content?: string;
+  embedding: number[];
+  payload?: Record<string, any>;
+  [key: string]: any;
+}
+
+interface QueryVectorArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  vector?: number[];
+  queryVector?: number[];
+  embedding?: number[];
+  limit?: number;
+  filter?: Record<string, any>;
+  withPayload?: boolean;
+  withVector?: boolean;
+}
+
+interface PointIdArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  id: string | number;
+}
+
+interface UpdatePointArgs extends PointIdArgs {
+  updatedContent: Record<string, any>;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+  private readonly fetchImpl: QdrantFetch;
+
+  constructor(
+    QDRANT_URL: string,
+    QDRANT_API_KEY?: string,
+    fetchImpl: QdrantFetch = fetch,
+  ) {
+    this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(
+      /\/+$/,
+      "",
+    );
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    this.fetchImpl = fetchImpl;
+  }
+
+  createClient(opts: QdrantClientOptions = {}): QdrantClient {
+    return {
+      url: this.QDRANT_URL,
+      apiKey: this.QDRANT_API_KEY,
+      collectionName: opts.collectionName,
+      request: (path, init) => this.request(path, init),
+    };
+  }
+
+  async createCollection({
+    client,
+    collectionName,
+    vectorSize,
+    distance = "Cosine",
+  }: {
+    client: QdrantClient;
+    collectionName?: string;
+    vectorSize: number;
+    distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+  }): Promise<any> {
+    const collection = this.resolveCollection(client, collectionName);
+    return client.request(`/collections/${encodeURIComponent(collection)}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        vectors: {
+          size: vectorSize,
+          distance,
+        },
+      }),
+    });
+  }
+
+  async insertVectorData({
+    client,
+    tableName,
+    collectionName,
+    id,
+    content,
+    embedding,
+    payload,
+    ...args
+  }: InsertVectorDataArgs): Promise<any> {
+    const collection = this.resolveCollection(
+      client,
+      collectionName || tableName,
+    );
+    const pointPayload = {
+      ...(content !== undefined ? { content } : {}),
+      ...args,
+      ...(payload || {}),
+    };
+
+    return client.request(
+      `/collections/${encodeURIComponent(collection)}/points?wait=true`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          points: [
+            {
+              id: id || crypto.randomUUID(),
+              vector: embedding,
+              payload: pointPayload,
+            },
+          ],
+        }),
+      },
+    );
+  }
+
+  async getDataFromQuery({
+    client,
+    tableName,
+    collectionName,
+    vector,
+    queryVector,
+    embedding,
+    limit = 10,
+    filter,
+    withPayload = true,
+    withVector = false,
+  }: QueryVectorArgs): Promise<any> {
+    const collection = this.resolveCollection(
+      client,
+      collectionName || tableName,
+    );
+    const query = vector || queryVector || embedding;
+
+    if (!query) {
+      throw new Error(
+        "Qdrant search requires vector, queryVector, or embedding",
+      );
+    }
+
+    const response = await client.request<{ result: any[] }>(
+      `/collections/${encodeURIComponent(collection)}/points/search`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          vector: query,
+          limit,
+          filter,
+          with_payload: withPayload,
+          with_vector: withVector,
+        }),
+      },
+    );
+
+    return (response.result || []).map((point) => ({
+      id: point.id,
+      score: point.score,
+      ...(point.payload || {}),
+      ...(point.vector ? { vector: point.vector } : {}),
+    }));
+  }
+
+  async getData({
+    client,
+    tableName,
+    collectionName,
+    limit = 10,
+    filter,
+    withPayload = true,
+    withVector = false,
+  }: Omit<
+    QueryVectorArgs,
+    "vector" | "queryVector" | "embedding"
+  >): Promise<any> {
+    const collection = this.resolveCollection(
+      client,
+      collectionName || tableName,
+    );
+    return client.request(
+      `/collections/${encodeURIComponent(collection)}/points/scroll`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          limit,
+          filter,
+          with_payload: withPayload,
+          with_vector: withVector,
+        }),
+      },
+    );
+  }
+
+  async getDataById({
+    client,
+    tableName,
+    collectionName,
+    id,
+    withPayload = true,
+    withVector = false,
+  }: PointIdArgs & {
+    withPayload?: boolean;
+    withVector?: boolean;
+  }): Promise<any> {
+    const collection = this.resolveCollection(
+      client,
+      collectionName || tableName,
+    );
+    return client.request(
+      `/collections/${encodeURIComponent(collection)}/points`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ids: [id],
+          with_payload: withPayload,
+          with_vector: withVector,
+        }),
+      },
+    );
+  }
+
+  async updateById({
+    client,
+    tableName,
+    collectionName,
+    id,
+    updatedContent,
+  }: UpdatePointArgs): Promise<any> {
+    const collection = this.resolveCollection(
+      client,
+      collectionName || tableName,
+    );
+    return client.request(
+      `/collections/${encodeURIComponent(collection)}/points/payload?wait=true`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          points: [id],
+          payload: updatedContent,
+        }),
+      },
+    );
+  }
+
+  async deleteById({
+    client,
+    tableName,
+    collectionName,
+    id,
+  }: PointIdArgs): Promise<any> {
+    const collection = this.resolveCollection(
+      client,
+      collectionName || tableName,
+    );
+    return client.request(
+      `/collections/${encodeURIComponent(collection)}/points/delete?wait=true`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          points: [id],
+        }),
+      },
+    );
+  }
+
+  private resolveCollection(
+    client: QdrantClient,
+    collectionName?: string,
+  ): string {
+    const collection = collectionName || client.collectionName;
+    if (!collection) {
+      throw new Error("Qdrant collectionName or tableName is required");
+    }
+    return collection;
+  }
+
+  private async request<T = any>(
+    path: string,
+    init: RequestInit = {},
+  ): Promise<T> {
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required");
+    }
+
+    const headers = new Headers(init.headers);
+    headers.set("Content-Type", "application/json");
+    if (this.QDRANT_API_KEY) {
+      headers.set("api-key", this.QDRANT_API_KEY);
+    }
+
+    const response = await this.fetchImpl(`${this.QDRANT_URL}${path}`, {
+      ...init,
+      headers,
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(
+        `Qdrant request failed with ${response.status}: ${message}`,
+      );
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+function createFetchMock(responseBody: any = { result: { status: "ok" } }) {
+  return vi.fn().mockImplementation(
+    async () =>
+      new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  ) as unknown as typeof fetch;
+}
+
+async function readLastRequestBody(fetchMock: ReturnType<typeof vi.fn>) {
+  const [, init] = fetchMock.mock.calls.at(-1)!;
+  return JSON.parse(init.body as string);
+}
+
+describe("Qdrant", () => {
+  it("creates collections through the REST API without qdrant SDK packages", async () => {
+    const fetchMock = createFetchMock();
+    const qdrant = new Qdrant("https://qdrant.example", "secret", fetchMock);
+    const client = qdrant.createClient();
+
+    await qdrant.createCollection({
+      client,
+      collectionName: "documents",
+      vectorSize: 1536,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.any(Headers),
+      }),
+    );
+    expect(await readLastRequestBody(fetchMock as any)).toEqual({
+      vectors: { size: 1536, distance: "Cosine" },
+    });
+  });
+
+  it("upserts vector data with payload content", async () => {
+    const fetchMock = createFetchMock();
+    const qdrant = new Qdrant("https://qdrant.example", "secret", fetchMock);
+    const client = qdrant.createClient({ collectionName: "documents" });
+
+    await qdrant.insertVectorData({
+      client,
+      id: 42,
+      content: "hello",
+      embedding: [0.1, 0.2],
+      source: "unit-test",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents/points?wait=true",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(await readLastRequestBody(fetchMock as any)).toEqual({
+      points: [
+        {
+          id: 42,
+          vector: [0.1, 0.2],
+          payload: {
+            content: "hello",
+            source: "unit-test",
+          },
+        },
+      ],
+    });
+  });
+
+  it("searches vectors and normalizes scored payloads", async () => {
+    const fetchMock = createFetchMock({
+      result: [
+        {
+          id: "a",
+          score: 0.91,
+          payload: { content: "matched" },
+        },
+      ],
+    });
+    const qdrant = new Qdrant("https://qdrant.example", undefined, fetchMock);
+    const client = qdrant.createClient({ collectionName: "documents" });
+
+    const result = await qdrant.getDataFromQuery({
+      client,
+      queryVector: [1, 2, 3],
+      limit: 5,
+      filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents/points/search",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(await readLastRequestBody(fetchMock as any)).toEqual({
+      vector: [1, 2, 3],
+      limit: 5,
+      filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+      with_payload: true,
+      with_vector: false,
+    });
+    expect(result).toEqual([{ id: "a", score: 0.91, content: "matched" }]);
+  });
+
+  it("supports scroll, retrieve, payload update, and delete requests", async () => {
+    const fetchMock = createFetchMock();
+    const qdrant = new Qdrant("https://qdrant.example", "secret", fetchMock);
+    const client = qdrant.createClient({ collectionName: "documents" });
+
+    await qdrant.getData({ client, limit: 2 });
+    await qdrant.getDataById({ client, id: "point-1" });
+    await qdrant.updateById({
+      client,
+      id: "point-1",
+      updatedContent: { content: "updated" },
+    });
+    await qdrant.deleteById({ client, id: "point-1" });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://qdrant.example/collections/documents/points/scroll",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://qdrant.example/collections/documents/points",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://qdrant.example/collections/documents/points/payload?wait=true",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://qdrant.example/collections/documents/points/delete?wait=true",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("raises useful errors for failed Qdrant responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("bad request", {
+        status: 400,
+      }),
+    ) as unknown as typeof fetch;
+    const qdrant = new Qdrant("https://qdrant.example", "secret", fetchMock);
+    const client = qdrant.createClient({ collectionName: "documents" });
+
+    await expect(
+      qdrant.getDataFromQuery({ client, embedding: [0.1], limit: 1 }),
+    ).rejects.toThrow("Qdrant request failed with 400: bad request");
+  });
+});


### PR DESCRIPTION
## Summary

/claim #273

This PR adds Qdrant support to the JavaScript SDK vector-db package without introducing any Qdrant npm dependency:
- adds a dependency-free `Qdrant` REST client using direct Qdrant HTTP API calls
- supports collection creation, vector upsert, vector search, scroll, retrieve, payload update, and delete-by-id
- keeps the API shape close to the existing Supabase vector-db helper, accepting `tableName` as a collection alias where useful
- exports `Qdrant` from `@arakoodev/edgechains.js/vector-db`
- adds mocked Vitest coverage for request shapes, result normalization, and API error handling

## Validation

- `node node_modules/vitest/vitest.mjs run src/vector-db/src/tests/qdrant/qdrant.test.ts`
- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/prettier/bin/prettier.cjs --check src/vector-db/src/lib/qdrant/qdrant.ts src/vector-db/src/tests/qdrant/qdrant.test.ts src/vector-db/src/index.ts`
- `git diff --check`

Note: this is a client/test implementation only, so I did not attach a UI demo video. The mocked tests verify the exact REST calls without requiring a live Qdrant server.