### PR TITLE
Add AWS Comprehend PII redactor for JS SDK

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
+        "@aws-sdk/client-comprehend": "^3.699.0",
         "@hono/node-server": "^0.6.0",
         "@lifeomic/attempt": "^3.1.0",
         "@playwright/test": "^1.45.3",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,11 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AwsComprehendRedactor, redactByOffsets } from "./lib/aws-comprehend/comprehend.js";
+export type {
+    AwsComprehendRedactorOptions,
+    ChatMessage,
+    ComprehendClientLike,
+    ComprehendPiiEntity,
+    RedactTextResult,
+} from "./lib/aws-comprehend/comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend.ts
@@ -190,21 +190,55 @@ export function redactByOffsets(
     mask = "[REDACTED:{type}]"
 ): string {
     return entities
-        .filter(
-            (entity) =>
-                Number.isInteger(entity.BeginOffset) &&
-                Number.isInteger(entity.EndOffset) &&
-                entity.BeginOffset! >= 0 &&
-                entity.EndOffset! > entity.BeginOffset! &&
-                entity.EndOffset! <= text.length
-        )
-        .sort((a, b) => b.BeginOffset! - a.BeginOffset!)
-        .reduce((redactedText, entity) => {
-            const replacement = mask.replace("{type}", entity.Type || "PII");
+        .map((entity) => {
+            if (!Number.isInteger(entity.BeginOffset) || !Number.isInteger(entity.EndOffset)) {
+                return undefined;
+            }
+
+            const begin = codePointOffsetToCodeUnitIndex(text, entity.BeginOffset!);
+            const end = codePointOffsetToCodeUnitIndex(text, entity.EndOffset!);
+
+            if (begin < 0 || end <= begin) {
+                return undefined;
+            }
+
+            return {
+                begin,
+                end,
+                type: entity.Type || "PII",
+            };
+        })
+        .filter((range): range is { begin: number; end: number; type: string } => Boolean(range))
+        .sort((a, b) => b.begin - a.begin)
+        .reduce((redactedText, range) => {
+            const replacement = mask.replace("{type}", range.type);
             return (
-                redactedText.slice(0, entity.BeginOffset) +
-                replacement +
-                redactedText.slice(entity.EndOffset)
+                redactedText.slice(0, range.begin) + replacement + redactedText.slice(range.end)
             );
         }, text);
+}
+
+function codePointOffsetToCodeUnitIndex(text: string, offset: number): number {
+    if (offset < 0) {
+        return -1;
+    }
+    if (offset === 0) {
+        return 0;
+    }
+
+    let codePointIndex = 0;
+    for (let codeUnitIndex = 0; codeUnitIndex < text.length; codePointIndex += 1) {
+        if (codePointIndex === offset) {
+            return codeUnitIndex;
+        }
+
+        const codePoint = text.codePointAt(codeUnitIndex);
+        codeUnitIndex += codePoint && codePoint > 0xffff ? 2 : 1;
+
+        if (codePointIndex + 1 === offset) {
+            return codeUnitIndex;
+        }
+    }
+
+    return codePointIndex === offset ? text.length : -1;
 }

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend.ts
@@ -1,0 +1,210 @@
+type ComprehendLanguageCode =
+    | "en"
+    | "es"
+    | "fr"
+    | "de"
+    | "it"
+    | "pt"
+    | "ar"
+    | "hi"
+    | "ja"
+    | "ko"
+    | "zh"
+    | "zh-TW";
+
+type PiiEntityType =
+    | "BANK_ACCOUNT_NUMBER"
+    | "BANK_ROUTING"
+    | "CREDIT_DEBIT_NUMBER"
+    | "CREDIT_DEBIT_CVV"
+    | "CREDIT_DEBIT_EXPIRY"
+    | "PIN"
+    | "EMAIL"
+    | "ADDRESS"
+    | "NAME"
+    | "PHONE"
+    | "SSN"
+    | "DATE_TIME"
+    | "PASSPORT_NUMBER"
+    | "DRIVER_ID"
+    | "URL"
+    | "AGE"
+    | "USERNAME"
+    | "PASSWORD"
+    | "AWS_ACCESS_KEY"
+    | "AWS_SECRET_KEY"
+    | "IP_ADDRESS"
+    | "MAC_ADDRESS"
+    | "ALL";
+
+export interface ComprehendPiiEntity {
+    Type?: PiiEntityType | string;
+    Score?: number;
+    BeginOffset?: number;
+    EndOffset?: number;
+}
+
+interface DetectPiiEntitiesResponse {
+    Entities?: ComprehendPiiEntity[];
+}
+
+export interface ComprehendClientLike {
+    send(command: unknown): Promise<DetectPiiEntitiesResponse>;
+}
+
+interface DetectPiiEntitiesCommandCtor {
+    new (input: { Text: string; LanguageCode: ComprehendLanguageCode }): unknown;
+}
+
+interface AwsComprehendModule {
+    ComprehendClient: new (options: {
+        region?: string;
+        credentials?: AwsComprehendRedactorOptions["credentials"];
+    }) => ComprehendClientLike;
+    DetectPiiEntitiesCommand: DetectPiiEntitiesCommandCtor;
+}
+
+export interface AwsComprehendRedactorOptions {
+    client?: ComprehendClientLike;
+    commandCtor?: DetectPiiEntitiesCommandCtor;
+    region?: string;
+    credentials?: {
+        accessKeyId: string;
+        secretAccessKey: string;
+        sessionToken?: string;
+    };
+    languageCode?: ComprehendLanguageCode;
+    entityTypes?: Array<PiiEntityType | string>;
+    minScore?: number;
+    mask?: string;
+}
+
+export interface RedactTextResult {
+    text: string;
+    entities: ComprehendPiiEntity[];
+}
+
+export interface ChatMessage {
+    role: string;
+    content: string;
+    name?: string;
+}
+
+export class AwsComprehendRedactor {
+    private readonly client?: ComprehendClientLike;
+    private readonly commandCtor?: DetectPiiEntitiesCommandCtor;
+    private readonly region?: string;
+    private readonly credentials?: AwsComprehendRedactorOptions["credentials"];
+    private readonly languageCode: ComprehendLanguageCode;
+    private readonly entityTypes?: Set<string>;
+    private readonly minScore: number;
+    private readonly mask: string;
+
+    constructor(options: AwsComprehendRedactorOptions = {}) {
+        this.client = options.client;
+        this.commandCtor = options.commandCtor;
+        this.region = options.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
+        this.credentials = options.credentials;
+        this.languageCode = options.languageCode || "en";
+        this.entityTypes = options.entityTypes ? new Set(options.entityTypes) : undefined;
+        this.minScore = options.minScore ?? 0;
+        this.mask = options.mask || "[REDACTED:{type}]";
+    }
+
+    async detectPiiEntities(text: string): Promise<ComprehendPiiEntity[]> {
+        if (!text) {
+            return [];
+        }
+
+        const { client, commandCtor } = await this.getClientAndCommand();
+        const command = new commandCtor({
+            Text: text,
+            LanguageCode: this.languageCode,
+        });
+        const response = await client.send(command);
+        return (response.Entities || []).filter((entity) => this.shouldRedact(entity));
+    }
+
+    async redactText(text: string): Promise<RedactTextResult> {
+        const entities = await this.detectPiiEntities(text);
+        return {
+            text: redactByOffsets(text, entities, this.mask),
+            entities,
+        };
+    }
+
+    async redactPrompt(prompt: string): Promise<string> {
+        return (await this.redactText(prompt)).text;
+    }
+
+    async redactMessages(messages: ChatMessage[]): Promise<ChatMessage[]> {
+        return Promise.all(
+            messages.map(async (message) => ({
+                ...message,
+                content: await this.redactPrompt(message.content),
+            }))
+        );
+    }
+
+    asPromptRedactor(): (prompt: string) => Promise<string> {
+        return (prompt: string) => this.redactPrompt(prompt);
+    }
+
+    private shouldRedact(entity: ComprehendPiiEntity): boolean {
+        const score = entity.Score ?? 0;
+        const type = entity.Type || "";
+        if (score < this.minScore) {
+            return false;
+        }
+        if (!this.entityTypes || this.entityTypes.has("ALL")) {
+            return true;
+        }
+        return this.entityTypes.has(type);
+    }
+
+    private async getClientAndCommand(): Promise<{
+        client: ComprehendClientLike;
+        commandCtor: DetectPiiEntitiesCommandCtor;
+    }> {
+        if (this.client && this.commandCtor) {
+            return {
+                client: this.client,
+                commandCtor: this.commandCtor,
+            };
+        }
+
+        const awsComprehend = (await import("@aws-sdk/client-comprehend")) as AwsComprehendModule;
+        return {
+            client: this.client || new awsComprehend.ComprehendClient({
+                region: this.region,
+                credentials: this.credentials,
+            }),
+            commandCtor: this.commandCtor || awsComprehend.DetectPiiEntitiesCommand,
+        };
+    }
+}
+
+export function redactByOffsets(
+    text: string,
+    entities: ComprehendPiiEntity[],
+    mask = "[REDACTED:{type}]"
+): string {
+    return entities
+        .filter(
+            (entity) =>
+                Number.isInteger(entity.BeginOffset) &&
+                Number.isInteger(entity.EndOffset) &&
+                entity.BeginOffset! >= 0 &&
+                entity.EndOffset! > entity.BeginOffset! &&
+                entity.EndOffset! <= text.length
+        )
+        .sort((a, b) => b.BeginOffset! - a.BeginOffset!)
+        .reduce((redactedText, entity) => {
+            const replacement = mask.replace("{type}", entity.Type || "PII");
+            return (
+                redactedText.slice(0, entity.BeginOffset) +
+                replacement +
+                redactedText.slice(entity.EndOffset)
+            );
+        }, text);
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
@@ -93,6 +93,22 @@ describe("redactByOffsets", () => {
         expect(result).toBe("[REDACTED:EMAIL] and [REDACTED:NAME]");
     });
 
+    test("converts Comprehend code point offsets before slicing JavaScript strings", () => {
+        const text = "Lead 😀 contact jane@example.com today";
+        const prefix = "Lead 😀 contact ";
+        const email = "jane@example.com";
+
+        const result = redactByOffsets(text, [
+            {
+                Type: "EMAIL",
+                BeginOffset: Array.from(prefix).length,
+                EndOffset: Array.from(prefix + email).length,
+            },
+        ]);
+
+        expect(result).toBe("Lead 😀 contact [REDACTED:EMAIL] today");
+    });
+
     test("ignores invalid offsets", () => {
         const result = redactByOffsets("safe text", [
             { Type: "EMAIL", BeginOffset: -1, EndOffset: 99 },

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
@@ -1,0 +1,103 @@
+import {
+    AwsComprehendRedactor,
+    ComprehendClientLike,
+    redactByOffsets,
+} from "../lib/aws-comprehend/comprehend";
+
+class MockDetectPiiEntitiesCommand {
+    input: { Text: string; LanguageCode: string };
+
+    constructor(input: { Text: string; LanguageCode: string }) {
+        this.input = input;
+    }
+}
+
+describe("AwsComprehendRedactor", () => {
+    test("redacts PII entities returned by AWS Comprehend offsets", async () => {
+        const client: ComprehendClientLike = {
+            send: jest.fn().mockResolvedValue({
+                Entities: [
+                    { Type: "EMAIL", Score: 0.99, BeginOffset: 18, EndOffset: 34 },
+                    { Type: "PHONE", Score: 0.98, BeginOffset: 39, EndOffset: 51 },
+                ],
+            }),
+        };
+        const redactor = new AwsComprehendRedactor({
+            client,
+            commandCtor: MockDetectPiiEntitiesCommand,
+        });
+
+        const result = await redactor.redactText("Customer contact: jane@example.com and +15551234567");
+
+        expect(result.text).toBe(
+            "Customer contact: [REDACTED:EMAIL] and [REDACTED:PHONE]"
+        );
+        expect(result.entities).toHaveLength(2);
+        expect(client.send).toHaveBeenCalledWith(expect.any(MockDetectPiiEntitiesCommand));
+    });
+
+    test("filters entities by score and type", async () => {
+        const client: ComprehendClientLike = {
+            send: jest.fn().mockResolvedValue({
+                Entities: [
+                    { Type: "EMAIL", Score: 0.99, BeginOffset: 4, EndOffset: 20 },
+                    { Type: "NAME", Score: 0.99, BeginOffset: 24, EndOffset: 35 },
+                    { Type: "PHONE", Score: 0.20, BeginOffset: 42, EndOffset: 54 },
+                ],
+            }),
+        };
+        const redactor = new AwsComprehendRedactor({
+            client,
+            commandCtor: MockDetectPiiEntitiesCommand,
+            entityTypes: ["EMAIL", "PHONE"],
+            minScore: 0.9,
+            mask: "[PRIVATE]",
+        });
+
+        const result = await redactor.redactText("PII jane@example.com for Jane Smith at +15551234567");
+
+        expect(result.text).toBe("PII [PRIVATE] for Jane Smith at +15551234567");
+        expect(result.entities).toEqual([
+            { Type: "EMAIL", Score: 0.99, BeginOffset: 4, EndOffset: 20 },
+        ]);
+    });
+
+    test("redacts chat messages without mutating metadata", async () => {
+        const client: ComprehendClientLike = {
+            send: jest.fn().mockResolvedValue({
+                Entities: [{ Type: "EMAIL", Score: 0.99, BeginOffset: 7, EndOffset: 23 }],
+            }),
+        };
+        const redactor = new AwsComprehendRedactor({
+            client,
+            commandCtor: MockDetectPiiEntitiesCommand,
+        });
+
+        const result = await redactor.redactMessages([
+            { role: "user", name: "customer", content: "Email: jane@example.com" },
+        ]);
+
+        expect(result).toEqual([
+            { role: "user", name: "customer", content: "Email: [REDACTED:EMAIL]" },
+        ]);
+    });
+});
+
+describe("redactByOffsets", () => {
+    test("applies replacements from right to left so offsets remain stable", () => {
+        const result = redactByOffsets("a@example.com and Bob", [
+            { Type: "EMAIL", BeginOffset: 0, EndOffset: 13 },
+            { Type: "NAME", BeginOffset: 18, EndOffset: 21 },
+        ]);
+
+        expect(result).toBe("[REDACTED:EMAIL] and [REDACTED:NAME]");
+    });
+
+    test("ignores invalid offsets", () => {
+        const result = redactByOffsets("safe text", [
+            { Type: "EMAIL", BeginOffset: -1, EndOffset: 99 },
+        ]);
+
+        expect(result).toBe("safe text");
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,26 @@
+# AWS Comprehend redaction example
+
+This example redacts PII from a prompt before sending it to an LLM endpoint.
+
+## Setup
+
+```sh
+npm install
+AWS_REGION=us-east-1 OPENAI_API_KEY=... npm start
+```
+
+The `AwsComprehendRedactor` uses Amazon Comprehend's `DetectPiiEntities` API and replaces detected spans with labels such as `[REDACTED:EMAIL]`.
+
+```ts
+import { AwsComprehendRedactor } from "@arakoodev/edgechains.js/ai";
+
+const redactor = new AwsComprehendRedactor({
+  region: "us-east-1",
+  languageCode: "en",
+  minScore: 0.8,
+});
+
+const prompt = await redactor.redactPrompt(
+  "Contact jane@example.com at +15551234567"
+);
+```

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "aws-comprehend-redaction-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "^0.1.23",
+    "@aws-sdk/client-comprehend": "^3.699.0",
+    "tsx": "^4.19.2"
+  }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,27 @@
+import { AwsComprehendRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+const redactor = new AwsComprehendRedactor({
+    region: process.env.AWS_REGION || "us-east-1",
+    languageCode: "en",
+    minScore: 0.8,
+});
+
+const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    orgId: process.env.OPENAI_ORG_ID,
+});
+
+const prompt =
+    "Summarize this support note without exposing PII: Jane Smith, jane@example.com, called from +15551234567 about invoice INV-123.";
+
+const redactedPrompt = await redactor.redactPrompt(prompt);
+
+const completion = await openai.chat({
+    model: "gpt-3.5-turbo",
+    prompt: redactedPrompt,
+});
+
+console.log({
+    redactedPrompt,
+    completion,
+});


### PR DESCRIPTION
Implements the AWS Comprehend PII redaction utility requested in #290 for the JavaScript SDK.

/claim #290

### What changed

- Added `AwsComprehendRedactor` under the AI package.
- Uses Amazon Comprehend `DetectPiiEntities` to detect PII spans.
- Redacts prompts using stable AWS offsets, including Unicode-safe code point offset conversion for JavaScript strings.
- Supports filtering by entity type and confidence score.
- Adds helpers for prompt strings and chat message arrays.
- Exports the redactor from `@arakoodev/edgechains.js/ai`.
- Adds mocked unit tests for offset redaction, filtering, chat message handling and emoji/code-point offsets.
- Adds a working example under `examples/aws-comprehend-redaction`.

### Verification

```sh
npx jest src/ai/src/tests/awsComprehendRedactor.test.ts --runInBand
npx tsc -p tsconfig.json --noEmit
npx tsc -b
```

Results locally:

- `awsComprehendRedactor.test.ts`: 6 tests passed.
- `tsc --noEmit`: passed.
- `tsc -b`: passed.
- GitHub Actions `js`: passed.
- GitHub Actions `CLAAssistant`: passed.
- `npm run build`: not run successfully on Windows because the existing script uses Unix `rm -rf`.

### Note

The real AWS call requires AWS credentials and region configured in the environment. Tests mock the Comprehend client so CI does not need AWS credentials.