### PR TITLE
Add AWS Comprehend PII redactor

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,11 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { ComprehendRedactor } from "./lib/aws/comprehendRedactor.js";
+export type {
+    ComprehendLikeClient,
+    ComprehendPiiEntity,
+    ComprehendRedactorOptions,
+    DetectPiiEntitiesCommandInput,
+    DetectPiiEntitiesCommandOutput,
+} from "./lib/aws/comprehendRedactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehendRedactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehendRedactor.ts
@@ -1,0 +1,103 @@
+export interface ComprehendPiiEntity {
+    Type?: string;
+    BeginOffset?: number;
+    EndOffset?: number;
+    Score?: number;
+}
+
+export interface DetectPiiEntitiesCommandInput {
+    Text: string;
+    LanguageCode: string;
+}
+
+export interface DetectPiiEntitiesCommandOutput {
+    Entities?: ComprehendPiiEntity[];
+}
+
+export interface ComprehendLikeClient {
+    detectPiiEntities?: (
+        input: DetectPiiEntitiesCommandInput
+    ) => Promise<DetectPiiEntitiesCommandOutput>;
+    send?: (command: unknown) => Promise<DetectPiiEntitiesCommandOutput>;
+}
+
+export interface ComprehendRedactorOptions {
+    client: ComprehendLikeClient;
+    languageCode?: string;
+    replacement?: string | ((entity: ComprehendPiiEntity) => string);
+    minScore?: number;
+    commandFactory?: (input: DetectPiiEntitiesCommandInput) => unknown;
+}
+
+export class ComprehendRedactor {
+    private readonly client: ComprehendLikeClient;
+    private readonly languageCode: string;
+    private readonly replacement: string | ((entity: ComprehendPiiEntity) => string);
+    private readonly minScore: number;
+    private readonly commandFactory?: (input: DetectPiiEntitiesCommandInput) => unknown;
+
+    constructor(options: ComprehendRedactorOptions) {
+        this.client = options.client;
+        this.languageCode = options.languageCode || "en";
+        this.replacement = options.replacement || ((entity) => `[${entity.Type || "PII"}]`);
+        this.minScore = options.minScore ?? 0;
+        this.commandFactory = options.commandFactory;
+    }
+
+    async redact(text: string): Promise<string> {
+        if (!text) {
+            return text;
+        }
+
+        const input = { Text: text, LanguageCode: this.languageCode };
+        const response = await this.detectPiiEntities(input);
+        const entities = this.normalizeEntities(response.Entities || [], text.length);
+
+        return entities.reduceRight((redacted, entity) => {
+            const replacement =
+                typeof this.replacement === "function" ? this.replacement(entity) : this.replacement;
+            return `${redacted.slice(0, entity.BeginOffset)}${replacement}${redacted.slice(
+                entity.EndOffset
+            )}`;
+        }, text);
+    }
+
+    private async detectPiiEntities(
+        input: DetectPiiEntitiesCommandInput
+    ): Promise<DetectPiiEntitiesCommandOutput> {
+        if (this.client.detectPiiEntities) {
+            return this.client.detectPiiEntities(input);
+        }
+
+        if (this.client.send && this.commandFactory) {
+            return this.client.send(this.commandFactory(input));
+        }
+
+        throw new Error("ComprehendRedactor requires detectPiiEntities or send plus commandFactory");
+    }
+
+    private normalizeEntities(entities: ComprehendPiiEntity[], textLength: number): Required<ComprehendPiiEntity>[] {
+        return entities
+            .filter((entity): entity is Required<ComprehendPiiEntity> => {
+                if (typeof entity.BeginOffset !== "number" || typeof entity.EndOffset !== "number") {
+                    return false;
+                }
+                if (entity.BeginOffset < 0 || entity.EndOffset > textLength || entity.BeginOffset >= entity.EndOffset) {
+                    return false;
+                }
+                return (entity.Score ?? 1) >= this.minScore;
+            })
+            .sort((a, b) => a.BeginOffset - b.BeginOffset)
+            .reduce<Required<ComprehendPiiEntity>[]>((acc, entity) => {
+                const previous = acc[acc.length - 1];
+                if (previous && entity.BeginOffset < previous.EndOffset) {
+                    if ((entity.Score ?? 0) > (previous.Score ?? 0)) {
+                        acc[acc.length - 1] = entity;
+                    }
+                    return acc;
+                }
+                acc.push(entity);
+                return acc;
+            }, []);
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehendRedactor.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test, vi } from "vitest";
+import { ComprehendRedactor } from "../lib/aws/comprehendRedactor";
+
+describe("ComprehendRedactor", () => {
+    test("redacts PII entities returned by a Comprehend compatible client", async () => {
+        const client = {
+            detectPiiEntities: vi.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "EMAIL",
+                        BeginOffset: 11,
+                        EndOffset: 27,
+                        Score: 0.99,
+                    },
+                ],
+            }),
+        };
+        const redactor = new ComprehendRedactor({ client });
+
+        await expect(redactor.redact("Contact me test@example.com")).resolves.toBe("Contact me [EMAIL]");
+        expect(client.detectPiiEntities).toHaveBeenCalledWith({
+            Text: "Contact me test@example.com",
+            LanguageCode: "en",
+        });
+    });
+
+    test("supports custom replacements and minimum confidence", async () => {
+        const client = {
+            detectPiiEntities: vi.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "EMAIL",
+                        BeginOffset: 6,
+                        EndOffset: 22,
+                        Score: 0.4,
+                    },
+                    {
+                        Type: "PHONE",
+                        BeginOffset: 29,
+                        EndOffset: 41,
+                        Score: 0.95,
+                    },
+                ],
+            }),
+        };
+        const redactor = new ComprehendRedactor({
+            client,
+            minScore: 0.8,
+            replacement: (entity) => `<${entity.Type}>`,
+        });
+
+        await expect(redactor.redact("Email test@example.com phone 555-123-4567")).resolves.toBe(
+            "Email test@example.com phone <PHONE>"
+        );
+    });
+
+    test("supports AWS SDK v3 style send with command factory", async () => {
+        const command = { command: "DetectPiiEntities" };
+        const client = {
+            send: vi.fn().mockResolvedValue({
+                Entities: [
+                    {
+                        Type: "NAME",
+                        BeginOffset: 0,
+                        EndOffset: 4,
+                    },
+                ],
+            }),
+        };
+        const redactor = new ComprehendRedactor({
+            client,
+            commandFactory: () => command,
+        });
+
+        await expect(redactor.redact("John paid")).resolves.toBe("[NAME] paid");
+        expect(client.send).toHaveBeenCalledWith(command);
+    });
+});


### PR DESCRIPTION
## Summary

- Add a ComprehendRedactor utility for AWS Comprehend-style PII redaction
- Support simple `detectPiiEntities(input)` clients and AWS SDK v3-style `send(command)` clients via command factories
- Add configurable language code, replacement behavior, and minimum confidence filtering
- Export the utility from the AI package
- Add tests for redaction, confidence filtering, custom replacements, and SDK-v3 style usage

Closes #290

## Test Plan

- `npx.cmd vitest run comprehendRedactor`
- `npx.cmd tsc -b`
- `git diff --check`