### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,238 @@
+type QdrantId = string | number;
+type QdrantVector = number[];
+
+interface QdrantClient {
+    url: string;
+    apiKey?: string;
+    headers: Record<string, string>;
+}
+
+interface QdrantPoint {
+    id: QdrantId;
+    vector: QdrantVector;
+    payload?: Record<string, any>;
+}
+
+interface QdrantRequestOptions {
+    method?: string;
+    body?: unknown;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(): QdrantClient {
+        if (!this.QDRANT_URL) throw new Error("QDRANT_URL is required");
+        return {
+            url: this.QDRANT_URL,
+            apiKey: this.QDRANT_API_KEY,
+            headers: {
+                "content-type": "application/json",
+                ...(this.QDRANT_API_KEY ? { "api-key": this.QDRANT_API_KEY } : {}),
+            },
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: {
+        client: QdrantClient;
+        collectionName: string;
+        vectorSize: number;
+        distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+    }): Promise<any> {
+        return this.request(client, `/collections/${collectionName}`, {
+            method: "PUT",
+            body: { vectors: { size: vectorSize, distance } },
+        });
+    }
+
+    async insertVectorData({
+        client,
+        tableName,
+        collectionName = tableName,
+        points,
+        id,
+        vector,
+        embedding,
+        payload,
+        ...args
+    }: {
+        client: QdrantClient;
+        tableName?: string;
+        collectionName?: string;
+        points?: QdrantPoint[];
+        id?: QdrantId;
+        vector?: QdrantVector;
+        embedding?: QdrantVector;
+        payload?: Record<string, any>;
+        [key: string]: any;
+    }): Promise<any> {
+        if (!collectionName) throw new Error("collectionName or tableName is required");
+        const bodyPoints = points || [
+            {
+                id: id ?? args.pointId ?? args.documentId,
+                vector: vector || embedding || args.vectors,
+                payload: payload || this.payloadFromArgs(args),
+            },
+        ];
+        for (const point of bodyPoints) {
+            if (point.id === undefined || point.id === null) throw new Error("Qdrant point id is required");
+            if (!Array.isArray(point.vector)) throw new Error("Qdrant point vector is required");
+        }
+        return this.request(client, `/collections/${collectionName}/points`, {
+            method: "PUT",
+            body: { points: bodyPoints },
+        });
+    }
+
+    async getDataFromQuery({
+        client,
+        tableName,
+        collectionName = tableName,
+        queryVector,
+        vector,
+        embedding,
+        limit = 10,
+        filter,
+        with_payload = true,
+        with_vector = false,
+        score_threshold,
+    }: {
+        client: QdrantClient;
+        tableName?: string;
+        collectionName?: string;
+        queryVector?: QdrantVector;
+        vector?: QdrantVector;
+        embedding?: QdrantVector;
+        limit?: number;
+        filter?: Record<string, any>;
+        with_payload?: boolean;
+        with_vector?: boolean;
+        score_threshold?: number;
+    }): Promise<any> {
+        if (!collectionName) throw new Error("collectionName or tableName is required");
+        const query = queryVector || vector || embedding;
+        if (!Array.isArray(query)) throw new Error("queryVector, vector, or embedding is required");
+        const res = await this.request(client, `/collections/${collectionName}/points/search`, {
+            method: "POST",
+            body: { vector: query, limit, filter, with_payload, with_vector, score_threshold },
+        });
+        return res.result;
+    }
+
+    async getData({
+        client,
+        tableName,
+        collectionName = tableName,
+        limit = 10,
+        offset,
+        filter,
+        with_payload = true,
+        with_vector = false,
+    }: {
+        client: QdrantClient;
+        tableName?: string;
+        collectionName?: string;
+        limit?: number;
+        offset?: QdrantId;
+        filter?: Record<string, any>;
+        with_payload?: boolean;
+        with_vector?: boolean;
+    }): Promise<any> {
+        if (!collectionName) throw new Error("collectionName or tableName is required");
+        const res = await this.request(client, `/collections/${collectionName}/points/scroll`, {
+            method: "POST",
+            body: { limit, offset, filter, with_payload, with_vector },
+        });
+        return res.result;
+    }
+
+    async getDataById({
+        client,
+        tableName,
+        collectionName = tableName,
+        id,
+        with_payload = true,
+        with_vector = false,
+    }: {
+        client: QdrantClient;
+        tableName?: string;
+        collectionName?: string;
+        id: QdrantId;
+        with_payload?: boolean;
+        with_vector?: boolean;
+    }): Promise<any> {
+        if (!collectionName) throw new Error("collectionName or tableName is required");
+        const res = await this.request(client, `/collections/${collectionName}/points`, {
+            method: "POST",
+            body: { ids: [id], with_payload, with_vector },
+        });
+        return res.result?.[0] ?? null;
+    }
+
+    async updateById({
+        client,
+        tableName,
+        collectionName = tableName,
+        id,
+        updatedContent,
+    }: {
+        client: QdrantClient;
+        tableName?: string;
+        collectionName?: string;
+        id: QdrantId;
+        updatedContent: Record<string, any>;
+    }): Promise<any> {
+        if (!collectionName) throw new Error("collectionName or tableName is required");
+        return this.request(client, `/collections/${collectionName}/points/payload`, {
+            method: "POST",
+            body: { payload: updatedContent, points: [id] },
+        });
+    }
+
+    async deleteById({
+        client,
+        tableName,
+        collectionName = tableName,
+        id,
+    }: {
+        client: QdrantClient;
+        tableName?: string;
+        collectionName?: string;
+        id: QdrantId;
+    }): Promise<any> {
+        if (!collectionName) throw new Error("collectionName or tableName is required");
+        return this.request(client, `/collections/${collectionName}/points/delete`, {
+            method: "POST",
+            body: { points: [id] },
+        });
+    }
+
+    private payloadFromArgs(args: Record<string, any>): Record<string, any> {
+        const { pointId, documentId, vectors, client, tableName, collectionName, ...payload } = args;
+        return payload;
+    }
+
+    private async request(client: QdrantClient, path: string, options: QdrantRequestOptions): Promise<any> {
+        const response = await fetch(`${client.url}${path}`, {
+            method: options.method || "GET",
+            headers: client.headers,
+            body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        });
+        const body = await response.json().catch(() => undefined);
+        if (!response.ok) {
+            throw new Error(`Qdrant request failed: ${response.status} ${response.statusText} ${JSON.stringify(body)}`);
+        }
+        return body;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+function mockJsonResponse(body: unknown, ok = true, status = 200, statusText = "OK") {
+    return Promise.resolve({
+        ok,
+        status,
+        statusText,
+        json: () => Promise.resolve(body),
+    } as Response);
+}
+
+describe("Qdrant", () => {
+    beforeEach(() => {
+        fetchMock.mockReset();
+    });
+
+    it("creates a REST client with API key headers", () => {
+        const qdrant = new Qdrant("https://qdrant.example.com/", "secret");
+
+        expect(qdrant.createClient()).toEqual({
+            url: "https://qdrant.example.com",
+            apiKey: "secret",
+            headers: {
+                "content-type": "application/json",
+                "api-key": "secret",
+            },
+        });
+    });
+
+    it("creates a collection using Qdrant REST API", async () => {
+        fetchMock.mockResolvedValueOnce(await mockJsonResponse({ result: true }));
+        const qdrant = new Qdrant("https://qdrant.example.com", "secret");
+        const client = qdrant.createClient();
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents",
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({ vectors: { size: 1536, distance: "Cosine" } }),
+            })
+        );
+    });
+
+    it("upserts vector data into a collection", async () => {
+        fetchMock.mockResolvedValueOnce(await mockJsonResponse({ result: { operation_id: 1 } }));
+        const qdrant = new Qdrant("https://qdrant.example.com");
+        const client = qdrant.createClient();
+
+        await qdrant.insertVectorData({
+            client,
+            tableName: "documents",
+            id: 42,
+            embedding: [0.1, 0.2],
+            content: "hello",
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents/points",
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({
+                    points: [{ id: 42, vector: [0.1, 0.2], payload: { content: "hello" } }],
+                }),
+            })
+        );
+    });
+
+    it("searches points from a query vector", async () => {
+        const results = [{ id: 42, score: 0.91, payload: { content: "hello" } }];
+        fetchMock.mockResolvedValueOnce(await mockJsonResponse({ result: results }));
+        const qdrant = new Qdrant("https://qdrant.example.com");
+        const client = qdrant.createClient();
+
+        const res = await qdrant.getDataFromQuery({
+            client,
+            tableName: "documents",
+            queryVector: [0.1, 0.2],
+            limit: 3,
+        });
+
+        expect(res).toEqual(results);
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example.com/collections/documents/points/search",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    vector: [0.1, 0.2],
+                    limit: 3,
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            })
+        );
+    });
+
+    it("retrieves, updates, and deletes by id", async () => {
+        fetchMock
+            .mockResolvedValueOnce(await mockJsonResponse({ result: [{ id: 42, payload: { content: "hello" } }] }))
+            .mockResolvedValueOnce(await mockJsonResponse({ result: { operation_id: 2 } }))
+            .mockResolvedValueOnce(await mockJsonResponse({ result: { operation_id: 3 } }));
+        const qdrant = new Qdrant("https://qdrant.example.com");
+        const client = qdrant.createClient();
+
+        await expect(qdrant.getDataById({ client, tableName: "documents", id: 42 })).resolves.toEqual({
+            id: 42,
+            payload: { content: "hello" },
+        });
+        await qdrant.updateById({
+            client,
+            tableName: "documents",
+            id: 42,
+            updatedContent: { content: "updated" },
+        });
+        await qdrant.deleteById({ client, tableName: "documents", id: 42 });
+
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            "https://qdrant.example.com/collections/documents/points/payload",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ payload: { content: "updated" }, points: [42] }),
+            })
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            3,
+            "https://qdrant.example.com/collections/documents/points/delete",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ points: [42] }),
+            })
+        );
+    });
+});


### PR DESCRIPTION
## Summary

/claim #273

Adds Qdrant vector database support to the JavaScript SDK using Qdrant REST APIs directly, without adding Qdrant npm packages.

Changes:
- Add a dependency-free `Qdrant` REST client under `src/vector-db/src/lib/qdrant`
- Export `Qdrant` from `@arakoodev/edgechains.js/vector-db`
- Support collection creation, vector upsert, search, scroll, retrieve by id, payload update, and delete by id
- Add focused mocked Vitest coverage for request shape and core operations

## Demo

Short demo video: https://raw.githubusercontent.com/rjnevins/EdgeChains/846c39924d52eaa9fa2b2f185b0a89338b5dfa7a/edgechains-qdrant-demo.mp4

## Verification

Run from `JS/edgechains/arakoodev`:

- `npm run build`
- `npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts`

Both passed locally.

## Notes

The implementation uses `fetch` against Qdrant REST endpoints directly and does not introduce a Qdrant SDK dependency.
