### PR TITLE
Add AWS Comprehend prompt redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,20 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+  AWSComprehendRedactor,
+  AWSComprehendSdkAdapter,
+} from "./lib/aws-comprehend/aws-comprehend-redactor.js";
+export type {
+  AWSComprehendRedactorOptions,
+  ChatEndpoint,
+  ComprehendPiiClient,
+  ComprehendPiiEntity,
+  DetectPiiEntitiesInput,
+  DetectPiiEntitiesOutput,
+  PiiReplacement,
+  RedactableChatOptions,
+  RedactionMessage,
+  RedactionResult,
+  RedactOptions,
+} from "./lib/aws-comprehend/aws-comprehend-redactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/aws-comprehend-redactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/aws-comprehend-redactor.ts
@@ -1,0 +1,220 @@
+export type PiiReplacement =
+  | string
+  | ((entity: ComprehendPiiEntity, originalText: string) => string);
+
+export interface ComprehendPiiEntity {
+  Type?: string;
+  Score?: number;
+  BeginOffset: number;
+  EndOffset: number;
+}
+
+export interface DetectPiiEntitiesInput {
+  Text: string;
+  LanguageCode: string;
+}
+
+export interface DetectPiiEntitiesOutput {
+  Entities?: ComprehendPiiEntity[];
+}
+
+export interface ComprehendPiiClient {
+  detectPiiEntities(
+    input: DetectPiiEntitiesInput,
+  ): Promise<DetectPiiEntitiesOutput>;
+}
+
+export interface AwsSdkComprehendClient {
+  send(command: unknown): Promise<DetectPiiEntitiesOutput>;
+}
+
+export interface RedactionMessage {
+  content?: string;
+  [key: string]: unknown;
+}
+
+export interface RedactableChatOptions {
+  prompt?: string;
+  messages?: RedactionMessage[];
+  [key: string]: unknown;
+}
+
+export interface ChatEndpoint<TOptions, TResult> {
+  chat(options: TOptions): Promise<TResult>;
+}
+
+export interface AWSComprehendRedactorOptions {
+  client: ComprehendPiiClient;
+  languageCode?: string;
+  minScore?: number;
+  entityTypes?: string[];
+  replacement?: PiiReplacement;
+}
+
+export interface RedactOptions {
+  languageCode?: string;
+  minScore?: number;
+  entityTypes?: string[];
+  replacement?: PiiReplacement;
+}
+
+export interface RedactionResult {
+  text: string;
+  entities: ComprehendPiiEntity[];
+}
+
+type DetectPiiEntitiesCommandFactory = new (
+  input: DetectPiiEntitiesInput,
+) => unknown;
+
+export class AWSComprehendSdkAdapter implements ComprehendPiiClient {
+  constructor(
+    private readonly client: AwsSdkComprehendClient,
+    private readonly DetectPiiEntitiesCommand: DetectPiiEntitiesCommandFactory,
+  ) {}
+
+  async detectPiiEntities(
+    input: DetectPiiEntitiesInput,
+  ): Promise<DetectPiiEntitiesOutput> {
+    return await this.client.send(new this.DetectPiiEntitiesCommand(input));
+  }
+}
+
+export class AWSComprehendRedactor {
+  private readonly client: ComprehendPiiClient;
+  private readonly languageCode: string;
+  private readonly minScore: number;
+  private readonly entityTypes?: Set<string>;
+  private readonly replacement: PiiReplacement;
+
+  constructor(options: AWSComprehendRedactorOptions) {
+    this.client = options.client;
+    this.languageCode = options.languageCode || "en";
+    this.minScore = options.minScore ?? 0;
+    this.entityTypes = options.entityTypes
+      ? new Set(options.entityTypes)
+      : undefined;
+    this.replacement =
+      options.replacement || ((entity) => `[${entity.Type || "PII"}]`);
+  }
+
+  async detect(
+    text: string,
+    options: RedactOptions = {},
+  ): Promise<ComprehendPiiEntity[]> {
+    if (!text) {
+      return [];
+    }
+
+    const response = await this.client.detectPiiEntities({
+      Text: text,
+      LanguageCode: options.languageCode || this.languageCode,
+    });
+
+    return (response.Entities || [])
+      .filter((entity) => this.isEntityEnabled(entity, options))
+      .sort((left, right) => left.BeginOffset - right.BeginOffset);
+  }
+
+  async redact(
+    text: string,
+    options: RedactOptions = {},
+  ): Promise<RedactionResult> {
+    const entities = await this.detect(text, options);
+    const replacement = options.replacement || this.replacement;
+
+    const redacted = entities
+      .slice()
+      .sort((left, right) => right.BeginOffset - left.BeginOffset)
+      .reduce((currentText, entity) => {
+        const entityText = text.slice(entity.BeginOffset, entity.EndOffset);
+        const value =
+          typeof replacement === "function"
+            ? replacement(entity, entityText)
+            : replacement;
+
+        return (
+          currentText.slice(0, entity.BeginOffset) +
+          value +
+          currentText.slice(entity.EndOffset)
+        );
+      }, text);
+
+    return {
+      text: redacted,
+      entities,
+    };
+  }
+
+  async redactChatOptions<TOptions extends RedactableChatOptions>(
+    chatOptions: TOptions,
+    options: RedactOptions = {},
+  ): Promise<TOptions> {
+    const redactedOptions: RedactableChatOptions = { ...chatOptions };
+
+    if (typeof chatOptions.prompt === "string") {
+      redactedOptions.prompt = (
+        await this.redact(chatOptions.prompt, options)
+      ).text;
+    }
+
+    if (Array.isArray(chatOptions.messages)) {
+      redactedOptions.messages = await Promise.all(
+        chatOptions.messages.map(async (message) => {
+          if (typeof message.content !== "string") {
+            return { ...message };
+          }
+
+          return {
+            ...message,
+            content: (await this.redact(message.content, options)).text,
+          };
+        }),
+      );
+    }
+
+    return redactedOptions as TOptions;
+  }
+
+  async chainChat<TOptions extends RedactableChatOptions, TResult>(
+    endpoint: ChatEndpoint<TOptions, TResult>,
+    chatOptions: TOptions,
+    options: RedactOptions = {},
+  ): Promise<TResult> {
+    return endpoint.chat(await this.redactChatOptions(chatOptions, options));
+  }
+
+  operator<TOptions extends RedactableChatOptions>(
+    options: RedactOptions = {},
+  ): (chatOptions: TOptions) => Promise<TOptions> {
+    return async (chatOptions) => this.redactChatOptions(chatOptions, options);
+  }
+
+  private isEntityEnabled(
+    entity: ComprehendPiiEntity,
+    options: RedactOptions,
+  ): boolean {
+    const minScore = options.minScore ?? this.minScore;
+    const entityTypes = options.entityTypes
+      ? new Set(options.entityTypes)
+      : this.entityTypes;
+
+    if ((entity.Score ?? 1) < minScore) {
+      return false;
+    }
+
+    if (entity.BeginOffset < 0 || entity.EndOffset <= entity.BeginOffset) {
+      return false;
+    }
+
+    if (!entityTypes) {
+      return true;
+    }
+
+    if (!entity.Type) {
+      return false;
+    }
+
+    return entityTypes.has(entity.Type);
+  }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/aws-comprehend-redactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend/aws-comprehend-redactor.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  AWSComprehendRedactor,
+  AWSComprehendSdkAdapter,
+  ComprehendPiiClient,
+} from "../../lib/aws-comprehend/aws-comprehend-redactor";
+
+const createClient = (): ComprehendPiiClient => ({
+  detectPiiEntities: vi.fn(async ({ Text }) => {
+    const email = "a@example.test";
+    const phone = "+1-555-0100";
+
+    return {
+      Entities: [
+        {
+          Type: "EMAIL",
+          Score: 0.99,
+          BeginOffset: Text.indexOf(email),
+          EndOffset: Text.indexOf(email) + email.length,
+        },
+        {
+          Type: "PHONE",
+          Score: 0.94,
+          BeginOffset: Text.indexOf(phone),
+          EndOffset: Text.indexOf(phone) + phone.length,
+        },
+      ].filter((entity) => entity.BeginOffset >= 0),
+    };
+  }),
+});
+
+describe("AWSComprehendRedactor", () => {
+  test("redacts detected PII without shifting later offsets", async () => {
+    const redactor = new AWSComprehendRedactor({ client: createClient() });
+    const result = await redactor.redact(
+      "Contact Alice: a@example.test or +1-555-0100.",
+    );
+
+    expect(result.text).toBe("Contact Alice: [EMAIL] or [PHONE].");
+    expect(result.entities.map((entity) => entity.Type)).toEqual([
+      "EMAIL",
+      "PHONE",
+    ]);
+  });
+
+  test("filters entities by score and type", async () => {
+    const redactor = new AWSComprehendRedactor({
+      client: createClient(),
+      entityTypes: ["EMAIL"],
+      minScore: 0.98,
+    });
+
+    const result = await redactor.redact(
+      "Contact Alice: a@example.test or +1-555-0100.",
+    );
+
+    expect(result.text).toBe("Contact Alice: [EMAIL] or +1-555-0100.");
+    expect(result.entities).toHaveLength(1);
+  });
+
+  test("redacts prompt and message content before chaining to chat endpoints", async () => {
+    const redactor = new AWSComprehendRedactor({
+      client: createClient(),
+      replacement: "[REDACTED]",
+    });
+    const endpoint = {
+      chat: vi.fn(async (options) => options),
+    };
+
+    const response = await redactor.chainChat(endpoint, {
+      prompt: "Contact Alice: a@example.test or +1-555-0100.",
+      messages: [
+        {
+          role: "user",
+          content: "Contact Alice: a@example.test or +1-555-0100.",
+        },
+        {
+          role: "assistant",
+          content: undefined,
+        },
+      ],
+      temperature: 0,
+    });
+
+    expect(endpoint.chat).toHaveBeenCalledOnce();
+    expect(response.prompt).toBe("Contact Alice: [REDACTED] or [REDACTED].");
+    expect(response.messages?.[0].content).toBe(
+      "Contact Alice: [REDACTED] or [REDACTED].",
+    );
+    expect(response.temperature).toBe(0);
+  });
+
+  test("wraps an AWS SDK v3 client without adding a hard package dependency", async () => {
+    class DetectPiiEntitiesCommand {
+      constructor(public readonly input: unknown) {}
+    }
+
+    const sdkClient = {
+      send: vi.fn(async (command) => ({
+        Entities: [
+          {
+            Type: "NAME",
+            BeginOffset: 0,
+            EndOffset: 5,
+          },
+        ],
+        command,
+      })),
+    };
+
+    const adapter = new AWSComprehendSdkAdapter(
+      sdkClient,
+      DetectPiiEntitiesCommand,
+    );
+    const output = await adapter.detectPiiEntities({
+      Text: "Alice",
+      LanguageCode: "en",
+    });
+
+    expect(output.Entities?.[0].Type).toBe("NAME");
+    expect(sdkClient.send).toHaveBeenCalledWith(
+      expect.any(DetectPiiEntitiesCommand),
+    );
+  });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,14 @@
+# AWS Comprehend redaction example
+
+This example shows how to redact PII before sending a prompt to an endpoint-style
+chat client. It uses a mock Comprehend-compatible client so the example runs
+without AWS credentials.
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+Production callers can pass an AWS SDK v3 Comprehend client through
+`AWSComprehendSdkAdapter`.

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,4 @@
+{
+    languageCode: "en",
+    samplePrompt: "Please email Alice at alice@example.test or call +1-555-0100.",
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aws-comprehend-redaction",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,47 @@
+import {
+  AWSComprehendRedactor,
+  ComprehendPiiClient,
+} from "@arakoodev/edgechains.js/ai";
+
+const mockComprehendClient: ComprehendPiiClient = {
+  async detectPiiEntities({ Text }) {
+    return {
+      Entities: [
+        {
+          Type: "EMAIL",
+          Score: 0.99,
+          BeginOffset: Text.indexOf("alice@example.test"),
+          EndOffset:
+            Text.indexOf("alice@example.test") + "alice@example.test".length,
+        },
+        {
+          Type: "PHONE",
+          Score: 0.98,
+          BeginOffset: Text.indexOf("+1-555-0100"),
+          EndOffset: Text.indexOf("+1-555-0100") + "+1-555-0100".length,
+        },
+      ].filter((entity) => entity.BeginOffset >= 0),
+    };
+  },
+};
+
+const endpoint = {
+  async chat({ prompt }: { prompt: string }) {
+    return {
+      content: `Endpoint received: ${prompt}`,
+    };
+  },
+};
+
+const redactor = new AWSComprehendRedactor({
+  client: mockComprehendClient,
+  minScore: 0.9,
+});
+
+const prompt = "Please email Alice at alice@example.test or call +1-555-0100.";
+const redactedPrompt = await redactor.redact(prompt);
+const response = await redactor.chainChat(endpoint, { prompt });
+
+console.log("Original prompt:", prompt);
+console.log("Redacted prompt:", redactedPrompt.text);
+console.log("Endpoint response:", response.content);

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
/claim #290

## Summary

- add an `AWSComprehendRedactor` utility with an injectable Comprehend-compatible client
- add an `AWSComprehendSdkAdapter` for callers using the AWS SDK v3 client/command pair
- support direct text redaction, prompt/message redaction, endpoint-style `chat()` chaining, score/type filters, and custom replacements
- export the utility and public types from the AI package
- add mocked Vitest coverage and a runnable `aws-comprehend-redaction` example

## Validation

- `npx vitest run src/ai/src/tests/aws-comprehend/aws-comprehend-redactor.test.ts`
- `npx tsc -b`
- `npx prettier --check src/ai/src/lib/aws-comprehend/aws-comprehend-redactor.ts src/ai/src/tests/aws-comprehend/aws-comprehend-redactor.test.ts src/ai/src/index.ts`
- `cd JS/edgechains/examples/aws-comprehend-redaction && npm install --package-lock=false --ignore-scripts --no-audit --no-fund --progress=false --loglevel=warn && npm run build && npm start`