### PR TITLE
Add PaLM2 API support to JS SDK

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,6 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,75 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+
+const DEFAULT_MODEL = "models/text-bison-001";
+const GENERATE_TEXT_URL =
+    "https://generativelanguage.googleapis.com/v1beta/{model}:generateText";
+
+interface Palm2AIConstructionOptions {
+    apiKey?: string;
+}
+
+interface Palm2AIChatOptions {
+    model?: string;
+    prompt: string;
+    candidate_count?: number;
+    max_output_tokens?: number;
+    temperature?: number;
+    top_k?: number;
+    top_p?: number;
+    max_retry?: number;
+    delay?: number;
+}
+
+type Palm2SafetyRating = {
+    category: string;
+    probability: string;
+};
+
+type Palm2Candidate = {
+    output: string;
+    safetyRatings?: Palm2SafetyRating[];
+};
+
+type Palm2Response = {
+    candidates: Palm2Candidate[];
+    filters?: unknown[];
+};
+
+export class Palm2AI {
+    apiKey: string;
+
+    constructor(options: Palm2AIConstructionOptions = {}) {
+        this.apiKey = options.apiKey || process.env.PALM2_API_KEY || process.env.GOOGLE_API_KEY || "";
+    }
+
+    async chat(chatOptions: Palm2AIChatOptions): Promise<Palm2Response> {
+        const model = chatOptions.model || DEFAULT_MODEL;
+        const url = GENERATE_TEXT_URL.replace("{model}", model);
+
+        const data = {
+            prompt: {
+                text: chatOptions.prompt,
+            },
+            candidateCount: chatOptions.candidate_count || 1,
+            maxOutputTokens: chatOptions.max_output_tokens || 1024,
+            temperature: chatOptions.temperature || 0.7,
+            topK: chatOptions.top_k,
+            topP: chatOptions.top_p,
+        };
+
+        return await retry(
+            async () => {
+                return (
+                    await axios.post(url, data, {
+                        headers: {
+                            "Content-Type": "application/json",
+                            "x-goog-api-key": this.apiKey,
+                        },
+                    })
+                ).data;
+            },
+            { maxAttempts: chatOptions.max_retry || 3, delay: chatOptions.delay || 200 }
+        );
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2.test.ts
@@ -1,0 +1,75 @@
+import axios from "axios";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Palm2AI } from "../lib/palm2/palm2";
+
+vi.mock("axios");
+
+describe("Palm2AI", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test("should generate text with the default PaLM2 model", async () => {
+        const mockResponse = {
+            candidates: [{ output: "Test response" }],
+        };
+
+        vi.mocked(axios.post).mockResolvedValueOnce({ data: mockResponse });
+
+        const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+        const response = await palm2.chat({ prompt: "test prompt", max_retry: 1 });
+
+        expect(response).toEqual(mockResponse);
+        expect(axios.post).toHaveBeenCalledWith(
+            "https://generativelanguage.googleapis.com/v1beta/models/text-bison-001:generateText",
+            {
+                prompt: {
+                    text: "test prompt",
+                },
+                candidateCount: 1,
+                maxOutputTokens: 1024,
+                temperature: 0.7,
+                topK: undefined,
+                topP: undefined,
+            },
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-goog-api-key": "test_api_key",
+                },
+            }
+        );
+    });
+
+    test("should allow overriding model and generation options", async () => {
+        const mockResponse = {
+            candidates: [{ output: "Custom response" }],
+        };
+
+        vi.mocked(axios.post).mockResolvedValueOnce({ data: mockResponse });
+
+        const palm2 = new Palm2AI({ apiKey: "test_api_key" });
+        await palm2.chat({
+            model: "models/chat-bison-001",
+            prompt: "hello",
+            candidate_count: 2,
+            max_output_tokens: 128,
+            temperature: 0.2,
+            top_k: 40,
+            top_p: 0.9,
+            max_retry: 1,
+        });
+
+        expect(axios.post).toHaveBeenCalledWith(
+            "https://generativelanguage.googleapis.com/v1beta/models/chat-bison-001:generateText",
+            expect.objectContaining({
+                candidateCount: 2,
+                maxOutputTokens: 128,
+                temperature: 0.2,
+                topK: 40,
+                topP: 0.9,
+            }),
+            expect.any(Object)
+        );
+    });
+});

--- a/JS/edgechains/examples/palm2/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2/jsonnet/main.jsonnet
@@ -1,0 +1,18 @@
+local promptTemplate = |||
+  You are a helpful assistant.
+  Answer the following question: {question}
+|||;
+
+local key = std.extVar('palm2_api_key');
+local question = std.extVar('question');
+
+local promptWithQuestion = std.strReplace(promptTemplate, '{question}', question + '\n');
+
+local main() =
+  local response = arakoo.native('palm2Call')({
+    prompt: promptWithQuestion,
+    palm2ApiKey: key,
+  });
+  response;
+
+main()

--- a/JS/edgechains/examples/palm2/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2/jsonnet/secrets.jsonnet
@@ -1,0 +1,5 @@
+local PALM2_API_KEY = "AIza-***";
+
+{
+  "palm2_api_key": PALM2_API_KEY,
+}

--- a/JS/edgechains/examples/palm2/package.json
+++ b/JS/edgechains/examples/palm2/package.json
@@ -1,0 +1,12 @@
+{
+  "type": "module",
+  "scripts": {
+    "start": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "*",
+    "@arakoodev/jsonnet": "*",
+    "file-uri-to-path": "^2.0.0",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/JS/edgechains/examples/palm2/src/index.ts
+++ b/JS/edgechains/examples/palm2/src/index.ts
@@ -1,0 +1,30 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const palm2Call = createSyncRPC(path.join(__dirname, "./lib/generateResponse.cjs"));
+
+app.post("/chat", async (c: any) => {
+    try {
+        const { question } = await c.req.json();
+        const key = JSON.parse(
+            jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet"))
+        ).palm2_api_key;
+        jsonnet.extString("palm2_api_key", key);
+        jsonnet.extString("question", question || "");
+        jsonnet.javascriptCallback("palm2Call", palm2Call);
+        const response = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+        return c.json(JSON.parse(response));
+    } catch (error) {
+        console.log("error occured", error);
+    }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/palm2/src/lib/generateResponse.cjs
+++ b/JS/edgechains/examples/palm2/src/lib/generateResponse.cjs
@@ -1,0 +1,6 @@
+const { Palm2AI } = require("@arakoodev/edgechains.js/ai");
+
+module.exports = async function generateResponse({ prompt, palm2ApiKey }) {
+  const palm2 = new Palm2AI({ apiKey: palm2ApiKey });
+  return palm2.chat({ prompt });
+};


### PR DESCRIPTION
## Summary
- adds a Palm2AI client for Google PaLM/Text Bison generateText calls
- exports Palm2AI from the AI package entrypoint
- adds a jsonnet-based PaLM2 example and unit coverage for default/custom request options

## Tests
- npm run build
- npx vitest run palm2.test.ts

Fixes #279
