### PR TITLE
Add PaLM2 API support to JavaScript SDK

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,16 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
+export type {
+  Palm2Model,
+  Palm2SafetyCategory,
+  Palm2SafetyRating,
+  Palm2SafetySetting,
+  Palm2SafetyThreshold,
+  Palm2TextCandidate,
+  Palm2TextOptions,
+  Palm2TextResponse,
+} from "./lib/palm2/palm2.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,128 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+
+const defaultPalm2Url = "https://generativelanguage.googleapis.com/v1beta2";
+
+interface Palm2AIConstructionOptions {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export type Palm2Model = "text-bison-001" | "chat-bison-001" | string;
+
+export type Palm2SafetyCategory =
+  | "HARM_CATEGORY_DEROGATORY"
+  | "HARM_CATEGORY_TOXICITY"
+  | "HARM_CATEGORY_VIOLENCE"
+  | "HARM_CATEGORY_SEXUAL"
+  | "HARM_CATEGORY_MEDICAL"
+  | "HARM_CATEGORY_DANGEROUS";
+
+export type Palm2SafetyThreshold =
+  | "BLOCK_NONE"
+  | "BLOCK_LOW_AND_ABOVE"
+  | "BLOCK_MEDIUM_AND_ABOVE"
+  | "BLOCK_ONLY_HIGH";
+
+export interface Palm2SafetySetting {
+  category: Palm2SafetyCategory;
+  threshold: Palm2SafetyThreshold;
+}
+
+export interface Palm2SafetyRating {
+  category: Palm2SafetyCategory;
+  probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
+}
+
+export interface Palm2TextCandidate {
+  output: string;
+  safetyRatings?: Palm2SafetyRating[];
+}
+
+export interface Palm2TextResponse {
+  candidates: Palm2TextCandidate[];
+  filters?: Array<{
+    reason: string;
+    message?: string;
+  }>;
+}
+
+export interface Palm2TextOptions {
+  model?: Palm2Model;
+  prompt: string;
+  safetySettings?: Palm2SafetySetting[];
+  stopSequences?: string[];
+  temperature?: number;
+  candidate_count?: number;
+  candidateCount?: number;
+  maxOutputTokens?: number;
+  topP?: number;
+  topK?: number;
+  max_retry?: number;
+  delay?: number;
+}
+
+export class Palm2AI {
+  apiKey: string;
+  baseUrl: string;
+
+  constructor(options: Palm2AIConstructionOptions = {}) {
+    this.apiKey = options.apiKey || process.env.PALM_API_KEY || "";
+    this.baseUrl = (options.baseUrl || defaultPalm2Url).replace(/\/+$/, "");
+  }
+
+  async chat(chatOptions: Palm2TextOptions): Promise<Palm2TextResponse> {
+    return this.generateText(chatOptions);
+  }
+
+  async generateText(
+    chatOptions: Palm2TextOptions,
+  ): Promise<Palm2TextResponse> {
+    const data = {
+      prompt: {
+        text: chatOptions.prompt,
+      },
+      safetySettings: chatOptions.safetySettings,
+      stopSequences: chatOptions.stopSequences,
+      temperature: chatOptions.temperature,
+      candidate_count:
+        chatOptions.candidate_count || chatOptions.candidateCount,
+      maxOutputTokens: chatOptions.maxOutputTokens,
+      topP: chatOptions.topP,
+      topK: chatOptions.topK,
+    };
+
+    return await retry(
+      async () => {
+        return (
+          await axios.post<Palm2TextResponse>(
+            this.generateTextUrl(chatOptions.model || "text-bison-001"),
+            this.removeUndefined(data),
+            {
+              headers: {
+                "Content-Type": "application/json",
+              },
+            },
+          )
+        ).data;
+      },
+      {
+        maxAttempts: chatOptions.max_retry || 3,
+        delay: chatOptions.delay || 200,
+      },
+    );
+  }
+
+  private generateTextUrl(model: Palm2Model): string {
+    const normalizedModel = model.replace(/^models\//, "");
+    return `${this.baseUrl}/models/${encodeURIComponent(normalizedModel)}:generateText?key=${this.apiKey}`;
+  }
+
+  private removeUndefined<T extends Record<string, any>>(
+    payload: T,
+  ): Partial<T> {
+    return Object.fromEntries(
+      Object.entries(payload).filter(([, value]) => value !== undefined),
+    ) as Partial<T>;
+  }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
@@ -1,0 +1,99 @@
+import axios from "axios";
+import { Palm2AI } from "../../../../../dist/ai/src/lib/palm2/palm2.js";
+
+jest.mock("axios");
+
+describe("Palm2AI", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("generates text with the PaLM2 text-bison endpoint", async () => {
+    const mockResponse = {
+      candidates: [
+        {
+          output: "Test response",
+          safetyRatings: [
+            {
+              category: "HARM_CATEGORY_TOXICITY",
+              probability: "NEGLIGIBLE",
+            },
+          ],
+        },
+      ],
+    };
+
+    (axios.post as jest.Mock).mockResolvedValueOnce({ data: mockResponse });
+
+    const palm2 = new Palm2AI({ apiKey: "test-api-key" });
+    const response = await palm2.generateText({
+      prompt: "Write a short product description.",
+      temperature: 0.4,
+      candidate_count: 1,
+      maxOutputTokens: 120,
+      topP: 0.8,
+      topK: 10,
+      safetySettings: [
+        {
+          category: "HARM_CATEGORY_TOXICITY",
+          threshold: "BLOCK_ONLY_HIGH",
+        },
+      ],
+    });
+
+    expect(response.candidates[0].output).toBe("Test response");
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta2/models/text-bison-001:generateText?key=test-api-key",
+      {
+        prompt: {
+          text: "Write a short product description.",
+        },
+        safetySettings: [
+          {
+            category: "HARM_CATEGORY_TOXICITY",
+            threshold: "BLOCK_ONLY_HIGH",
+          },
+        ],
+        temperature: 0.4,
+        candidate_count: 1,
+        maxOutputTokens: 120,
+        topP: 0.8,
+        topK: 10,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+
+  test("supports models passed with the models/ prefix", async () => {
+    const mockResponse = {
+      candidates: [{ output: "Prefixed model response" }],
+    };
+
+    (axios.post as jest.Mock).mockResolvedValueOnce({ data: mockResponse });
+
+    const palm2 = new Palm2AI({ apiKey: "test-api-key" });
+    const response = await palm2.chat({
+      model: "models/text-bison-001",
+      prompt: "Hello",
+    });
+
+    expect(response.candidates[0].output).toBe("Prefixed model response");
+    expect(axios.post).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta2/models/text-bison-001:generateText?key=test-api-key",
+      {
+        prompt: {
+          text: "Hello",
+        },
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+});

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,14 @@
+local promptTemplate = |||
+  You are a concise assistant. Answer the following question in two short sentences:
+  {question}
+|||;
+
+local key = std.extVar("palm_api_key");
+local userQuestion = std.extVar("question");
+local promptWithQuestion = std.strReplace(promptTemplate, "{question}", userQuestion + "\n");
+
+local main() =
+  local response = arakoo.native("palm2Call")({ prompt: promptWithQuestion, palmApiKey: key });
+  response;
+
+main()

--- a/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
@@ -1,0 +1,5 @@
+local PALM_API_KEY = "YOUR_PALM_API_KEY";
+
+{
+    "palm_api_key": PALM_API_KEY,
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "palm2-chat",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsc && node --experimental-wasm-modules ./dist/index.js"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "@arakoodev/jsonnet": "^0.24.0",
+    "file-uri-to-path": "^2.0.0",
+    "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "typescript": "^5.7.0-dev.20241007"
+  }
+}

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,36 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import Jsonnet from "@arakoodev/jsonnet";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const palm2Call = createSyncRPC(
+  path.join(__dirname, "./lib/generateResponse.cjs"),
+);
+
+app.post("/chat", async (c: any) => {
+  try {
+    const { question } = await c.req.json();
+    const key = JSON.parse(
+      jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet")),
+    ).palm_api_key;
+
+    jsonnet.extString("palm_api_key", key);
+    jsonnet.extString("question", question || "");
+    jsonnet.javascriptCallback("palm2Call", palm2Call);
+
+    const response = jsonnet.evaluateFile(
+      path.join(__dirname, "../jsonnet/main.jsonnet"),
+    );
+    return c.json(JSON.parse(response));
+  } catch (error) {
+    console.log("error occured", error);
+    return c.json({ error: "Unable to generate a PaLM2 response" }, 500);
+  }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
+++ b/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
@@ -1,0 +1,19 @@
+const { Palm2AI } = require("@arakoodev/edgechains.js/ai");
+
+async function palm2Call({ prompt, palmApiKey }: any) {
+  try {
+    const palm2 = new Palm2AI({ apiKey: palmApiKey });
+    const response = await palm2.generateText({
+      prompt,
+      temperature: 0.4,
+      candidate_count: 1,
+      maxOutputTokens: 256,
+    });
+
+    return JSON.stringify(response);
+  } catch (error) {
+    return JSON.stringify({ error });
+  }
+}
+
+module.exports = palm2Call;

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
/claim #279

Closes #279

Adds PaLM2 API support to the JavaScript SDK using Google's PaLM REST API shape.

Changes:
- Added `Palm2AI` client under the AI package
- Added TypeScript types for PaLM2 text generation options and responses
- Exported `Palm2AI` and related types from `@arakoodev/edgechains.js/ai`
- Added mocked unit tests in `tests/palm2`
- Added a `palm2-chat` example using jsonnet prompts

Verification:
- `npx tsc -b`
- `npx jest src/ai/src/tests/palm2/palm2.test.ts --runInBand`
- `npx tsc --noEmit -p JS/edgechains/examples/palm2-chat/tsconfig.json`