### PR TITLE
Add Qdrant vector database support

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,350 @@
+import axios, { AxiosInstance } from "axios";
+import retry from "retry";
+
+type QdrantPointId = number | string;
+type QdrantSparseVector = {
+    indices: number[];
+    values: number[];
+};
+type QdrantVector = number[] | Record<string, number[] | QdrantSparseVector>;
+type QdrantPayload = Record<string, any>;
+type QdrantFilter = Record<string, any>;
+type QdrantOrdering = "weak" | "medium" | "strong";
+
+interface QdrantPoint {
+    id: QdrantPointId;
+    vector: QdrantVector;
+    payload?: QdrantPayload;
+}
+
+interface QdrantRequestArgs {
+    client: AxiosInstance;
+    collectionName: string;
+    maxRetries?: number;
+}
+
+interface QdrantWriteOptions {
+    wait?: boolean;
+    ordering?: QdrantOrdering;
+    timeout?: number;
+}
+
+interface InsertVectorDataArgs extends QdrantRequestArgs, QdrantWriteOptions {
+    points?: QdrantPoint[];
+    id?: QdrantPointId;
+    vector?: QdrantVector;
+    payload?: QdrantPayload;
+}
+
+interface GetDataFromQueryArgs extends QdrantRequestArgs {
+    query?: QdrantPointId | QdrantVector | Record<string, any>;
+    vector?: QdrantVector;
+    filter?: QdrantFilter;
+    limit?: number;
+    offset?: number | string;
+    using?: string;
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+    params?: Record<string, any>;
+    prefetch?: Record<string, any> | Array<Record<string, any>>;
+}
+
+interface GetDataArgs extends QdrantRequestArgs {
+    filter?: QdrantFilter;
+    limit?: number;
+    offset?: number | string;
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[];
+    orderBy?: string | Record<string, any>;
+}
+
+interface GetDataByIdArgs extends QdrantRequestArgs {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    withPayload?: boolean | string[] | Record<string, any>;
+    withVector?: boolean | string[];
+}
+
+interface UpdateByIdArgs extends QdrantRequestArgs, QdrantWriteOptions {
+    id: QdrantPointId;
+    vector: QdrantVector;
+    payload?: QdrantPayload;
+}
+
+interface DeleteByIdArgs extends QdrantRequestArgs, QdrantWriteOptions {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    filter?: QdrantFilter;
+}
+
+interface CreateCollectionArgs extends QdrantRequestArgs {
+    vectors: Record<string, any> | { size: number; distance: string };
+    replicationFactor?: number;
+    writeConsistencyFactor?: number;
+    shardNumber?: number;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "http://localhost:6333";
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY || "";
+    }
+
+    createClient(): AxiosInstance {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        return axios.create({
+            baseURL: this.QDRANT_URL.replace(/\/+$/, ""),
+            headers,
+        });
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectors,
+        replicationFactor,
+        writeConsistencyFactor,
+        shardNumber,
+        maxRetries,
+    }: CreateCollectionArgs): Promise<any> {
+        const body = this.removeUndefined({
+            vectors,
+            replication_factor: replicationFactor,
+            write_consistency_factor: writeConsistencyFactor,
+            shard_number: shardNumber,
+        });
+
+        return this.withRetry(async () => {
+            const response = await client.put(this.collectionPath(collectionName), body);
+            return response.data;
+        }, maxRetries);
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        points,
+        id,
+        vector,
+        payload,
+        wait = true,
+        ordering,
+        timeout,
+        maxRetries,
+    }: InsertVectorDataArgs): Promise<any> {
+        const pointsToInsert = points || this.pointFromArgs({ id, vector, payload });
+
+        return this.withRetry(async () => {
+            const response = await client.put(
+                this.pointsPath(collectionName),
+                { points: pointsToInsert },
+                { params: this.removeUndefined({ wait, ordering, timeout }) }
+            );
+            return response.data;
+        }, maxRetries);
+    }
+
+    async getDataFromQuery({
+        client,
+        collectionName,
+        query,
+        vector,
+        filter,
+        limit = 10,
+        offset,
+        using,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+        params,
+        prefetch,
+        maxRetries,
+    }: GetDataFromQueryArgs): Promise<any> {
+        const queryValue = query !== undefined ? query : vector;
+        if (queryValue === undefined) {
+            throw new Error("Qdrant query requires either query or vector.");
+        }
+
+        const body = this.removeUndefined({
+            query: queryValue,
+            filter,
+            limit,
+            offset,
+            using,
+            with_payload: withPayload,
+            with_vector: withVector,
+            score_threshold: scoreThreshold,
+            params,
+            prefetch,
+        });
+
+        return this.withRetry(async () => {
+            const response = await client.post(`${this.pointsPath(collectionName)}/query`, body);
+            return response.data;
+        }, maxRetries);
+    }
+
+    async getData({
+        client,
+        collectionName,
+        filter,
+        limit = 10,
+        offset,
+        withPayload = true,
+        withVector = false,
+        orderBy,
+        maxRetries,
+    }: GetDataArgs): Promise<any> {
+        const body = this.removeUndefined({
+            filter,
+            limit,
+            offset,
+            with_payload: withPayload,
+            with_vector: withVector,
+            order_by: orderBy,
+        });
+
+        return this.withRetry(async () => {
+            const response = await client.post(`${this.pointsPath(collectionName)}/scroll`, body);
+            return response.data;
+        }, maxRetries);
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        id,
+        ids,
+        withPayload = true,
+        withVector = false,
+        maxRetries,
+    }: GetDataByIdArgs): Promise<any> {
+        const pointIds = ids || (id !== undefined ? [id] : undefined);
+        if (!pointIds?.length) {
+            throw new Error("Qdrant getDataById requires id or ids.");
+        }
+
+        const body = this.removeUndefined({
+            ids: pointIds,
+            with_payload: withPayload,
+            with_vector: withVector,
+        });
+
+        return this.withRetry(async () => {
+            const response = await client.post(this.pointsPath(collectionName), body);
+            return response.data;
+        }, maxRetries);
+    }
+
+    async updateById({
+        client,
+        collectionName,
+        id,
+        vector,
+        payload,
+        wait = true,
+        ordering,
+        timeout,
+        maxRetries,
+    }: UpdateByIdArgs): Promise<any> {
+        return this.insertVectorData({
+            client,
+            collectionName,
+            points: [{ id, vector, payload }],
+            wait,
+            ordering,
+            timeout,
+            maxRetries,
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        id,
+        ids,
+        filter,
+        wait = true,
+        ordering,
+        timeout,
+        maxRetries,
+    }: DeleteByIdArgs): Promise<any> {
+        const points = ids || (id !== undefined ? [id] : undefined);
+        if (!points?.length && !filter) {
+            throw new Error("Qdrant deleteById requires id, ids, or filter.");
+        }
+
+        const body = filter ? { filter } : { points };
+
+        return this.withRetry(async () => {
+            const response = await client.post(`${this.pointsPath(collectionName)}/delete`, body, {
+                params: this.removeUndefined({ wait, ordering, timeout }),
+            });
+            return response.data;
+        }, maxRetries);
+    }
+
+    private pointFromArgs({
+        id,
+        vector,
+        payload,
+    }: {
+        id?: QdrantPointId;
+        vector?: QdrantVector;
+        payload?: QdrantPayload;
+    }): QdrantPoint[] {
+        if (id === undefined || !vector) {
+            throw new Error("Qdrant insertVectorData requires points or id and vector.");
+        }
+
+        return [{ id, vector, payload }];
+    }
+
+    private pointsPath(collectionName: string): string {
+        return `${this.collectionPath(collectionName)}/points`;
+    }
+
+    private collectionPath(collectionName: string): string {
+        return `/collections/${encodeURIComponent(collectionName)}`;
+    }
+
+    private removeUndefined<T extends Record<string, any>>(value: T): Partial<T> {
+        return Object.fromEntries(
+            Object.entries(value).filter(([, item]) => item !== undefined)
+        ) as Partial<T>;
+    }
+
+    private withRetry<T>(request: () => Promise<T>, maxRetries = 5): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: maxRetries,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    resolve(await request());
+                } catch (error: any) {
+                    if (operation.retry(error)) {
+                        return;
+                    }
+                    reject(operation.mainError() || error);
+                }
+            });
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -3,8 +3,8 @@ import retry from "retry";
 
 type QdrantPointId = number | string;
 type QdrantSparseVector = {
-    indices: number[];
-    values: number[];
+  indices: number[];
+  values: number[];
 };
 type QdrantVector = number[] | Record<string, number[] | QdrantSparseVector>;
 type QdrantPayload = Record<string, any>;
@@ -12,339 +12,356 @@ type QdrantFilter = Record<string, any>;
 type QdrantOrdering = "weak" | "medium" | "strong";
 
 interface QdrantPoint {
-    id: QdrantPointId;
-    vector: QdrantVector;
-    payload?: QdrantPayload;
+  id: QdrantPointId;
+  vector: QdrantVector;
+  payload?: QdrantPayload;
 }
 
 interface QdrantRequestArgs {
-    client: AxiosInstance;
-    collectionName: string;
-    maxRetries?: number;
+  client: AxiosInstance;
+  collectionName: string;
+  maxRetries?: number;
 }
 
 interface QdrantWriteOptions {
-    wait?: boolean;
-    ordering?: QdrantOrdering;
-    timeout?: number;
+  wait?: boolean;
+  ordering?: QdrantOrdering;
+  timeout?: number;
 }
 
 interface InsertVectorDataArgs extends QdrantRequestArgs, QdrantWriteOptions {
-    points?: QdrantPoint[];
-    id?: QdrantPointId;
-    vector?: QdrantVector;
-    payload?: QdrantPayload;
+  points?: QdrantPoint[];
+  id?: QdrantPointId;
+  vector?: QdrantVector;
+  payload?: QdrantPayload;
 }
 
 interface GetDataFromQueryArgs extends QdrantRequestArgs {
-    query?: QdrantPointId | QdrantVector | Record<string, any>;
-    vector?: QdrantVector;
-    filter?: QdrantFilter;
-    limit?: number;
-    offset?: number | string;
-    using?: string;
-    withPayload?: boolean | string[] | Record<string, any>;
-    withVector?: boolean | string[];
-    scoreThreshold?: number;
-    params?: Record<string, any>;
-    prefetch?: Record<string, any> | Array<Record<string, any>>;
+  query?: QdrantPointId | QdrantVector | Record<string, any>;
+  vector?: QdrantVector;
+  filter?: QdrantFilter;
+  limit?: number;
+  offset?: number | string;
+  using?: string;
+  withPayload?: boolean | string[] | Record<string, any>;
+  withVector?: boolean | string[];
+  scoreThreshold?: number;
+  params?: Record<string, any>;
+  prefetch?: Record<string, any> | Array<Record<string, any>>;
 }
 
 interface GetDataArgs extends QdrantRequestArgs {
-    filter?: QdrantFilter;
-    limit?: number;
-    offset?: number | string;
-    withPayload?: boolean | string[] | Record<string, any>;
-    withVector?: boolean | string[];
-    orderBy?: string | Record<string, any>;
+  filter?: QdrantFilter;
+  limit?: number;
+  offset?: number | string;
+  withPayload?: boolean | string[] | Record<string, any>;
+  withVector?: boolean | string[];
+  orderBy?: string | Record<string, any>;
 }
 
 interface GetDataByIdArgs extends QdrantRequestArgs {
-    id?: QdrantPointId;
-    ids?: QdrantPointId[];
-    withPayload?: boolean | string[] | Record<string, any>;
-    withVector?: boolean | string[];
+  id?: QdrantPointId;
+  ids?: QdrantPointId[];
+  withPayload?: boolean | string[] | Record<string, any>;
+  withVector?: boolean | string[];
 }
 
 interface UpdateByIdArgs extends QdrantRequestArgs, QdrantWriteOptions {
-    id: QdrantPointId;
-    vector: QdrantVector;
-    payload?: QdrantPayload;
+  id: QdrantPointId;
+  vector: QdrantVector;
+  payload?: QdrantPayload;
 }
 
 interface DeleteByIdArgs extends QdrantRequestArgs, QdrantWriteOptions {
-    id?: QdrantPointId;
-    ids?: QdrantPointId[];
-    filter?: QdrantFilter;
+  id?: QdrantPointId;
+  ids?: QdrantPointId[];
+  filter?: QdrantFilter;
 }
 
 interface CreateCollectionArgs extends QdrantRequestArgs {
-    vectors: Record<string, any> | { size: number; distance: string };
-    replicationFactor?: number;
-    writeConsistencyFactor?: number;
-    shardNumber?: number;
+  vectors: Record<string, any> | { size: number; distance: string };
+  replicationFactor?: number;
+  writeConsistencyFactor?: number;
+  shardNumber?: number;
 }
 
 export class Qdrant {
-    QDRANT_URL: string;
-    QDRANT_API_KEY: string;
+  QDRANT_URL: string;
+  QDRANT_API_KEY: string;
 
-    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
-        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "http://localhost:6333";
-        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY || "";
+  constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+    this.QDRANT_URL =
+      QDRANT_URL || process.env.QDRANT_URL || "http://localhost:6333";
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY || "";
+  }
+
+  createClient(): AxiosInstance {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (this.QDRANT_API_KEY) {
+      headers["api-key"] = this.QDRANT_API_KEY;
     }
 
-    createClient(): AxiosInstance {
-        const headers: Record<string, string> = {
-            "Content-Type": "application/json",
-        };
+    return axios.create({
+      baseURL: this.QDRANT_URL.replace(/\/+$/, ""),
+      headers,
+    });
+  }
 
-        if (this.QDRANT_API_KEY) {
-            headers["api-key"] = this.QDRANT_API_KEY;
+  async createCollection({
+    client,
+    collectionName,
+    vectors,
+    replicationFactor,
+    writeConsistencyFactor,
+    shardNumber,
+    maxRetries,
+  }: CreateCollectionArgs): Promise<any> {
+    const body = this.removeUndefined({
+      vectors,
+      replication_factor: replicationFactor,
+      write_consistency_factor: writeConsistencyFactor,
+      shard_number: shardNumber,
+    });
+
+    return this.withRetry(async () => {
+      const response = await client.put(
+        this.collectionPath(collectionName),
+        body,
+      );
+      return response.data;
+    }, maxRetries);
+  }
+
+  async insertVectorData({
+    client,
+    collectionName,
+    points,
+    id,
+    vector,
+    payload,
+    wait = true,
+    ordering,
+    timeout,
+    maxRetries,
+  }: InsertVectorDataArgs): Promise<any> {
+    const pointsToInsert =
+      points || this.pointFromArgs({ id, vector, payload });
+
+    return this.withRetry(async () => {
+      const response = await client.put(
+        this.pointsPath(collectionName),
+        { points: pointsToInsert },
+        { params: this.removeUndefined({ wait, ordering, timeout }) },
+      );
+      return response.data;
+    }, maxRetries);
+  }
+
+  async getDataFromQuery({
+    client,
+    collectionName,
+    query,
+    vector,
+    filter,
+    limit = 10,
+    offset,
+    using,
+    withPayload = true,
+    withVector = false,
+    scoreThreshold,
+    params,
+    prefetch,
+    maxRetries,
+  }: GetDataFromQueryArgs): Promise<any> {
+    const queryValue = query !== undefined ? query : vector;
+    if (queryValue === undefined) {
+      throw new Error("Qdrant query requires either query or vector.");
+    }
+
+    const body = this.removeUndefined({
+      query: queryValue,
+      filter,
+      limit,
+      offset,
+      using,
+      with_payload: withPayload,
+      with_vector: withVector,
+      score_threshold: scoreThreshold,
+      params,
+      prefetch,
+    });
+
+    return this.withRetry(async () => {
+      const response = await client.post(
+        `${this.pointsPath(collectionName)}/query`,
+        body,
+      );
+      return response.data;
+    }, maxRetries);
+  }
+
+  async getData({
+    client,
+    collectionName,
+    filter,
+    limit = 10,
+    offset,
+    withPayload = true,
+    withVector = false,
+    orderBy,
+    maxRetries,
+  }: GetDataArgs): Promise<any> {
+    const body = this.removeUndefined({
+      filter,
+      limit,
+      offset,
+      with_payload: withPayload,
+      with_vector: withVector,
+      order_by: orderBy,
+    });
+
+    return this.withRetry(async () => {
+      const response = await client.post(
+        `${this.pointsPath(collectionName)}/scroll`,
+        body,
+      );
+      return response.data;
+    }, maxRetries);
+  }
+
+  async getDataById({
+    client,
+    collectionName,
+    id,
+    ids,
+    withPayload = true,
+    withVector = false,
+    maxRetries,
+  }: GetDataByIdArgs): Promise<any> {
+    const pointIds = ids || (id !== undefined ? [id] : undefined);
+    if (!pointIds?.length) {
+      throw new Error("Qdrant getDataById requires id or ids.");
+    }
+
+    const body = this.removeUndefined({
+      ids: pointIds,
+      with_payload: withPayload,
+      with_vector: withVector,
+    });
+
+    return this.withRetry(async () => {
+      const response = await client.post(this.pointsPath(collectionName), body);
+      return response.data;
+    }, maxRetries);
+  }
+
+  async updateById({
+    client,
+    collectionName,
+    id,
+    vector,
+    payload,
+    wait = true,
+    ordering,
+    timeout,
+    maxRetries,
+  }: UpdateByIdArgs): Promise<any> {
+    return this.insertVectorData({
+      client,
+      collectionName,
+      points: [{ id, vector, payload }],
+      wait,
+      ordering,
+      timeout,
+      maxRetries,
+    });
+  }
+
+  async deleteById({
+    client,
+    collectionName,
+    id,
+    ids,
+    filter,
+    wait = true,
+    ordering,
+    timeout,
+    maxRetries,
+  }: DeleteByIdArgs): Promise<any> {
+    const points = ids || (id !== undefined ? [id] : undefined);
+    if (!points?.length && !filter) {
+      throw new Error("Qdrant deleteById requires id, ids, or filter.");
+    }
+
+    const body = filter ? { filter } : { points };
+
+    return this.withRetry(async () => {
+      const response = await client.post(
+        `${this.pointsPath(collectionName)}/delete`,
+        body,
+        {
+          params: this.removeUndefined({ wait, ordering, timeout }),
+        },
+      );
+      return response.data;
+    }, maxRetries);
+  }
+
+  private pointFromArgs({
+    id,
+    vector,
+    payload,
+  }: {
+    id?: QdrantPointId;
+    vector?: QdrantVector;
+    payload?: QdrantPayload;
+  }): QdrantPoint[] {
+    if (id === undefined || !vector) {
+      throw new Error(
+        "Qdrant insertVectorData requires points or id and vector.",
+      );
+    }
+
+    return [{ id, vector, payload }];
+  }
+
+  private pointsPath(collectionName: string): string {
+    return `${this.collectionPath(collectionName)}/points`;
+  }
+
+  private collectionPath(collectionName: string): string {
+    return `/collections/${encodeURIComponent(collectionName)}`;
+  }
+
+  private removeUndefined<T extends Record<string, any>>(value: T): Partial<T> {
+    return Object.fromEntries(
+      Object.entries(value).filter(([, item]) => item !== undefined),
+    ) as Partial<T>;
+  }
+
+  private withRetry<T>(request: () => Promise<T>, maxRetries = 5): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const operation = retry.operation({
+        retries: maxRetries,
+        factor: 3,
+        minTimeout: 1 * 1000,
+        maxTimeout: 60 * 1000,
+        randomize: true,
+      });
+
+      operation.attempt(async () => {
+        try {
+          resolve(await request());
+        } catch (error: any) {
+          if (operation.retry(error)) {
+            return;
+          }
+          reject(operation.mainError() || error);
         }
-
-        return axios.create({
-            baseURL: this.QDRANT_URL.replace(/\/+$/, ""),
-            headers,
-        });
-    }
-
-    async createCollection({
-        client,
-        collectionName,
-        vectors,
-        replicationFactor,
-        writeConsistencyFactor,
-        shardNumber,
-        maxRetries,
-    }: CreateCollectionArgs): Promise<any> {
-        const body = this.removeUndefined({
-            vectors,
-            replication_factor: replicationFactor,
-            write_consistency_factor: writeConsistencyFactor,
-            shard_number: shardNumber,
-        });
-
-        return this.withRetry(async () => {
-            const response = await client.put(this.collectionPath(collectionName), body);
-            return response.data;
-        }, maxRetries);
-    }
-
-    async insertVectorData({
-        client,
-        collectionName,
-        points,
-        id,
-        vector,
-        payload,
-        wait = true,
-        ordering,
-        timeout,
-        maxRetries,
-    }: InsertVectorDataArgs): Promise<any> {
-        const pointsToInsert = points || this.pointFromArgs({ id, vector, payload });
-
-        return this.withRetry(async () => {
-            const response = await client.put(
-                this.pointsPath(collectionName),
-                { points: pointsToInsert },
-                { params: this.removeUndefined({ wait, ordering, timeout }) }
-            );
-            return response.data;
-        }, maxRetries);
-    }
-
-    async getDataFromQuery({
-        client,
-        collectionName,
-        query,
-        vector,
-        filter,
-        limit = 10,
-        offset,
-        using,
-        withPayload = true,
-        withVector = false,
-        scoreThreshold,
-        params,
-        prefetch,
-        maxRetries,
-    }: GetDataFromQueryArgs): Promise<any> {
-        const queryValue = query !== undefined ? query : vector;
-        if (queryValue === undefined) {
-            throw new Error("Qdrant query requires either query or vector.");
-        }
-
-        const body = this.removeUndefined({
-            query: queryValue,
-            filter,
-            limit,
-            offset,
-            using,
-            with_payload: withPayload,
-            with_vector: withVector,
-            score_threshold: scoreThreshold,
-            params,
-            prefetch,
-        });
-
-        return this.withRetry(async () => {
-            const response = await client.post(`${this.pointsPath(collectionName)}/query`, body);
-            return response.data;
-        }, maxRetries);
-    }
-
-    async getData({
-        client,
-        collectionName,
-        filter,
-        limit = 10,
-        offset,
-        withPayload = true,
-        withVector = false,
-        orderBy,
-        maxRetries,
-    }: GetDataArgs): Promise<any> {
-        const body = this.removeUndefined({
-            filter,
-            limit,
-            offset,
-            with_payload: withPayload,
-            with_vector: withVector,
-            order_by: orderBy,
-        });
-
-        return this.withRetry(async () => {
-            const response = await client.post(`${this.pointsPath(collectionName)}/scroll`, body);
-            return response.data;
-        }, maxRetries);
-    }
-
-    async getDataById({
-        client,
-        collectionName,
-        id,
-        ids,
-        withPayload = true,
-        withVector = false,
-        maxRetries,
-    }: GetDataByIdArgs): Promise<any> {
-        const pointIds = ids || (id !== undefined ? [id] : undefined);
-        if (!pointIds?.length) {
-            throw new Error("Qdrant getDataById requires id or ids.");
-        }
-
-        const body = this.removeUndefined({
-            ids: pointIds,
-            with_payload: withPayload,
-            with_vector: withVector,
-        });
-
-        return this.withRetry(async () => {
-            const response = await client.post(this.pointsPath(collectionName), body);
-            return response.data;
-        }, maxRetries);
-    }
-
-    async updateById({
-        client,
-        collectionName,
-        id,
-        vector,
-        payload,
-        wait = true,
-        ordering,
-        timeout,
-        maxRetries,
-    }: UpdateByIdArgs): Promise<any> {
-        return this.insertVectorData({
-            client,
-            collectionName,
-            points: [{ id, vector, payload }],
-            wait,
-            ordering,
-            timeout,
-            maxRetries,
-        });
-    }
-
-    async deleteById({
-        client,
-        collectionName,
-        id,
-        ids,
-        filter,
-        wait = true,
-        ordering,
-        timeout,
-        maxRetries,
-    }: DeleteByIdArgs): Promise<any> {
-        const points = ids || (id !== undefined ? [id] : undefined);
-        if (!points?.length && !filter) {
-            throw new Error("Qdrant deleteById requires id, ids, or filter.");
-        }
-
-        const body = filter ? { filter } : { points };
-
-        return this.withRetry(async () => {
-            const response = await client.post(`${this.pointsPath(collectionName)}/delete`, body, {
-                params: this.removeUndefined({ wait, ordering, timeout }),
-            });
-            return response.data;
-        }, maxRetries);
-    }
-
-    private pointFromArgs({
-        id,
-        vector,
-        payload,
-    }: {
-        id?: QdrantPointId;
-        vector?: QdrantVector;
-        payload?: QdrantPayload;
-    }): QdrantPoint[] {
-        if (id === undefined || !vector) {
-            throw new Error("Qdrant insertVectorData requires points or id and vector.");
-        }
-
-        return [{ id, vector, payload }];
-    }
-
-    private pointsPath(collectionName: string): string {
-        return `${this.collectionPath(collectionName)}/points`;
-    }
-
-    private collectionPath(collectionName: string): string {
-        return `/collections/${encodeURIComponent(collectionName)}`;
-    }
-
-    private removeUndefined<T extends Record<string, any>>(value: T): Partial<T> {
-        return Object.fromEntries(
-            Object.entries(value).filter(([, item]) => item !== undefined)
-        ) as Partial<T>;
-    }
-
-    private withRetry<T>(request: () => Promise<T>, maxRetries = 5): Promise<T> {
-        return new Promise((resolve, reject) => {
-            const operation = retry.operation({
-                retries: maxRetries,
-                factor: 3,
-                minTimeout: 1 * 1000,
-                maxTimeout: 60 * 1000,
-                randomize: true,
-            });
-
-            operation.attempt(async () => {
-                try {
-                    resolve(await request());
-                } catch (error: any) {
-                    if (operation.retry(error)) {
-                        return;
-                    }
-                    reject(operation.mainError() || error);
-                }
-            });
-        });
-    }
+      });
+    });
+  }
 }

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -11,9 +11,33 @@ describe("Qdrant", () => {
         post.mockReset();
     });
 
+    it("creates a collection with vector configuration", async () => {
+        put.mockResolvedValueOnce({
+            data: { status: "ok", result: true }
+        });
+
+        const qdrant = new Qdrant();
+        const result = await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectors: { size: 1536, distance: "Cosine" },
+            replicationFactor: 2,
+            writeConsistencyFactor: 1,
+            shardNumber: 3
+        });
+
+        expect(put).toHaveBeenCalledWith("/collections/documents", {
+            vectors: { size: 1536, distance: "Cosine" },
+            replication_factor: 2,
+            write_consistency_factor: 1,
+            shard_number: 3
+        });
+        expect(result.result).toBe(true);
+    });
+
     it("upserts vector points through the Qdrant REST API", async () => {
         put.mockResolvedValueOnce({
-            data: { status: "ok", result: { status: "acknowledged" } },
+            data: { status: "ok", result: { status: "acknowledged" } }
         });
 
         const qdrant = new Qdrant("http://localhost:6333", "test-key");
@@ -22,7 +46,7 @@ describe("Qdrant", () => {
             collectionName: "documents",
             id: 1,
             vector: [0.1, 0.2, 0.3],
-            payload: { content: "hello" },
+            payload: { content: "hello" }
         });
 
         expect(put).toHaveBeenCalledWith(
@@ -32,18 +56,49 @@ describe("Qdrant", () => {
                     {
                         id: 1,
                         vector: [0.1, 0.2, 0.3],
-                        payload: { content: "hello" },
-                    },
-                ],
+                        payload: { content: "hello" }
+                    }
+                ]
             },
             { params: { wait: true } }
         );
         expect(result.result.status).toBe("acknowledged");
     });
 
+    it("updates vector points by reusing the upsert endpoint", async () => {
+        put.mockResolvedValueOnce({
+            data: { status: "ok", result: { status: "acknowledged" } }
+        });
+
+        const qdrant = new Qdrant();
+        await qdrant.updateById({
+            client,
+            collectionName: "documents",
+            id: "point-2",
+            vector: [0.4, 0.5, 0.6],
+            payload: { content: "updated" },
+            wait: false,
+            ordering: "strong"
+        });
+
+        expect(put).toHaveBeenCalledWith(
+            "/collections/documents/points",
+            {
+                points: [
+                    {
+                        id: "point-2",
+                        vector: [0.4, 0.5, 0.6],
+                        payload: { content: "updated" }
+                    }
+                ]
+            },
+            { params: { wait: false, ordering: "strong" } }
+        );
+    });
+
     it("queries nearest points through /points/query", async () => {
         post.mockResolvedValueOnce({
-            data: { status: "ok", result: { points: [{ id: 1, score: 0.99 }] } },
+            data: { status: "ok", result: { points: [{ id: 1, score: 0.99 }] } }
         });
 
         const qdrant = new Qdrant();
@@ -52,29 +107,32 @@ describe("Qdrant", () => {
             collectionName: "documents",
             vector: [0.1, 0.2, 0.3],
             limit: 3,
-            filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
+            filter: { must: [{ key: "tenant", match: { value: "demo" } }] }
         });
 
-        expect(post).toHaveBeenCalledWith("/collections/documents/points/query", {
-            query: [0.1, 0.2, 0.3],
-            filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
-            limit: 3,
-            with_payload: true,
-            with_vector: false,
-        });
+        expect(post).toHaveBeenCalledWith(
+            "/collections/documents/points/query",
+            {
+                query: [0.1, 0.2, 0.3],
+                filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
+                limit: 3,
+                with_payload: true,
+                with_vector: false
+            }
+        );
         expect(result.result.points[0].score).toBe(0.99);
     });
 
     it("deletes vector points by id", async () => {
         post.mockResolvedValueOnce({
-            data: { status: "ok", result: { status: "acknowledged" } },
+            data: { status: "ok", result: { status: "acknowledged" } }
         });
 
         const qdrant = new Qdrant();
         await qdrant.deleteById({
             client,
             collectionName: "documents",
-            id: "point-1",
+            id: "point-1"
         });
 
         expect(post).toHaveBeenCalledWith(
@@ -86,27 +144,36 @@ describe("Qdrant", () => {
 
     it("scrolls points with payloads enabled by default", async () => {
         post.mockResolvedValueOnce({
-            data: { status: "ok", result: { points: [{ id: 1, payload: { content: "hello" } }] } },
+            data: {
+                status: "ok",
+                result: { points: [{ id: 1, payload: { content: "hello" } }] }
+            }
         });
 
         const qdrant = new Qdrant();
         const result = await qdrant.getData({
             client,
             collectionName: "documents",
-            limit: 5,
+            limit: 5
         });
 
-        expect(post).toHaveBeenCalledWith("/collections/documents/points/scroll", {
-            limit: 5,
-            with_payload: true,
-            with_vector: false,
-        });
+        expect(post).toHaveBeenCalledWith(
+            "/collections/documents/points/scroll",
+            {
+                limit: 5,
+                with_payload: true,
+                with_vector: false
+            }
+        );
         expect(result.result.points[0].payload.content).toBe("hello");
     });
 
     it("retrieves points by id list", async () => {
         post.mockResolvedValueOnce({
-            data: { status: "ok", result: [{ id: "point-1", vector: [0.1, 0.2, 0.3] }] },
+            data: {
+                status: "ok",
+                result: [{ id: "point-1", vector: [0.1, 0.2, 0.3] }]
+            }
         });
 
         const qdrant = new Qdrant();
@@ -114,14 +181,39 @@ describe("Qdrant", () => {
             client,
             collectionName: "documents",
             ids: ["point-1"],
-            withVector: true,
+            withVector: true
         });
 
         expect(post).toHaveBeenCalledWith("/collections/documents/points", {
             ids: ["point-1"],
             with_payload: true,
-            with_vector: true,
+            with_vector: true
         });
         expect(result.result[0].id).toBe("point-1");
+    });
+
+    it("rejects inserts without either points or an id/vector pair", async () => {
+        const qdrant = new Qdrant();
+
+        await expect(
+            qdrant.insertVectorData({
+                client,
+                collectionName: "documents",
+                id: "point-without-vector"
+            })
+        ).rejects.toThrow(
+            "Qdrant insertVectorData requires points or id and vector."
+        );
+    });
+
+    it("rejects deletes without id, ids, or filter", async () => {
+        const qdrant = new Qdrant();
+
+        await expect(
+            qdrant.deleteById({
+                client,
+                collectionName: "documents"
+            })
+        ).rejects.toThrow("Qdrant deleteById requires id, ids, or filter.");
     });
 });

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -6,214 +6,208 @@ const post = vi.fn();
 const client = { put, post } as any;
 
 describe("Qdrant", () => {
-    beforeEach(() => {
-        put.mockReset();
-        post.mockReset();
+  beforeEach(() => {
+    put.mockReset();
+    post.mockReset();
+  });
+
+  it("creates a collection with vector configuration", async () => {
+    put.mockResolvedValueOnce({
+      data: { status: "ok", result: true },
     });
 
-    it("creates a collection with vector configuration", async () => {
-        put.mockResolvedValueOnce({
-            data: { status: "ok", result: true }
-        });
-
-        const qdrant = new Qdrant();
-        const result = await qdrant.createCollection({
-            client,
-            collectionName: "documents",
-            vectors: { size: 1536, distance: "Cosine" },
-            replicationFactor: 2,
-            writeConsistencyFactor: 1,
-            shardNumber: 3
-        });
-
-        expect(put).toHaveBeenCalledWith("/collections/documents", {
-            vectors: { size: 1536, distance: "Cosine" },
-            replication_factor: 2,
-            write_consistency_factor: 1,
-            shard_number: 3
-        });
-        expect(result.result).toBe(true);
+    const qdrant = new Qdrant();
+    const result = await qdrant.createCollection({
+      client,
+      collectionName: "documents",
+      vectors: { size: 1536, distance: "Cosine" },
+      replicationFactor: 2,
+      writeConsistencyFactor: 1,
+      shardNumber: 3,
     });
 
-    it("upserts vector points through the Qdrant REST API", async () => {
-        put.mockResolvedValueOnce({
-            data: { status: "ok", result: { status: "acknowledged" } }
-        });
+    expect(put).toHaveBeenCalledWith("/collections/documents", {
+      vectors: { size: 1536, distance: "Cosine" },
+      replication_factor: 2,
+      write_consistency_factor: 1,
+      shard_number: 3,
+    });
+    expect(result.result).toBe(true);
+  });
 
-        const qdrant = new Qdrant("http://localhost:6333", "test-key");
-        const result = await qdrant.insertVectorData({
-            client,
-            collectionName: "documents",
+  it("upserts vector points through the Qdrant REST API", async () => {
+    put.mockResolvedValueOnce({
+      data: { status: "ok", result: { status: "acknowledged" } },
+    });
+
+    const qdrant = new Qdrant("http://localhost:6333", "test-key");
+    const result = await qdrant.insertVectorData({
+      client,
+      collectionName: "documents",
+      id: 1,
+      vector: [0.1, 0.2, 0.3],
+      payload: { content: "hello" },
+    });
+
+    expect(put).toHaveBeenCalledWith(
+      "/collections/documents/points",
+      {
+        points: [
+          {
             id: 1,
             vector: [0.1, 0.2, 0.3],
-            payload: { content: "hello" }
-        });
+            payload: { content: "hello" },
+          },
+        ],
+      },
+      { params: { wait: true } },
+    );
+    expect(result.result.status).toBe("acknowledged");
+  });
 
-        expect(put).toHaveBeenCalledWith(
-            "/collections/documents/points",
-            {
-                points: [
-                    {
-                        id: 1,
-                        vector: [0.1, 0.2, 0.3],
-                        payload: { content: "hello" }
-                    }
-                ]
-            },
-            { params: { wait: true } }
-        );
-        expect(result.result.status).toBe("acknowledged");
+  it("updates vector points by reusing the upsert endpoint", async () => {
+    put.mockResolvedValueOnce({
+      data: { status: "ok", result: { status: "acknowledged" } },
     });
 
-    it("updates vector points by reusing the upsert endpoint", async () => {
-        put.mockResolvedValueOnce({
-            data: { status: "ok", result: { status: "acknowledged" } }
-        });
+    const qdrant = new Qdrant();
+    await qdrant.updateById({
+      client,
+      collectionName: "documents",
+      id: "point-2",
+      vector: [0.4, 0.5, 0.6],
+      payload: { content: "updated" },
+      wait: false,
+      ordering: "strong",
+    });
 
-        const qdrant = new Qdrant();
-        await qdrant.updateById({
-            client,
-            collectionName: "documents",
+    expect(put).toHaveBeenCalledWith(
+      "/collections/documents/points",
+      {
+        points: [
+          {
             id: "point-2",
             vector: [0.4, 0.5, 0.6],
             payload: { content: "updated" },
-            wait: false,
-            ordering: "strong"
-        });
+          },
+        ],
+      },
+      { params: { wait: false, ordering: "strong" } },
+    );
+  });
 
-        expect(put).toHaveBeenCalledWith(
-            "/collections/documents/points",
-            {
-                points: [
-                    {
-                        id: "point-2",
-                        vector: [0.4, 0.5, 0.6],
-                        payload: { content: "updated" }
-                    }
-                ]
-            },
-            { params: { wait: false, ordering: "strong" } }
-        );
+  it("queries nearest points through /points/query", async () => {
+    post.mockResolvedValueOnce({
+      data: { status: "ok", result: { points: [{ id: 1, score: 0.99 }] } },
     });
 
-    it("queries nearest points through /points/query", async () => {
-        post.mockResolvedValueOnce({
-            data: { status: "ok", result: { points: [{ id: 1, score: 0.99 }] } }
-        });
-
-        const qdrant = new Qdrant();
-        const result = await qdrant.getDataFromQuery({
-            client,
-            collectionName: "documents",
-            vector: [0.1, 0.2, 0.3],
-            limit: 3,
-            filter: { must: [{ key: "tenant", match: { value: "demo" } }] }
-        });
-
-        expect(post).toHaveBeenCalledWith(
-            "/collections/documents/points/query",
-            {
-                query: [0.1, 0.2, 0.3],
-                filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
-                limit: 3,
-                with_payload: true,
-                with_vector: false
-            }
-        );
-        expect(result.result.points[0].score).toBe(0.99);
+    const qdrant = new Qdrant();
+    const result = await qdrant.getDataFromQuery({
+      client,
+      collectionName: "documents",
+      vector: [0.1, 0.2, 0.3],
+      limit: 3,
+      filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
     });
 
-    it("deletes vector points by id", async () => {
-        post.mockResolvedValueOnce({
-            data: { status: "ok", result: { status: "acknowledged" } }
-        });
+    expect(post).toHaveBeenCalledWith("/collections/documents/points/query", {
+      query: [0.1, 0.2, 0.3],
+      filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
+      limit: 3,
+      with_payload: true,
+      with_vector: false,
+    });
+    expect(result.result.points[0].score).toBe(0.99);
+  });
 
-        const qdrant = new Qdrant();
-        await qdrant.deleteById({
-            client,
-            collectionName: "documents",
-            id: "point-1"
-        });
-
-        expect(post).toHaveBeenCalledWith(
-            "/collections/documents/points/delete",
-            { points: ["point-1"] },
-            { params: { wait: true } }
-        );
+  it("deletes vector points by id", async () => {
+    post.mockResolvedValueOnce({
+      data: { status: "ok", result: { status: "acknowledged" } },
     });
 
-    it("scrolls points with payloads enabled by default", async () => {
-        post.mockResolvedValueOnce({
-            data: {
-                status: "ok",
-                result: { points: [{ id: 1, payload: { content: "hello" } }] }
-            }
-        });
-
-        const qdrant = new Qdrant();
-        const result = await qdrant.getData({
-            client,
-            collectionName: "documents",
-            limit: 5
-        });
-
-        expect(post).toHaveBeenCalledWith(
-            "/collections/documents/points/scroll",
-            {
-                limit: 5,
-                with_payload: true,
-                with_vector: false
-            }
-        );
-        expect(result.result.points[0].payload.content).toBe("hello");
+    const qdrant = new Qdrant();
+    await qdrant.deleteById({
+      client,
+      collectionName: "documents",
+      id: "point-1",
     });
 
-    it("retrieves points by id list", async () => {
-        post.mockResolvedValueOnce({
-            data: {
-                status: "ok",
-                result: [{ id: "point-1", vector: [0.1, 0.2, 0.3] }]
-            }
-        });
+    expect(post).toHaveBeenCalledWith(
+      "/collections/documents/points/delete",
+      { points: ["point-1"] },
+      { params: { wait: true } },
+    );
+  });
 
-        const qdrant = new Qdrant();
-        const result = await qdrant.getDataById({
-            client,
-            collectionName: "documents",
-            ids: ["point-1"],
-            withVector: true
-        });
-
-        expect(post).toHaveBeenCalledWith("/collections/documents/points", {
-            ids: ["point-1"],
-            with_payload: true,
-            with_vector: true
-        });
-        expect(result.result[0].id).toBe("point-1");
+  it("scrolls points with payloads enabled by default", async () => {
+    post.mockResolvedValueOnce({
+      data: {
+        status: "ok",
+        result: { points: [{ id: 1, payload: { content: "hello" } }] },
+      },
     });
 
-    it("rejects inserts without either points or an id/vector pair", async () => {
-        const qdrant = new Qdrant();
-
-        await expect(
-            qdrant.insertVectorData({
-                client,
-                collectionName: "documents",
-                id: "point-without-vector"
-            })
-        ).rejects.toThrow(
-            "Qdrant insertVectorData requires points or id and vector."
-        );
+    const qdrant = new Qdrant();
+    const result = await qdrant.getData({
+      client,
+      collectionName: "documents",
+      limit: 5,
     });
 
-    it("rejects deletes without id, ids, or filter", async () => {
-        const qdrant = new Qdrant();
-
-        await expect(
-            qdrant.deleteById({
-                client,
-                collectionName: "documents"
-            })
-        ).rejects.toThrow("Qdrant deleteById requires id, ids, or filter.");
+    expect(post).toHaveBeenCalledWith("/collections/documents/points/scroll", {
+      limit: 5,
+      with_payload: true,
+      with_vector: false,
     });
+    expect(result.result.points[0].payload.content).toBe("hello");
+  });
+
+  it("retrieves points by id list", async () => {
+    post.mockResolvedValueOnce({
+      data: {
+        status: "ok",
+        result: [{ id: "point-1", vector: [0.1, 0.2, 0.3] }],
+      },
+    });
+
+    const qdrant = new Qdrant();
+    const result = await qdrant.getDataById({
+      client,
+      collectionName: "documents",
+      ids: ["point-1"],
+      withVector: true,
+    });
+
+    expect(post).toHaveBeenCalledWith("/collections/documents/points", {
+      ids: ["point-1"],
+      with_payload: true,
+      with_vector: true,
+    });
+    expect(result.result[0].id).toBe("point-1");
+  });
+
+  it("rejects inserts without either points or an id/vector pair", async () => {
+    const qdrant = new Qdrant();
+
+    await expect(
+      qdrant.insertVectorData({
+        client,
+        collectionName: "documents",
+        id: "point-without-vector",
+      }),
+    ).rejects.toThrow(
+      "Qdrant insertVectorData requires points or id and vector.",
+    );
+  });
+
+  it("rejects deletes without id, ids, or filter", async () => {
+    const qdrant = new Qdrant();
+
+    await expect(
+      qdrant.deleteById({
+        client,
+        collectionName: "documents",
+      }),
+    ).rejects.toThrow("Qdrant deleteById requires id, ids, or filter.");
+  });
 });

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+const put = vi.fn();
+const post = vi.fn();
+const client = { put, post } as any;
+
+describe("Qdrant", () => {
+    beforeEach(() => {
+        put.mockReset();
+        post.mockReset();
+    });
+
+    it("upserts vector points through the Qdrant REST API", async () => {
+        put.mockResolvedValueOnce({
+            data: { status: "ok", result: { status: "acknowledged" } },
+        });
+
+        const qdrant = new Qdrant("http://localhost:6333", "test-key");
+        const result = await qdrant.insertVectorData({
+            client,
+            collectionName: "documents",
+            id: 1,
+            vector: [0.1, 0.2, 0.3],
+            payload: { content: "hello" },
+        });
+
+        expect(put).toHaveBeenCalledWith(
+            "/collections/documents/points",
+            {
+                points: [
+                    {
+                        id: 1,
+                        vector: [0.1, 0.2, 0.3],
+                        payload: { content: "hello" },
+                    },
+                ],
+            },
+            { params: { wait: true } }
+        );
+        expect(result.result.status).toBe("acknowledged");
+    });
+
+    it("queries nearest points through /points/query", async () => {
+        post.mockResolvedValueOnce({
+            data: { status: "ok", result: { points: [{ id: 1, score: 0.99 }] } },
+        });
+
+        const qdrant = new Qdrant();
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
+        });
+
+        expect(post).toHaveBeenCalledWith("/collections/documents/points/query", {
+            query: [0.1, 0.2, 0.3],
+            filter: { must: [{ key: "tenant", match: { value: "demo" } }] },
+            limit: 3,
+            with_payload: true,
+            with_vector: false,
+        });
+        expect(result.result.points[0].score).toBe(0.99);
+    });
+
+    it("deletes vector points by id", async () => {
+        post.mockResolvedValueOnce({
+            data: { status: "ok", result: { status: "acknowledged" } },
+        });
+
+        const qdrant = new Qdrant();
+        await qdrant.deleteById({
+            client,
+            collectionName: "documents",
+            id: "point-1",
+        });
+
+        expect(post).toHaveBeenCalledWith(
+            "/collections/documents/points/delete",
+            { points: ["point-1"] },
+            { params: { wait: true } }
+        );
+    });
+
+    it("scrolls points with payloads enabled by default", async () => {
+        post.mockResolvedValueOnce({
+            data: { status: "ok", result: { points: [{ id: 1, payload: { content: "hello" } }] } },
+        });
+
+        const qdrant = new Qdrant();
+        const result = await qdrant.getData({
+            client,
+            collectionName: "documents",
+            limit: 5,
+        });
+
+        expect(post).toHaveBeenCalledWith("/collections/documents/points/scroll", {
+            limit: 5,
+            with_payload: true,
+            with_vector: false,
+        });
+        expect(result.result.points[0].payload.content).toBe("hello");
+    });
+
+    it("retrieves points by id list", async () => {
+        post.mockResolvedValueOnce({
+            data: { status: "ok", result: [{ id: "point-1", vector: [0.1, 0.2, 0.3] }] },
+        });
+
+        const qdrant = new Qdrant();
+        const result = await qdrant.getDataById({
+            client,
+            collectionName: "documents",
+            ids: ["point-1"],
+            withVector: true,
+        });
+
+        expect(post).toHaveBeenCalledWith("/collections/documents/points", {
+            ids: ["point-1"],
+            with_payload: true,
+            with_vector: true,
+        });
+        expect(result.result[0].id).toBe("point-1");
+    });
+});


### PR DESCRIPTION
/claim #273

Fixes #273.

This adds a Qdrant vector database wrapper to the JavaScript SDK without using Qdrant packages. It follows the existing vector-db style and calls Qdrant REST endpoints directly through axios.

Implemented:

- Qdrant client creation with optional `QDRANT_URL` and `QDRANT_API_KEY`
- collection creation helper
- point upsert through `PUT /collections/:collection_name/points`
- query through `POST /collections/:collection_name/points/query`
- scroll through `POST /collections/:collection_name/points/scroll`
- retrieve-by-id through `POST /collections/:collection_name/points`
- delete through `POST /collections/:collection_name/points/delete`
- `Qdrant` export from the vector-db package
- qdrant test folder covering collection creation, upsert, update-by-id, query, scroll, retrieve-by-id, delete, and validation behavior

Verification:

- TypeScript build passed locally with `node node_modules/typescript/bin/tsc -b`.
- Qdrant tests passed locally with Vitest: `node node_modules/vitest/vitest.mjs run src/vector-db/src/tests/qdrant/qdrant.test.ts --cache=false` (9 tests).

Demo note:

- This is an SDK-only change with mocked request-shape coverage; the included qdrant Vitest suite demonstrates collection creation, upsert, update-by-id, query, scroll, retrieve-by-id, delete, and validation behavior without requiring a live Qdrant server.