### PR TITLE
Add Qdrant vector database support

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,185 @@
+type PointId = string | number;
+
+interface QdrantClientOptions {
+    url?: string;
+    apiKey?: string;
+}
+
+interface UpsertPoint {
+    id: PointId;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+interface UpsertPointsArgs {
+    collectionName: string;
+    points: UpsertPoint[];
+    wait?: boolean;
+}
+
+interface SearchPointsArgs {
+    collectionName: string;
+    vector: number[] | Record<string, number[]>;
+    limit?: number;
+    offset?: number;
+    using?: string;
+    filter?: Record<string, any>;
+    params?: Record<string, any>;
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[] | Record<string, any>;
+    scoreThreshold?: number;
+}
+
+interface GetPointByIdArgs {
+    collectionName: string;
+    id: PointId;
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[] | Record<string, any>;
+}
+
+interface DeleteByIdArgs {
+    collectionName: string;
+    ids: PointId[];
+    wait?: boolean;
+}
+
+interface SetPayloadArgs {
+    collectionName: string;
+    payload: Record<string, any>;
+    points: PointId[];
+    wait?: boolean;
+}
+
+export class Qdrant {
+    url: string;
+    apiKey?: string;
+
+    constructor({ url, apiKey }: QdrantClientOptions = {}) {
+        this.url = (url || process.env.QDRANT_URL || "").replace(/\/+$/, "");
+        this.apiKey = apiKey || process.env.QDRANT_API_KEY;
+
+        if (!this.url) {
+            throw new Error("Qdrant URL is required. Pass url or set QDRANT_URL.");
+        }
+    }
+
+    async upsertPoints({ collectionName, points, wait = true }: UpsertPointsArgs): Promise<any> {
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points?wait=${wait}`,
+            {
+                method: "PUT",
+                body: { points },
+            }
+        );
+    }
+
+    async searchPoints({
+        collectionName,
+        vector,
+        limit = 10,
+        offset,
+        using,
+        filter,
+        params,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: SearchPointsArgs): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points/query`, {
+            method: "POST",
+            body: {
+                query: vector,
+                limit,
+                offset,
+                using,
+                filter,
+                params,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+            },
+        });
+    }
+
+    async getPointById({
+        collectionName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: GetPointByIdArgs): Promise<any> {
+        const query = new URLSearchParams({
+            with_payload: this.encodeQueryValue(withPayload),
+            with_vector: this.encodeQueryValue(withVector),
+        });
+
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points/${encodeURIComponent(
+                String(id)
+            )}?${query.toString()}`,
+            { method: "GET" }
+        );
+    }
+
+    async deleteById({ collectionName, ids, wait = true }: DeleteByIdArgs): Promise<any> {
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points/delete?wait=${wait}`,
+            {
+                method: "POST",
+                body: {
+                    points: ids,
+                },
+            }
+        );
+    }
+
+    async setPayload({ collectionName, payload, points, wait = true }: SetPayloadArgs): Promise<any> {
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points/payload?wait=${wait}`,
+            {
+                method: "POST",
+                body: {
+                    payload,
+                    points,
+                },
+            }
+        );
+    }
+
+    private async request(
+        path: string,
+        options: { method: string; body?: Record<string, any> }
+    ): Promise<any> {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+
+        if (this.apiKey) {
+            headers["api-key"] = this.apiKey;
+        }
+
+        const response = await fetch(`${this.url}${path}`, {
+            method: options.method,
+            headers,
+            body: options.body ? JSON.stringify(this.removeUndefined(options.body)) : undefined,
+        });
+
+        const responseText = await response.text();
+        const data = responseText ? JSON.parse(responseText) : null;
+
+        if (!response.ok) {
+            throw new Error(
+                `Qdrant request failed with status ${response.status}: ${JSON.stringify(data)}`
+            );
+        }
+
+        return data?.result ?? data;
+    }
+
+    private removeUndefined(input: Record<string, any>): Record<string, any> {
+        return Object.fromEntries(Object.entries(input).filter(([, value]) => value !== undefined));
+    }
+
+    private encodeQueryValue(value: boolean | string[] | Record<string, any>): string {
+        return typeof value === "boolean" ? String(value) : JSON.stringify(value);
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,96 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ result: { status: "ok" } }),
+    });
+});
+
+describe("Qdrant", () => {
+    it("should upsert vector points using the Qdrant HTTP API", async () => {
+        const qdrant = new Qdrant({
+            url: "https://example-qdrant.io",
+            apiKey: "mock-api-key",
+        });
+
+        const result = await qdrant.upsertPoints({
+            collectionName: "documents",
+            points: [
+                {
+                    id: "doc-1",
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { raw_text: "hello" },
+                },
+            ],
+        });
+
+        expect(result).toEqual({ status: "ok" });
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://example-qdrant.io/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                headers: expect.objectContaining({
+                    "Content-Type": "application/json",
+                    "api-key": "mock-api-key",
+                }),
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: "doc-1",
+                            vector: [0.1, 0.2, 0.3],
+                            payload: { raw_text: "hello" },
+                        },
+                    ],
+                }),
+            })
+        );
+    });
+
+    it("should search vector points using the Qdrant HTTP API", async () => {
+        const qdrant = new Qdrant({ url: "https://example-qdrant.io" });
+
+        await qdrant.searchPoints({
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://example-qdrant.io/collections/documents/points/query",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    query: [0.1, 0.2, 0.3],
+                    limit: 3,
+                    filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            })
+        );
+    });
+
+    it("should delete vector points by id", async () => {
+        const qdrant = new Qdrant({ url: "https://example-qdrant.io/" });
+
+        await qdrant.deleteById({
+            collectionName: "documents",
+            ids: ["doc-1", "doc-2"],
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "https://example-qdrant.io/collections/documents/points/delete?wait=true",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ points: ["doc-1", "doc-2"] }),
+            })
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- Add a Qdrant vector database client to `@arakoodev/edgechains.js/vector-db`
- Use Qdrant's HTTP API directly without adding a Qdrant SDK dependency
- Support point upsert, vector query, point retrieval, point deletion, and payload update
- Export `Qdrant` from the vector-db package
- Add mocked tests for upsert, query, and delete request behavior

## Verification
- `./node_modules/.bin/tsc -b`
- `./node_modules/.bin/jest qdrant.test.ts --runInBand`

## Notes
- Uses Qdrant's current `/collections/:collection_name/points/query` endpoint for vector search.
- `npm run build` currently uses `rm -rf`, which does not run in Windows PowerShell before TypeScript starts; direct `tsc -b` passes.

Closes #273