### PR TITLE
Add dependency-free AWS Comprehend PII redactor

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -7,6 +7,7 @@
     ],
     "exports": {
         "./ai": "./dist/ai/src/index.js",
+        "./ai/aws-comprehend": "./dist/ai/src/lib/aws-comprehend/index.js",
         "./vector-db": "./dist/vector-db/src/index.js",
         "./document-loader": "./dist/document-loader/src/index.js",
         "./splitter": "./dist/splitter/src/index.js",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,14 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+    AWSComprehendRedactor,
+    AwsComprehendRestClient,
+    type AWSComprehendRedactorOptions,
+    type ChatEndpoint,
+    type ComprehendPiiClient,
+    type ComprehendPiiEntity,
+    type PiiRedactionResult,
+    type PiiRedactionStrategy,
+    type PromptChatOptions,
+} from "./lib/aws-comprehend/index.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts
@@ -1,0 +1,372 @@
+import { createHash, createHmac } from "node:crypto";
+
+export type PiiRedactionStrategy = "label" | "mask" | "fixed";
+
+export interface AwsCredentials {
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+}
+
+export interface ComprehendPiiEntity {
+    BeginOffset: number;
+    EndOffset: number;
+    Score: number;
+    Type: string;
+}
+
+export interface DetectPiiEntitiesInput {
+    Text: string;
+    LanguageCode?: string;
+}
+
+export interface DetectPiiEntitiesOutput {
+    Entities?: ComprehendPiiEntity[];
+}
+
+export interface ComprehendPiiClient {
+    detectPiiEntities(input: DetectPiiEntitiesInput): Promise<DetectPiiEntitiesOutput>;
+}
+
+export interface AWSComprehendRedactorOptions {
+    client?: ComprehendPiiClient;
+    credentials?: AwsCredentials;
+    entityTypes?: string[];
+    languageCode?: string;
+    maskCharacter?: string;
+    minScore?: number;
+    region?: string;
+    replacementText?: string;
+    strategy?: PiiRedactionStrategy;
+}
+
+export interface PiiRedactionResult {
+    originalText: string;
+    redactedText: string;
+    entities: ComprehendPiiEntity[];
+}
+
+export interface MessageLike {
+    content: string;
+    [key: string]: unknown;
+}
+
+export interface PromptChatOptions {
+    messages?: MessageLike[];
+    prompt?: string;
+    [key: string]: unknown;
+}
+
+export interface ChatEndpoint<TOptions extends PromptChatOptions = PromptChatOptions, TReturn = unknown> {
+    chat(options: TOptions): Promise<TReturn> | TReturn;
+}
+
+export interface SubscriptionLike {
+    unsubscribe(): void;
+}
+
+export interface ObserverLike<T> {
+    complete?: () => void;
+    error?: (error: unknown) => void;
+    next?: (value: T) => void;
+}
+
+export interface ObservableLike<T> {
+    subscribe(observer: ObserverLike<T> | ((value: T) => void)): SubscriptionLike | void;
+}
+
+const DEFAULT_LANGUAGE_CODE = "en";
+const DEFAULT_MIN_SCORE = 0.5;
+const DEFAULT_REGION = "us-east-1";
+
+function hash(value: string): string {
+    return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function hmac(key: Buffer | string, value: string): Buffer {
+    return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function getSignatureKey(secretAccessKey: string, dateStamp: string, region: string): Buffer {
+    const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+    const regionKey = hmac(dateKey, region);
+    const serviceKey = hmac(regionKey, "comprehend");
+    return hmac(serviceKey, "aws4_request");
+}
+
+function toAmzDate(date: Date): string {
+    return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}
+
+function assertAwsCredentials(credentials: Required<Pick<AwsCredentials, "accessKeyId" | "secretAccessKey">>) {
+    if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+        throw new Error(
+            "AWS credentials are required. Provide accessKeyId/secretAccessKey or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+        );
+    }
+}
+
+export class AwsComprehendRestClient implements ComprehendPiiClient {
+    private readonly credentials: Required<Pick<AwsCredentials, "accessKeyId" | "secretAccessKey">> &
+        Pick<AwsCredentials, "sessionToken">;
+    private readonly region: string;
+
+    constructor(options: Pick<AWSComprehendRedactorOptions, "credentials" | "region"> = {}) {
+        this.region = options.region || process.env.AWS_REGION || DEFAULT_REGION;
+        this.credentials = {
+            accessKeyId: options.credentials?.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "",
+            secretAccessKey:
+                options.credentials?.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "",
+            sessionToken: options.credentials?.sessionToken || process.env.AWS_SESSION_TOKEN,
+        };
+    }
+
+    async detectPiiEntities(input: DetectPiiEntitiesInput): Promise<DetectPiiEntitiesOutput> {
+        assertAwsCredentials(this.credentials);
+
+        const body = JSON.stringify({
+            LanguageCode: input.LanguageCode || DEFAULT_LANGUAGE_CODE,
+            Text: input.Text,
+        });
+        const endpoint = `https://comprehend.${this.region}.amazonaws.com/`;
+        const url = new URL(endpoint);
+        const now = new Date();
+        const amzDate = toAmzDate(now);
+        const dateStamp = amzDate.slice(0, 8);
+        const target = "Comprehend_20171127.DetectPiiEntities";
+
+        const signingHeaders: Record<string, string> = {
+            "content-type": "application/x-amz-json-1.1",
+            host: url.host,
+            "x-amz-date": amzDate,
+            "x-amz-target": target,
+        };
+        if (this.credentials.sessionToken) {
+            signingHeaders["x-amz-security-token"] = this.credentials.sessionToken;
+        }
+
+        const sortedHeaderNames = Object.keys(signingHeaders).sort();
+        const canonicalHeaders = sortedHeaderNames
+            .map((name) => `${name}:${signingHeaders[name]}\n`)
+            .join("");
+        const signedHeaders = sortedHeaderNames.join(";");
+        const canonicalRequest = [
+            "POST",
+            "/",
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            hash(body),
+        ].join("\n");
+        const credentialScope = `${dateStamp}/${this.region}/comprehend/aws4_request`;
+        const stringToSign = [
+            "AWS4-HMAC-SHA256",
+            amzDate,
+            credentialScope,
+            hash(canonicalRequest),
+        ].join("\n");
+        const signature = createHmac(
+            "sha256",
+            getSignatureKey(this.credentials.secretAccessKey, dateStamp, this.region)
+        )
+            .update(stringToSign, "utf8")
+            .digest("hex");
+        const authorization = [
+            `AWS4-HMAC-SHA256 Credential=${this.credentials.accessKeyId}/${credentialScope}`,
+            `SignedHeaders=${signedHeaders}`,
+            `Signature=${signature}`,
+        ].join(", ");
+
+        const response = await fetch(endpoint, {
+            body,
+            headers: {
+                Authorization: authorization,
+                "Content-Type": signingHeaders["content-type"],
+                "X-Amz-Date": amzDate,
+                "X-Amz-Target": target,
+                ...(this.credentials.sessionToken
+                    ? { "X-Amz-Security-Token": this.credentials.sessionToken }
+                    : {}),
+            },
+            method: "POST",
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            throw new Error(`AWS Comprehend request failed: ${response.status} ${errorBody}`);
+        }
+
+        return (await response.json()) as DetectPiiEntitiesOutput;
+    }
+}
+
+export class AWSComprehendRedactor {
+    private readonly client: ComprehendPiiClient;
+    private readonly defaults: Required<
+        Pick<
+            AWSComprehendRedactorOptions,
+            "languageCode" | "maskCharacter" | "minScore" | "replacementText" | "strategy"
+        >
+    > &
+        Pick<AWSComprehendRedactorOptions, "entityTypes">;
+
+    constructor(options: AWSComprehendRedactorOptions = {}) {
+        this.client = options.client || new AwsComprehendRestClient(options);
+        this.defaults = {
+            entityTypes: options.entityTypes,
+            languageCode: options.languageCode || DEFAULT_LANGUAGE_CODE,
+            maskCharacter: options.maskCharacter || "*",
+            minScore: options.minScore ?? DEFAULT_MIN_SCORE,
+            replacementText: options.replacementText || "[REDACTED]",
+            strategy: options.strategy || "label",
+        };
+    }
+
+    async detectPiiEntities(
+        text: string,
+        options: Pick<AWSComprehendRedactorOptions, "languageCode"> = {}
+    ): Promise<ComprehendPiiEntity[]> {
+        const response = await this.client.detectPiiEntities({
+            LanguageCode: options.languageCode || this.defaults.languageCode,
+            Text: text,
+        });
+        return response.Entities || [];
+    }
+
+    async redactText(
+        text: string,
+        options: Pick<
+            AWSComprehendRedactorOptions,
+            "entityTypes" | "languageCode" | "maskCharacter" | "minScore" | "replacementText" | "strategy"
+        > = {}
+    ): Promise<PiiRedactionResult> {
+        const entities = this.filterEntities(
+            await this.detectPiiEntities(text, options),
+            options.entityTypes || this.defaults.entityTypes,
+            options.minScore ?? this.defaults.minScore
+        );
+
+        const redactedText = entities
+            .slice()
+            .sort((left, right) => right.BeginOffset - left.BeginOffset)
+            .reduce((value, entity) => {
+                return (
+                    value.slice(0, entity.BeginOffset) +
+                    this.replacementFor(entity, text, options) +
+                    value.slice(entity.EndOffset)
+                );
+            }, text);
+
+        return {
+            entities,
+            originalText: text,
+            redactedText,
+        };
+    }
+
+    async redactChatOptions<TOptions extends PromptChatOptions>(
+        chatOptions: TOptions,
+        options: Parameters<AWSComprehendRedactor["redactText"]>[1] = {}
+    ): Promise<TOptions> {
+        const nextOptions: PromptChatOptions = { ...chatOptions };
+        if (typeof chatOptions.prompt === "string") {
+            nextOptions.prompt = (await this.redactText(chatOptions.prompt, options)).redactedText;
+        }
+        if (Array.isArray(chatOptions.messages)) {
+            nextOptions.messages = await Promise.all(
+                chatOptions.messages.map(async (message) => ({
+                    ...message,
+                    content: (await this.redactText(message.content, options)).redactedText,
+                }))
+            );
+        }
+        return nextOptions as TOptions;
+    }
+
+    chainEndpoint<TOptions extends PromptChatOptions, TReturn>(
+        endpoint: ChatEndpoint<TOptions, TReturn>,
+        options: Parameters<AWSComprehendRedactor["redactText"]>[1] = {}
+    ): ChatEndpoint<TOptions, TReturn> {
+        return {
+            chat: async (chatOptions: TOptions) => {
+                return endpoint.chat(await this.redactChatOptions(chatOptions, options));
+            },
+        };
+    }
+
+    redactText$(
+        source: ObservableLike<string>,
+        options: Parameters<AWSComprehendRedactor["redactText"]>[1] = {}
+    ): ObservableLike<PiiRedactionResult> {
+        return this.mapObservable(source, (value) => this.redactText(value, options));
+    }
+
+    redactTextOperator(
+        options: Parameters<AWSComprehendRedactor["redactText"]>[1] = {}
+    ): (source: ObservableLike<string>) => ObservableLike<PiiRedactionResult> {
+        return (source) => this.redactText$(source, options);
+    }
+
+    private filterEntities(
+        entities: ComprehendPiiEntity[],
+        entityTypes: string[] | undefined,
+        minScore: number
+    ): ComprehendPiiEntity[] {
+        return entities.filter((entity) => {
+            const hasRequestedType = !entityTypes || entityTypes.includes(entity.Type);
+            return hasRequestedType && entity.Score >= minScore;
+        });
+    }
+
+    private mapObservable<TInput, TOutput>(
+        source: ObservableLike<TInput>,
+        project: (value: TInput) => Promise<TOutput>
+    ): ObservableLike<TOutput> {
+        return {
+            subscribe(observerOrNext: ObserverLike<TOutput> | ((value: TOutput) => void)) {
+                const observer =
+                    typeof observerOrNext === "function" ? { next: observerOrNext } : observerOrNext;
+                const pending: Promise<void>[] = [];
+
+                const subscription = source.subscribe({
+                    complete: () => {
+                        Promise.all(pending)
+                            .then(() => observer.complete?.())
+                            .catch((error) => observer.error?.(error));
+                    },
+                    error: (error) => observer.error?.(error),
+                    next: (value) => {
+                        pending.push(
+                            project(value)
+                                .then((mapped) => observer.next?.(mapped))
+                                .catch((error) => observer.error?.(error))
+                        );
+                    },
+                });
+
+                return {
+                    unsubscribe() {
+                        subscription?.unsubscribe();
+                    },
+                };
+            },
+        };
+    }
+
+    private replacementFor(
+        entity: ComprehendPiiEntity,
+        text: string,
+        options: Pick<
+            AWSComprehendRedactorOptions,
+            "maskCharacter" | "replacementText" | "strategy"
+        > = {}
+    ): string {
+        const strategy = options.strategy || this.defaults.strategy;
+        if (strategy === "label") return `[${entity.Type}]`;
+        if (strategy === "fixed") return options.replacementText || this.defaults.replacementText;
+
+        const spanLength = Math.max(entity.EndOffset - entity.BeginOffset, 0);
+        const maskCharacter = options.maskCharacter || this.defaults.maskCharacter;
+        return maskCharacter.repeat(spanLength || text.slice(entity.BeginOffset, entity.EndOffset).length);
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/index.ts
@@ -1,0 +1,17 @@
+export {
+    AWSComprehendRedactor,
+    AwsComprehendRestClient,
+    type AWSComprehendRedactorOptions,
+    type ChatEndpoint,
+    type ComprehendPiiClient,
+    type ComprehendPiiEntity,
+    type DetectPiiEntitiesInput,
+    type DetectPiiEntitiesOutput,
+    type MessageLike,
+    type ObservableLike,
+    type ObserverLike,
+    type PiiRedactionResult,
+    type PiiRedactionStrategy,
+    type PromptChatOptions,
+    type SubscriptionLike,
+} from "./awsComprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    AWSComprehendRedactor,
+    type ComprehendPiiClient,
+    type ComprehendPiiEntity,
+    type ObservableLike,
+    type ObserverLike,
+} from "../lib/aws-comprehend/index.js";
+
+function entity(text: string, value: string, type: string, score = 0.99): ComprehendPiiEntity {
+    const start = text.indexOf(value);
+    return {
+        BeginOffset: start,
+        EndOffset: start + value.length,
+        Score: score,
+        Type: type,
+    };
+}
+
+function mockClient(entities: ComprehendPiiEntity[]): ComprehendPiiClient {
+    return {
+        detectPiiEntities: vi.fn(async () => ({ Entities: entities })),
+    };
+}
+
+describe("AWSComprehendRedactor", () => {
+    it("redacts detected PII with entity labels", async () => {
+        const text = "Jane Doe emailed jane@example.com from 10.0.0.1";
+        const redactor = new AWSComprehendRedactor({
+            client: mockClient([
+                entity(text, "Jane Doe", "NAME"),
+                entity(text, "jane@example.com", "EMAIL"),
+                entity(text, "10.0.0.1", "IP_ADDRESS"),
+            ]),
+        });
+
+        const result = await redactor.redactText(text);
+
+        expect(result.redactedText).toBe("[NAME] emailed [EMAIL] from [IP_ADDRESS]");
+        expect(result.entities).toHaveLength(3);
+    });
+
+    it("filters low confidence and unrequested entity types", async () => {
+        const text = "Jane Doe uses jane@example.com";
+        const redactor = new AWSComprehendRedactor({
+            client: mockClient([
+                entity(text, "Jane Doe", "NAME", 0.99),
+                entity(text, "jane@example.com", "EMAIL", 0.4),
+            ]),
+        });
+
+        const result = await redactor.redactText(text, {
+            entityTypes: ["EMAIL"],
+            minScore: 0.9,
+        });
+
+        expect(result.redactedText).toBe(text);
+        expect(result.entities).toHaveLength(0);
+    });
+
+    it("supports fixed and mask replacement strategies", async () => {
+        const text = "Call 555-1212";
+        const redactor = new AWSComprehendRedactor({
+            client: mockClient([entity(text, "555-1212", "PHONE")]),
+        });
+
+        await expect(
+            redactor.redactText(text, { replacementText: "<private>", strategy: "fixed" })
+        ).resolves.toMatchObject({
+            redactedText: "Call <private>",
+        });
+        await expect(
+            redactor.redactText(text, { maskCharacter: "#", strategy: "mask" })
+        ).resolves.toMatchObject({
+            redactedText: "Call ########",
+        });
+    });
+
+    it("redacts prompt and message chat options before chaining to endpoints", async () => {
+        const text = "My ssn is 123-45-6789";
+        const client = mockClient([entity(text, "123-45-6789", "SSN")]);
+        const redactor = new AWSComprehendRedactor({ client });
+        const endpoint = {
+            chat: vi.fn(async (options) => ({ content: options.prompt || options.messages?.[0].content })),
+        };
+
+        const chained = redactor.chainEndpoint(endpoint);
+        const response = await chained.chat({
+            model: "example-model",
+            prompt: text,
+        });
+
+        expect(endpoint.chat).toHaveBeenCalledWith({
+            model: "example-model",
+            prompt: "My ssn is [SSN]",
+        });
+        expect(response).toEqual({ content: "My ssn is [SSN]" });
+
+        await redactor.redactChatOptions({
+            messages: [{ role: "user", content: text }],
+        });
+
+        expect(client.detectPiiEntities).toHaveBeenCalledTimes(2);
+    });
+
+    it("maps observable-like prompt streams to redaction results", async () => {
+        const text = "Email jane@example.com";
+        const redactor = new AWSComprehendRedactor({
+            client: mockClient([entity(text, "jane@example.com", "EMAIL")]),
+        });
+        const source: ObservableLike<string> = {
+            subscribe(observerOrNext: ObserverLike<string> | ((value: string) => void)) {
+                const observer =
+                    typeof observerOrNext === "function" ? { next: observerOrNext } : observerOrNext;
+                observer.next?.(text);
+                observer.complete?.();
+                return { unsubscribe() {} };
+            },
+        };
+
+        const values = await new Promise<string[]>((resolve, reject) => {
+            const collected: string[] = [];
+            redactor.redactTextOperator()(source).subscribe({
+                complete: () => resolve(collected),
+                error: reject,
+                next: (result) => collected.push(result.redactedText),
+            });
+        });
+
+        expect(values).toEqual(["Email [EMAIL]"]);
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -8,7 +8,7 @@ This example shows how to redact PII from prompts before passing them to an Edge
 2. Run `npm start`.
 3. To call real AWS Comprehend, set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_REGION`; otherwise the example uses an offline mock client.
 
-The example demonstrates direct prompt redaction and `chainEndpoint()` wrapping.
+The example demonstrates direct prompt redaction and `chainEndpoint()` wrapping. In a local repository checkout, `npm start` also builds the local AWS Comprehend redactor export used by this example.
 
 ## Expected Output
 

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,24 @@
+# AWS Comprehend Redaction Example
+
+This example shows how to redact PII from prompts before passing them to an EdgeChains-style endpoint.
+
+## Run
+
+1. Install dependencies from this folder with `npm install`.
+2. Run `npm start`.
+3. To call real AWS Comprehend, set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_REGION`; otherwise the example uses an offline mock client.
+
+The example demonstrates direct prompt redaction and `chainEndpoint()` wrapping.
+
+## Expected Output
+
+```text
+Original prompt:
+Please summarize this support ticket from Jane Doe. Email: jane@example.com. Phone: 555-1212.
+
+Redacted prompt:
+Please summarize this support ticket from [NAME]. Email: [EMAIL]. Phone: [PHONE].
+
+Endpoint response:
+Endpoint received safe prompt: Please summarize this support ticket from [NAME]. Email: [EMAIL]. Phone: [PHONE].
+```

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "type": "module",
     "scripts": {
+        "prestart": "node ./scripts/build-local-sdk.mjs",
         "start": "tsc && node dist/index.js"
     },
     "dependencies": {

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "aws-comprehend-redaction-example",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/scripts/build-local-sdk.mjs
+++ b/JS/edgechains/examples/aws-comprehend-redaction/scripts/build-local-sdk.mjs
@@ -1,0 +1,45 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const exampleRoot = resolve(scriptDir, "..");
+const packageRoot = resolve(exampleRoot, "../../arakoodev");
+const sourceRoot = resolve(packageRoot, "src/ai");
+const outputRoot = resolve(packageRoot, "dist/ai");
+const tsc = resolve(exampleRoot, "node_modules/typescript/bin/tsc");
+
+const entrypoint = resolve(sourceRoot, "src/lib/aws-comprehend/index.ts");
+const generatedDir = resolve(outputRoot, "src/lib/aws-comprehend");
+
+if (!existsSync(tsc)) {
+    throw new Error("TypeScript is not installed. Run npm install in this example first.");
+}
+
+rmSync(generatedDir, { recursive: true, force: true });
+
+execFileSync(
+    process.execPath,
+    [
+        tsc,
+        "--outDir",
+        outputRoot,
+        "--rootDir",
+        sourceRoot,
+        "--target",
+        "ES2022",
+        "--module",
+        "NodeNext",
+        "--moduleResolution",
+        "NodeNext",
+        "--strict",
+        "--skipLibCheck",
+        "--esModuleInterop",
+        "--declaration",
+        "--types",
+        "node",
+        entrypoint,
+    ],
+    { stdio: "inherit" },
+);

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,57 @@
+import {
+    AWSComprehendRedactor,
+    type ComprehendPiiClient,
+    type PromptChatOptions,
+} from "@arakoodev/edgechains.js/ai";
+
+const samplePrompt =
+    "Please summarize this support ticket from Jane Doe. Email: jane@example.com. Phone: 555-1212.";
+
+const offlineClient: ComprehendPiiClient = {
+    async detectPiiEntities({ Text }) {
+        const entities = [
+            { value: "Jane Doe", type: "NAME" },
+            { value: "jane@example.com", type: "EMAIL" },
+            { value: "555-1212", type: "PHONE" },
+        ]
+            .map(({ value, type }) => {
+                const start = Text.indexOf(value);
+                return {
+                    BeginOffset: start,
+                    EndOffset: start + value.length,
+                    Score: 0.99,
+                    Type: type,
+                };
+            })
+            .filter((entity) => entity.BeginOffset >= 0);
+
+        return { Entities: entities };
+    },
+};
+
+const useRealAws =
+    Boolean(process.env.AWS_ACCESS_KEY_ID) && Boolean(process.env.AWS_SECRET_ACCESS_KEY);
+
+const redactor = new AWSComprehendRedactor({
+    client: useRealAws ? undefined : offlineClient,
+    region: process.env.AWS_REGION || "us-east-1",
+});
+
+const redaction = await redactor.redactText(samplePrompt);
+console.log("Original prompt:");
+console.log(redaction.originalText);
+console.log("\nRedacted prompt:");
+console.log(redaction.redactedText);
+
+const mockEndpoint = {
+    async chat(options: PromptChatOptions) {
+        return {
+            content: `Endpoint received safe prompt: ${options.prompt}`,
+        };
+    },
+};
+
+const safeEndpoint = redactor.chainEndpoint(mockEndpoint);
+const response = await safeEndpoint.chat({ prompt: samplePrompt });
+console.log("\nEndpoint response:");
+console.log(response.content);

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -2,7 +2,7 @@ import {
     AWSComprehendRedactor,
     type ComprehendPiiClient,
     type PromptChatOptions,
-} from "@arakoodev/edgechains.js/ai";
+} from "@arakoodev/edgechains.js/ai/aws-comprehend";
 
 const samplePrompt =
     "Please summarize this support ticket from Jane Doe. Email: jane@example.com. Phone: 555-1212.";

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add `AWSComprehendRedactor` to the JS AI package with direct PII detection/redaction through AWS Comprehend.
- Keep runtime dependency-free by signing Comprehend REST requests with Node built-ins instead of adding the AWS SDK.
- Support injectable mock clients, direct text redaction, prompt/message redaction before endpoint `chat()` calls, and Observable-style chaining via `redactText$` / `redactTextOperator()`.
- Export the redactor and types from `@arakoodev/edgechains.js/ai`.
- Add mocked Vitest coverage and a runnable example under `JS/edgechains/examples/aws-comprehend-redaction`.

## Demo
Demo video/GIF:

![AWS Comprehend redaction demo](https://raw.githubusercontent.com/robin081412108-coder/EdgeChains/demo-assets/aws-comprehend-redaction-545/aws-comprehend-redaction-demo.gif)

The example can be run without AWS credentials using its offline mock client:

```bash
cd JS/edgechains/examples/aws-comprehend-redaction
npm install
npm start
```

Expected demo output is documented in `JS/edgechains/examples/aws-comprehend-redaction/README.md` and shows direct redaction plus `chainEndpoint()` forwarding a sanitized prompt.

## Validation
- `C:\Users\robin\Documents\Codex\2026-05-23\github-50\tooldeps-ts\node_modules\.bin\vitest.cmd run JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts` -> 5 passed
- `C:\Users\robin\Documents\Codex\2026-05-23\github-50\tooldeps-ts\node_modules\.bin\tsc.cmd --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --esModuleInterop --typeRoots C:\Users\robin\Documents\Codex\2026-05-23\github-50\tooldeps-ts\node_modules\@types --types node JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/awsComprehendRedactor.ts JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/index.ts` -> passed
- `npm start` from `JS/edgechains/examples/aws-comprehend-redaction` -> passed
- `git diff --cached --check` -> passed before commit

/claim #290

Closes #290