### PR TITLE
Fix Gemini generation config request shape

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,11 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
+export type {
+  GeminiAIChatOptions,
+  GeminiAIContent,
+  GeminiAIGenerationConfig,
+  GeminiAIResponse,
+} from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
@@ -1,97 +1,141 @@
 import axios from "axios";
 import { retry } from "@lifeomic/attempt";
-const url = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
+const baseUrl = "https://generativelanguage.googleapis.com/v1beta/models";
 
 interface GeminiAIConstructionOptions {
-    apiKey?: string;
+  apiKey?: string;
 }
 
-type SafetyRating = {
-    category:
-        | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
-        | "HARM_CATEGORY_HATE_SPEECH"
-        | "HARM_CATEGORY_HARASSMENT"
-        | "HARM_CATEGORY_DANGEROUS_CONTENT";
-    probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
+export type GeminiAISafetyRating = {
+  category:
+    | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
+    | "HARM_CATEGORY_HATE_SPEECH"
+    | "HARM_CATEGORY_HARASSMENT"
+    | "HARM_CATEGORY_DANGEROUS_CONTENT";
+  probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
 };
 
-type ContentPart = {
-    text: string;
+export type GeminiAIContentPart = {
+  text: string;
 };
 
-type Content = {
-    parts: ContentPart[];
-    role: string;
+export type GeminiAIContent = {
+  parts: GeminiAIContentPart[];
+  role?: "user" | "model";
 };
 
-type Candidate = {
-    content: Content;
-    finishReason: string;
-    index: number;
-    safetyRatings: SafetyRating[];
+export type GeminiAICandidate = {
+  content: GeminiAIContent;
+  finishReason: string;
+  index: number;
+  safetyRatings: GeminiAISafetyRating[];
 };
 
-type UsageMetadata = {
-    promptTokenCount: number;
-    candidatesTokenCount: number;
-    totalTokenCount: number;
+export type GeminiAIUsageMetadata = {
+  promptTokenCount: number;
+  candidatesTokenCount: number;
+  totalTokenCount: number;
 };
 
-type Response = {
-    candidates: Candidate[];
-    usageMetadata: UsageMetadata;
+export type GeminiAIResponse = {
+  candidates: GeminiAICandidate[];
+  usageMetadata: GeminiAIUsageMetadata;
 };
 
 type responseMimeType = "text/plain" | "application/json";
 
-interface GeminiAIChatOptions {
-    model?: string;
-    max_output_tokens?: number;
-    temperature?: number;
-    prompt: string;
-    max_retry?: number;
-    responseType?: responseMimeType;
-    delay?: number;
+export interface GeminiAIGenerationConfig {
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseMimeType?: responseMimeType;
+  topP?: number;
+  topK?: number;
+  candidateCount?: number;
+}
+
+export interface GeminiAIChatOptions {
+  model?: string;
+  max_output_tokens?: number;
+  maxOutputTokens?: number;
+  temperature?: number;
+  prompt?: string;
+  contents?: GeminiAIContent[];
+  max_retry?: number;
+  responseType?: responseMimeType;
+  topP?: number;
+  topK?: number;
+  candidateCount?: number;
+  delay?: number;
 }
 
 export class GeminiAI {
-    apiKey: string;
-    constructor(options: GeminiAIConstructionOptions) {
-        this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
+  apiKey: string;
+  constructor(options: GeminiAIConstructionOptions) {
+    this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
+  }
+
+  async chat(chatOptions: GeminiAIChatOptions): Promise<GeminiAIResponse> {
+    const data = {
+      contents: this.resolveContents(chatOptions),
+      generationConfig: this.removeUndefined({
+        temperature: chatOptions.temperature ?? 0.7,
+        responseMimeType: chatOptions.responseType || "text/plain",
+        maxOutputTokens:
+          chatOptions.maxOutputTokens || chatOptions.max_output_tokens || 1024,
+        topP: chatOptions.topP,
+        topK: chatOptions.topK,
+        candidateCount: chatOptions.candidateCount,
+      }),
+    };
+
+    const config = {
+      method: "post",
+      maxBodyLength: Infinity,
+      url: `${baseUrl}/${chatOptions.model || "gemini-2.0-flash"}:generateContent`,
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": this.apiKey,
+      },
+      data,
+    };
+
+    return await retry(
+      async () => {
+        return (await axios.request(config)).data;
+      },
+      {
+        maxAttempts: chatOptions.max_retry || 3,
+        delay: chatOptions.delay || 200,
+      },
+    );
+  }
+
+  private resolveContents(chatOptions: GeminiAIChatOptions): GeminiAIContent[] {
+    if (chatOptions.contents?.length) {
+      return chatOptions.contents;
     }
 
-    async chat(chatOptions: GeminiAIChatOptions): Promise<Response> {
-        let data = JSON.stringify({
-            contents: [
-                {
-                    role: "user",
-                    parts: [
-                        {
-                            text: chatOptions.prompt,
-                        },
-                    ],
-                },
-            ],
-        });
-
-        let config = {
-            method: "post",
-            maxBodyLength: Infinity,
-            url,
-            headers: {
-                "Content-Type": "application/json",
-                "x-goog-api-key": this.apiKey,
-            },
-            temperature: chatOptions.temperature || "0.7",
-            responseMimeType: chatOptions.responseType || "text/plain",
-            max_output_tokens: chatOptions.max_output_tokens || 1024,
-            data: data,
-        };
-        return await retry(
-            async () => {
-                return (await axios.request(config)).data;
-            },
-            { maxAttempts: chatOptions.max_retry || 3, delay: chatOptions.delay || 200 }
-        );
+    if (!chatOptions.prompt) {
+      throw new Error("GeminiAI chat requires either prompt or contents.");
     }
+
+    return [
+      {
+        role: "user",
+        parts: [
+          {
+            text: chatOptions.prompt,
+          },
+        ],
+      },
+    ];
+  }
+
+  private removeUndefined<T extends Record<string, any>>(value: T): Partial<T> {
+    return Object.fromEntries(
+      Object.entries(value).filter(
+        ([, entryValue]) => entryValue !== undefined,
+      ),
+    ) as Partial<T>;
+  }
 }

--- a/JS/edgechains/arakoodev/src/ai/src/testcases/palm2/basic.jsonnet
+++ b/JS/edgechains/arakoodev/src/ai/src/testcases/palm2/basic.jsonnet
@@ -1,0 +1,17 @@
+local promptTemplate = |||
+  You are a concise assistant.
+  Answer the following question in one sentence:
+  {question}
+|||;
+
+local question = std.extVar("question");
+
+{
+  model: "gemini-2.0-flash",
+  prompt: std.strReplace(promptTemplate, "{question}", question),
+  generationConfig: {
+    temperature: 0.2,
+    maxOutputTokens: 128,
+    responseMimeType: "text/plain",
+  },
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
@@ -1,0 +1,95 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GeminiAI } from "../../lib/gemini/gemini.js";
+
+describe("GeminiAI", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends Gemini generation settings in the request body", async () => {
+    const response = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "Hello from Gemini" }],
+          },
+          finishReason: "STOP",
+          index: 0,
+          safetyRatings: [],
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 2,
+        candidatesTokenCount: 3,
+        totalTokenCount: 5,
+      },
+    };
+    const request = vi
+      .spyOn(axios, "request")
+      .mockResolvedValueOnce({ data: response });
+    const gemini = new GeminiAI({ apiKey: "test-key" });
+
+    const result = await gemini.chat({
+      prompt: "Say hello",
+      model: "gemini-2.0-flash",
+      temperature: 0.2,
+      max_output_tokens: 128,
+      responseType: "application/json",
+      topP: 0.9,
+      topK: 40,
+    });
+
+    expect(result).toEqual(response);
+    expect(request).toHaveBeenCalledWith({
+      method: "post",
+      maxBodyLength: Infinity,
+      url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": "test-key",
+      },
+      data: {
+        contents: [
+          {
+            role: "user",
+            parts: [{ text: "Say hello" }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.2,
+          responseMimeType: "application/json",
+          maxOutputTokens: 128,
+          topP: 0.9,
+          topK: 40,
+        },
+      },
+    });
+  });
+
+  it("uses supplied contents for chat-style Gemini prompts", async () => {
+    const request = vi.spyOn(axios, "request").mockResolvedValueOnce({
+      data: { candidates: [], usageMetadata: {} },
+    });
+    const gemini = new GeminiAI({ apiKey: "test-key" });
+
+    await gemini.chat({
+      contents: [
+        { role: "user", parts: [{ text: "Question" }] },
+        { role: "model", parts: [{ text: "Prior answer" }] },
+        { role: "user", parts: [{ text: "Follow up" }] },
+      ],
+      maxOutputTokens: 64,
+    });
+
+    expect(request.mock.calls[0][0].data.contents).toEqual([
+      { role: "user", parts: [{ text: "Question" }] },
+      { role: "model", parts: [{ text: "Prior answer" }] },
+      { role: "user", parts: [{ text: "Follow up" }] },
+    ]);
+    expect(request.mock.calls[0][0].data.generationConfig.maxOutputTokens).toBe(
+      64,
+    );
+  });
+});

--- a/JS/edgechains/examples/palm2-chat/.gitignore
+++ b/JS/edgechains/examples/palm2-chat/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,20 @@
+local promptTemplate = |||
+  You are a concise assistant.
+  Answer the following question in one sentence:
+  {question}
+|||;
+
+local key = std.extVar("gemini_api_key");
+local question = std.extVar("question");
+local prompt = std.strReplace(promptTemplate, "{question}", question + "\n");
+
+local main() =
+  arakoo.native("geminiCall")({
+    prompt: prompt,
+    geminiApiKey: key,
+    model: "gemini-2.0-flash",
+    maxOutputTokens: 128,
+    temperature: 0.2,
+  });
+
+main()

--- a/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
@@ -1,0 +1,5 @@
+local GEMINI_API_KEY = "AIza-***";
+
+{
+  "gemini_api_key": GEMINI_API_KEY,
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "palm2-chat",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsc && node ./dist/index.js"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "@arakoodev/jsonnet": "^0.24.0",
+    "file-uri-to-path": "^2.0.0",
+    "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "typescript": "^5.7.0-dev.20241007"
+  }
+}

--- a/JS/edgechains/examples/palm2-chat/readme.md
+++ b/JS/edgechains/examples/palm2-chat/readme.md
@@ -1,0 +1,20 @@
+# Palm2/Gemini Chat Example
+
+## Configuration
+
+Add a Gemini API key in `jsonnet/secrets.jsonnet`.
+
+## Usage
+
+```bash
+npm install
+npm run start
+```
+
+Send a request:
+
+```bash
+curl -X POST http://localhost:3000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"question":"What is EdgeChains?"}'
+```

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,31 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const geminiCall = createSyncRPC(
+  path.join(__dirname, "./lib/generateResponse.cjs"),
+);
+
+app.post("/chat", async (c: any) => {
+  const { question } = await c.req.json();
+  const key = JSON.parse(
+    jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet")),
+  ).gemini_api_key;
+
+  jsonnet.extString("gemini_api_key", key);
+  jsonnet.extString("question", question || "");
+  jsonnet.javascriptCallback("geminiCall", geminiCall);
+
+  const response = jsonnet.evaluateFile(
+    path.join(__dirname, "../jsonnet/main.jsonnet"),
+  );
+  return c.json(JSON.parse(response));
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
+++ b/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
@@ -1,0 +1,27 @@
+const { GeminiAI } = require("@arakoodev/edgechains.js/ai");
+
+async function geminiCall({
+  prompt,
+  geminiApiKey,
+  model,
+  temperature,
+  maxOutputTokens,
+}: {
+  prompt: string;
+  geminiApiKey: string;
+  model: string;
+  temperature: number;
+  maxOutputTokens: number;
+}) {
+  const gemini = new GeminiAI({ apiKey: geminiApiKey });
+  const response = await gemini.chat({
+    prompt,
+    model,
+    temperature,
+    maxOutputTokens,
+  });
+
+  return JSON.stringify(response);
+}
+
+module.exports = geminiCall;

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["./**/*.test.ts", "vitest.config.ts", "./jsonnet/**/*"]
+}


### PR DESCRIPTION
/claim #279

Summary:
- Fixes the existing Gemini/PaLM-compatible client so generation settings are sent inside the Google `generationConfig` request body.
- Exports typed Gemini request/response interfaces from the AI package entrypoint.
- Adds a `testcases/palm2` Jsonnet config.
- Adds mocked Vitest coverage for Gemini request shape and chat-style contents.
- Adds a small Jsonnet-driven `palm2-chat` example.

Verification:
- npm run build
- npx vitest run src/ai/src/tests/palm2/gemini.test.ts
- npx prettier --check src/ai/src/index.ts src/ai/src/lib/gemini/gemini.ts src/ai/src/tests/palm2/gemini.test.ts ../examples/palm2-chat/package.json ../examples/palm2-chat/readme.md ../examples/palm2-chat/src/index.ts ../examples/palm2-chat/src/lib/generateResponse.cts ../examples/palm2-chat/tsconfig.json
- npx tsc --noEmit in JS/edgechains/examples/palm2-chat after package build

Notes:
- Keeps the implementation in the existing GeminiAI class while making the request body match the Generative Language API.
- Prompts for the example live in Jsonnet rather than being hardcoded in TypeScript.