### PR TITLE
Add Qdrant vector database support to JS SDK

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,182 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+interface QdrantClient {
+    http: AxiosInstance;
+}
+
+interface QdrantCreateClientArgs {
+    url?: string;
+    apiKey?: string;
+    axiosConfig?: AxiosRequestConfig;
+}
+
+interface QdrantCreateCollectionArgs {
+    client: QdrantClient;
+    collectionName: string;
+    vectors: Record<string, any> | { size: number; distance: string };
+    [key: string]: any;
+}
+
+interface QdrantInsertVectorDataArgs {
+    client: QdrantClient;
+    collectionName: string;
+    points: Array<Record<string, any>>;
+    wait?: boolean;
+    ordering?: "weak" | "medium" | "strong";
+}
+
+interface QdrantQueryArgs {
+    client: QdrantClient;
+    collectionName: string;
+    query?: number[] | Record<string, any>;
+    vector?: number[] | Record<string, any>;
+    limit?: number;
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[] | Record<string, any>;
+    [key: string]: any;
+}
+
+interface QdrantPointIdArgs {
+    client: QdrantClient;
+    collectionName: string;
+    id: string | number;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL!;
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(args: QdrantCreateClientArgs = {}): QdrantClient {
+        const url = (args.url || this.QDRANT_URL || "").replace(/\/+$/, "");
+        const apiKey = args.apiKey || this.QDRANT_API_KEY;
+        const headers = apiKey ? { "api-key": apiKey } : {};
+
+        return {
+            http: axios.create({
+                baseURL: url,
+                headers,
+                ...args.axiosConfig,
+            }),
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectors,
+        ...args
+    }: QdrantCreateCollectionArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.http.put(`/collections/${collectionName}`, {
+                vectors,
+                ...args,
+            });
+            return response.data;
+        });
+    }
+
+    async insertVectorData({
+        client,
+        collectionName,
+        points,
+        wait = true,
+        ordering,
+    }: QdrantInsertVectorDataArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.http.put(`/collections/${collectionName}/points`, {
+                points,
+                wait,
+                ...(ordering ? { ordering } : {}),
+            });
+            return response.data;
+        });
+    }
+
+    async getDataFromQuery({
+        client,
+        collectionName,
+        query,
+        vector,
+        limit = 10,
+        with_payload = true,
+        with_vector = false,
+        ...args
+    }: QdrantQueryArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.http.post(`/collections/${collectionName}/points/query`, {
+                query: query || vector,
+                limit,
+                with_payload,
+                with_vector,
+                ...args,
+            });
+            return response.data?.result;
+        });
+    }
+
+    async search({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        with_payload = true,
+        with_vector = false,
+        ...args
+    }: QdrantQueryArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.http.post(`/collections/${collectionName}/points/search`, {
+                vector,
+                limit,
+                with_payload,
+                with_vector,
+                ...args,
+            });
+            return response.data?.result;
+        });
+    }
+
+    async getDataById({ client, collectionName, id }: QdrantPointIdArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.http.get(`/collections/${collectionName}/points/${id}`);
+            return response.data?.result;
+        });
+    }
+
+    async deleteById({ client, collectionName, id }: QdrantPointIdArgs): Promise<any> {
+        return this.withRetry(async () => {
+            const response = await client.http.post(`/collections/${collectionName}/points/delete`, {
+                points: [id],
+            });
+            return response.data;
+        });
+    }
+
+    private async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    resolve(await fn());
+                } catch (error: any) {
+                    if (operation.retry(error)) return;
+                    reject(error);
+                }
+            });
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -38,71 +38,61 @@ describe("Qdrant", () => {
         expect(result).toEqual({ result: true });
     });
 
-    test("insertVectorData should upsert Qdrant points", async () => {
-        mockHttp.put.mockResolvedValueOnce({ data: { status: "acknowledged" } });
+    test("insertVectorData should upsert points", async () => {
+        mockHttp.put.mockResolvedValueOnce({ data: { result: { operation_id: 1 } } });
         const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
         const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
+        const points = [{ id: 1, vector: [0.1, 0.2, 0.3], payload: { content: "test" } }];
 
         const result = await qdrant.insertVectorData({
             client,
             collectionName: "documents",
-            points: [
-                {
-                    id: "doc-1",
-                    vector: [0.1, 0.2, 0.3],
-                    payload: { text: "hello" },
-                },
-            ],
+            points,
         });
 
         expect(mockHttp.put).toHaveBeenCalledWith("/collections/documents/points", {
-            points: [
-                {
-                    id: "doc-1",
-                    vector: [0.1, 0.2, 0.3],
-                    payload: { text: "hello" },
-                },
-            ],
+            points,
+            wait: true,
         });
-        expect(result).toEqual({ status: "acknowledged" });
+        expect(result).toEqual({ result: { operation_id: 1 } });
     });
 
-    test("getDataFromQuery should search the collection", async () => {
-        mockHttp.post.mockResolvedValueOnce({ data: { result: [{ id: "doc-1" }] } });
+    test("getDataFromQuery should query nearest points", async () => {
+        const points = [{ id: 1, score: 0.99, payload: { content: "test" } }];
+        mockHttp.post.mockResolvedValueOnce({ data: { result: { points } } });
         const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
         const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
 
         const result = await qdrant.getDataFromQuery({
             client,
             collectionName: "documents",
-            vector: [0.1, 0.2, 0.3],
-            limit: 2,
-            withPayload: true,
+            query: [0.1, 0.2, 0.3],
+            limit: 1,
         });
 
-        expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/search", {
-            vector: [0.1, 0.2, 0.3],
-            limit: 2,
+        expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/query", {
+            query: [0.1, 0.2, 0.3],
+            limit: 1,
             with_payload: true,
             with_vector: false,
         });
-        expect(result).toEqual({ result: [{ id: "doc-1" }] });
+        expect(result).toEqual({ points });
     });
 
     test("deleteById should delete a point by id", async () => {
-        mockHttp.post.mockResolvedValueOnce({ data: { result: true } });
+        mockHttp.post.mockResolvedValueOnce({ data: { result: { operation_id: 2 } } });
         const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
         const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
 
         const result = await qdrant.deleteById({
             client,
             collectionName: "documents",
-            id: "doc-1",
+            id: 1,
         });
 
         expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/delete", {
-            points: ["doc-1"],
+            points: [1],
         });
-        expect(result).toEqual({ result: true });
+        expect(result).toEqual({ result: { operation_id: 2 } });
     });
 });

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
 
 describe("Qdrant", () => {
     const mockHttp = {
@@ -38,61 +38,71 @@ describe("Qdrant", () => {
         expect(result).toEqual({ result: true });
     });
 
-    test("insertVectorData should upsert points", async () => {
-        mockHttp.put.mockResolvedValueOnce({ data: { result: { operation_id: 1 } } });
+    test("insertVectorData should upsert Qdrant points", async () => {
+        mockHttp.put.mockResolvedValueOnce({ data: { status: "acknowledged" } });
         const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
         const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
-        const points = [{ id: 1, vector: [0.1, 0.2, 0.3], payload: { content: "test" } }];
 
         const result = await qdrant.insertVectorData({
             client,
             collectionName: "documents",
-            points,
+            points: [
+                {
+                    id: "doc-1",
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { text: "hello" },
+                },
+            ],
         });
 
         expect(mockHttp.put).toHaveBeenCalledWith("/collections/documents/points", {
-            points,
-            wait: true,
+            points: [
+                {
+                    id: "doc-1",
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { text: "hello" },
+                },
+            ],
         });
-        expect(result).toEqual({ result: { operation_id: 1 } });
+        expect(result).toEqual({ status: "acknowledged" });
     });
 
-    test("getDataFromQuery should query nearest points", async () => {
-        const points = [{ id: 1, score: 0.99, payload: { content: "test" } }];
-        mockHttp.post.mockResolvedValueOnce({ data: { result: { points } } });
+    test("getDataFromQuery should search the collection", async () => {
+        mockHttp.post.mockResolvedValueOnce({ data: { result: [{ id: "doc-1" }] } });
         const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
         const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
 
         const result = await qdrant.getDataFromQuery({
             client,
             collectionName: "documents",
-            query: [0.1, 0.2, 0.3],
-            limit: 1,
+            vector: [0.1, 0.2, 0.3],
+            limit: 2,
+            withPayload: true,
         });
 
-        expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/query", {
-            query: [0.1, 0.2, 0.3],
-            limit: 1,
+        expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/search", {
+            vector: [0.1, 0.2, 0.3],
+            limit: 2,
             with_payload: true,
             with_vector: false,
         });
-        expect(result).toEqual({ points });
+        expect(result).toEqual({ result: [{ id: "doc-1" }] });
     });
 
     test("deleteById should delete a point by id", async () => {
-        mockHttp.post.mockResolvedValueOnce({ data: { result: { operation_id: 2 } } });
+        mockHttp.post.mockResolvedValueOnce({ data: { result: true } });
         const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
         const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
 
         const result = await qdrant.deleteById({
             client,
             collectionName: "documents",
-            id: 1,
+            id: "doc-1",
         });
 
         expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/delete", {
-            points: [1],
+            points: ["doc-1"],
         });
-        expect(result).toEqual({ result: { operation_id: 2 } });
+        expect(result).toEqual({ result: true });
     });
 });

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,98 @@
+import axios from "axios";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+describe("Qdrant", () => {
+    const mockHttp = {
+        put: vi.fn(),
+        post: vi.fn(),
+        get: vi.fn(),
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test("createClient should configure base URL and API key", () => {
+        const qdrant = new Qdrant("https://example-qdrant.com/", "test-api-key");
+        const client = qdrant.createClient();
+
+        expect(client.http.defaults.baseURL).toBe("https://example-qdrant.com");
+        expect(client.http.defaults.headers["api-key"]).toBe("test-api-key");
+    });
+
+    test("createCollection should call Qdrant collection API", async () => {
+        mockHttp.put.mockResolvedValueOnce({ data: { result: true } });
+        const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
+        const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
+
+        const result = await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectors: { size: 3, distance: "Cosine" },
+        });
+
+        expect(mockHttp.put).toHaveBeenCalledWith("/collections/documents", {
+            vectors: { size: 3, distance: "Cosine" },
+        });
+        expect(result).toEqual({ result: true });
+    });
+
+    test("insertVectorData should upsert points", async () => {
+        mockHttp.put.mockResolvedValueOnce({ data: { result: { operation_id: 1 } } });
+        const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
+        const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
+        const points = [{ id: 1, vector: [0.1, 0.2, 0.3], payload: { content: "test" } }];
+
+        const result = await qdrant.insertVectorData({
+            client,
+            collectionName: "documents",
+            points,
+        });
+
+        expect(mockHttp.put).toHaveBeenCalledWith("/collections/documents/points", {
+            points,
+            wait: true,
+        });
+        expect(result).toEqual({ result: { operation_id: 1 } });
+    });
+
+    test("getDataFromQuery should query nearest points", async () => {
+        const points = [{ id: 1, score: 0.99, payload: { content: "test" } }];
+        mockHttp.post.mockResolvedValueOnce({ data: { result: { points } } });
+        const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
+        const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
+
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "documents",
+            query: [0.1, 0.2, 0.3],
+            limit: 1,
+        });
+
+        expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/query", {
+            query: [0.1, 0.2, 0.3],
+            limit: 1,
+            with_payload: true,
+            with_vector: false,
+        });
+        expect(result).toEqual({ points });
+    });
+
+    test("deleteById should delete a point by id", async () => {
+        mockHttp.post.mockResolvedValueOnce({ data: { result: { operation_id: 2 } } });
+        const qdrant = new Qdrant("https://example-qdrant.com", "test-api-key");
+        const client = { http: mockHttp as unknown as ReturnType<typeof axios.create> };
+
+        const result = await qdrant.deleteById({
+            client,
+            collectionName: "documents",
+            id: 1,
+        });
+
+        expect(mockHttp.post).toHaveBeenCalledWith("/collections/documents/points/delete", {
+            points: [1],
+        });
+        expect(result).toEqual({ result: { operation_id: 2 } });
+    });
+});

--- a/JS/edgechains/examples/qdrant/package.json
+++ b/JS/edgechains/examples/qdrant/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "qdrant-vector-search",
+    "type": "module",
+    "scripts": {
+        "dev": "ts-node src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "^0.1.23",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/qdrant/src/index.ts
+++ b/JS/edgechains/examples/qdrant/src/index.ts
@@ -1,0 +1,35 @@
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY);
+const client = qdrant.createClient();
+
+async function main() {
+    await qdrant.createCollection({
+        client,
+        collectionName: "documents",
+        vectors: { size: 3, distance: "Cosine" },
+    });
+
+    await qdrant.insertVectorData({
+        client,
+        collectionName: "documents",
+        points: [
+            {
+                id: 1,
+                vector: [0.1, 0.2, 0.3],
+                payload: { content: "Qdrant works with EdgeChains" },
+            },
+        ],
+    });
+
+    const result = await qdrant.getDataFromQuery({
+        client,
+        collectionName: "documents",
+        query: [0.1, 0.2, 0.3],
+        limit: 1,
+    });
+
+    console.log(result);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- adds a Qdrant vector database client for collection, point upsert, query/search, get-by-id, and delete operations
- exports Qdrant from the vector-db package entrypoint
- adds a minimal Qdrant example and unit coverage for core API requests

## Tests
- npm run build
- npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts

Fixes #273
