### PR TITLE
Add AWS Comprehend PII redactor

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,25 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+  AWSComprehendPIIRedactor,
+  AWSComprehendRedactor,
+  AWSComprehendRestClient,
+} from "./lib/aws-comprehend/aws-comprehend-redactor.js";
+export type {
+  AWSCredentials,
+  AWSComprehendChatEndpoint,
+  AWSComprehendChatOptions,
+  AWSComprehendMessage,
+  AWSComprehendPiiClient,
+  AWSComprehendPiiDetectionRequest,
+  AWSComprehendPiiDetectionResponse,
+  AWSComprehendPiiEntity,
+  AWSComprehendPiiEntityType,
+  AWSComprehendRedactedEntity,
+  AWSComprehendRedactionOptions,
+  AWSComprehendRedactionResult,
+  AWSComprehendRedactorOptions,
+  AWSComprehendReplacement,
+  AWSComprehendRestClientOptions,
+} from "./lib/aws-comprehend/aws-comprehend-redactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/aws-comprehend-redactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/aws-comprehend-redactor.ts
@@ -1,0 +1,592 @@
+import axios from "axios";
+import { createHash, createHmac } from "node:crypto";
+
+type HeaderMap = Record<string, string>;
+
+interface HttpClient {
+  post(
+    url: string,
+    data?: string,
+    config?: { headers: HeaderMap },
+  ): Promise<{ data: AWSComprehendPiiDetectionResponse }>;
+}
+
+export type AWSComprehendPiiEntityType =
+  | "ADDRESS"
+  | "AGE"
+  | "AWS_ACCESS_KEY"
+  | "AWS_SECRET_KEY"
+  | "BANK_ACCOUNT_NUMBER"
+  | "BANK_ROUTING"
+  | "CREDIT_DEBIT_CVV"
+  | "CREDIT_DEBIT_EXPIRY"
+  | "CREDIT_DEBIT_NUMBER"
+  | "DATE_TIME"
+  | "DRIVER_ID"
+  | "EMAIL"
+  | "IP_ADDRESS"
+  | "MAC_ADDRESS"
+  | "NAME"
+  | "PASSWORD"
+  | "PHONE"
+  | "PIN"
+  | "SSN"
+  | "URL"
+  | "USERNAME"
+  | string;
+
+export interface AWSComprehendPiiEntity {
+  Type: AWSComprehendPiiEntityType;
+  Score: number;
+  BeginOffset: number;
+  EndOffset: number;
+}
+
+export interface AWSComprehendPiiDetectionRequest {
+  Text: string;
+  LanguageCode?: string;
+}
+
+export interface AWSComprehendPiiDetectionResponse {
+  Entities?: AWSComprehendPiiEntity[];
+}
+
+export interface AWSComprehendPiiClient {
+  detectPiiEntities(
+    input: AWSComprehendPiiDetectionRequest,
+  ): Promise<AWSComprehendPiiDetectionResponse>;
+}
+
+export interface AWSCredentials {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+}
+
+export interface AWSComprehendRestClientOptions extends AWSCredentials {
+  region?: string;
+  httpClient?: HttpClient;
+  now?: () => Date;
+}
+
+export interface AWSComprehendRedactedEntity extends AWSComprehendPiiEntity {
+  Text: string;
+  Replacement: string;
+}
+
+export interface AWSComprehendRedactionResult {
+  originalText: string;
+  redactedText: string;
+  entities: AWSComprehendRedactedEntity[];
+}
+
+export type AWSComprehendReplacement =
+  | string
+  | ((entity: AWSComprehendRedactedEntity) => string);
+
+export interface AWSComprehendRedactionOptions {
+  languageCode?: string;
+  minScore?: number;
+  redactTypes?: AWSComprehendPiiEntityType[];
+  replacement?: AWSComprehendReplacement;
+}
+
+export interface AWSComprehendRedactorOptions
+  extends AWSComprehendRestClientOptions, AWSComprehendRedactionOptions {
+  client?: AWSComprehendPiiClient;
+}
+
+export interface AWSComprehendMessage {
+  content?: string;
+  [key: string]: unknown;
+}
+
+export interface AWSComprehendChatOptions {
+  prompt?: string;
+  messages?: AWSComprehendMessage[];
+  [key: string]: unknown;
+}
+
+export interface AWSComprehendChatEndpoint {
+  chat(options: AWSComprehendChatOptions): Promise<unknown>;
+}
+
+interface NormalizedRedactionOptions {
+  languageCode: string;
+  minScore: number;
+  redactTypes?: AWSComprehendPiiEntityType[];
+  replacement?: AWSComprehendReplacement;
+}
+
+interface RedactionSpan {
+  begin: number;
+  end: number;
+  entity: AWSComprehendRedactedEntity;
+}
+
+export class AWSComprehendRestClient implements AWSComprehendPiiClient {
+  private readonly region: string;
+  private readonly endpoint: string;
+  private readonly httpClient: HttpClient;
+  private readonly now: () => Date;
+  private readonly accessKeyId?: string;
+  private readonly secretAccessKey?: string;
+  private readonly sessionToken?: string;
+
+  constructor(options: AWSComprehendRestClientOptions = {}) {
+    this.region =
+      options.region ||
+      process.env.AWS_REGION ||
+      process.env.AWS_DEFAULT_REGION ||
+      "us-east-1";
+    this.endpoint = `https://comprehend.${this.region}.amazonaws.com/`;
+    this.httpClient = options.httpClient || (axios as HttpClient);
+    this.now = options.now || (() => new Date());
+    this.accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
+    this.secretAccessKey =
+      options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
+    this.sessionToken = options.sessionToken || process.env.AWS_SESSION_TOKEN;
+  }
+
+  async detectPiiEntities(
+    input: AWSComprehendPiiDetectionRequest,
+  ): Promise<AWSComprehendPiiDetectionResponse> {
+    if (!input.Text) {
+      return { Entities: [] };
+    }
+
+    const credentials = this.resolveCredentials();
+    const payload = JSON.stringify({
+      Text: input.Text,
+      LanguageCode: input.LanguageCode || "en",
+    });
+    const headers = this.createSignedHeaders(payload, credentials);
+    const response = await this.httpClient.post(this.endpoint, payload, {
+      headers,
+    });
+    return response.data;
+  }
+
+  private resolveCredentials(): Required<
+    Pick<AWSCredentials, "accessKeyId" | "secretAccessKey">
+  > &
+    Pick<AWSCredentials, "sessionToken"> {
+    if (!this.accessKeyId || !this.secretAccessKey) {
+      throw new Error(
+        "AWS credentials are required to call Comprehend. Provide accessKeyId/secretAccessKey or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.",
+      );
+    }
+
+    return {
+      accessKeyId: this.accessKeyId,
+      secretAccessKey: this.secretAccessKey,
+      sessionToken: this.sessionToken,
+    };
+  }
+
+  private createSignedHeaders(
+    payload: string,
+    credentials: Required<
+      Pick<AWSCredentials, "accessKeyId" | "secretAccessKey">
+    > &
+      Pick<AWSCredentials, "sessionToken">,
+  ): HeaderMap {
+    const date = this.now();
+    const amzDate = toAmzDate(date);
+    const dateStamp = amzDate.slice(0, 8);
+    const host = `comprehend.${this.region}.amazonaws.com`;
+    const service = "comprehend";
+
+    const headers: HeaderMap = {
+      "content-type": "application/x-amz-json-1.1",
+      host,
+      "x-amz-date": amzDate,
+      "x-amz-target": "Comprehend_20171127.DetectPiiEntities",
+    };
+
+    if (credentials.sessionToken) {
+      headers["x-amz-security-token"] = credentials.sessionToken;
+    }
+
+    const sortedHeaderNames = Object.keys(headers).sort();
+    const canonicalHeaders = sortedHeaderNames
+      .map((name) => `${name}:${headers[name].trim()}\n`)
+      .join("");
+    const signedHeaders = sortedHeaderNames.join(";");
+    const canonicalRequest = [
+      "POST",
+      "/",
+      "",
+      canonicalHeaders,
+      signedHeaders,
+      sha256Hex(payload),
+    ].join("\n");
+    const credentialScope = `${dateStamp}/${this.region}/${service}/aws4_request`;
+    const stringToSign = [
+      "AWS4-HMAC-SHA256",
+      amzDate,
+      credentialScope,
+      sha256Hex(canonicalRequest),
+    ].join("\n");
+    const signingKey = getSignatureKey(
+      credentials.secretAccessKey,
+      dateStamp,
+      this.region,
+      service,
+    );
+    const signature = createHmac("sha256", signingKey)
+      .update(stringToSign, "utf8")
+      .digest("hex");
+
+    return {
+      ...headers,
+      Authorization: `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    };
+  }
+}
+
+export class AWSComprehendRedactor {
+  private readonly client: AWSComprehendPiiClient;
+  private readonly defaults: NormalizedRedactionOptions;
+
+  constructor(options: AWSComprehendRedactorOptions = {}) {
+    const {
+      client,
+      languageCode,
+      minScore,
+      redactTypes,
+      replacement,
+      ...restClientOptions
+    } = options;
+
+    this.client = client || new AWSComprehendRestClient(restClientOptions);
+    this.defaults = {
+      languageCode: languageCode || "en",
+      minScore: minScore ?? 0.5,
+      redactTypes,
+      replacement,
+    };
+  }
+
+  async detectPii(
+    text: string,
+    options: AWSComprehendRedactionOptions = {},
+  ): Promise<AWSComprehendPiiEntity[]> {
+    if (!text) {
+      return [];
+    }
+
+    const mergedOptions = this.mergeOptions(options);
+    const response = await this.client.detectPiiEntities({
+      Text: text,
+      LanguageCode: mergedOptions.languageCode,
+    });
+    return response.Entities || [];
+  }
+
+  async redact(
+    text: string,
+    options: AWSComprehendRedactionOptions = {},
+  ): Promise<string> {
+    const result = await this.redactText(text, options);
+    return result.redactedText;
+  }
+
+  async redactText(
+    text: string,
+    options: AWSComprehendRedactionOptions = {},
+  ): Promise<AWSComprehendRedactionResult> {
+    if (!text) {
+      return { originalText: text, redactedText: text, entities: [] };
+    }
+
+    const mergedOptions = this.mergeOptions(options);
+    const detectedEntities = await this.detectPii(text, mergedOptions);
+    const spans = this.createRedactionSpans(
+      text,
+      detectedEntities,
+      mergedOptions,
+    );
+    let redactedText = text;
+
+    for (const span of spans.slice().reverse()) {
+      redactedText =
+        redactedText.slice(0, span.begin) +
+        span.entity.Replacement +
+        redactedText.slice(span.end);
+    }
+
+    return {
+      originalText: text,
+      redactedText,
+      entities: spans.map((span) => span.entity),
+    };
+  }
+
+  async redactPrompt(
+    prompt: string,
+    options: AWSComprehendRedactionOptions = {},
+  ): Promise<string> {
+    return this.redact(prompt, options);
+  }
+
+  async redactMessages<TMessage extends AWSComprehendMessage>(
+    messages: TMessage[],
+    options: AWSComprehendRedactionOptions = {},
+  ): Promise<TMessage[]> {
+    const redactedMessages: TMessage[] = [];
+
+    for (const message of messages) {
+      if (typeof message.content === "string") {
+        redactedMessages.push({
+          ...message,
+          content: await this.redact(message.content, options),
+        });
+      } else {
+        redactedMessages.push({ ...message });
+      }
+    }
+
+    return redactedMessages;
+  }
+
+  async redactChatOptions<TOptions extends AWSComprehendChatOptions>(
+    chatOptions: TOptions,
+    options: AWSComprehendRedactionOptions = {},
+  ): Promise<TOptions> {
+    const nextOptions: AWSComprehendChatOptions = { ...chatOptions };
+
+    if (typeof chatOptions.prompt === "string") {
+      nextOptions.prompt = await this.redact(chatOptions.prompt, options);
+    }
+
+    if (Array.isArray(chatOptions.messages)) {
+      nextOptions.messages = await this.redactMessages(
+        chatOptions.messages,
+        options,
+      );
+    }
+
+    return nextOptions as TOptions;
+  }
+
+  async chain<TResult>(
+    prompt: string,
+    next: (
+      redactedPrompt: string,
+      result: AWSComprehendRedactionResult,
+    ) => TResult | Promise<TResult>,
+    options: AWSComprehendRedactionOptions = {},
+  ): Promise<TResult> {
+    const result = await this.redactText(prompt, options);
+    return next(result.redactedText, result);
+  }
+
+  chainEndpoint<TEndpoint extends AWSComprehendChatEndpoint>(
+    endpoint: TEndpoint,
+    options: AWSComprehendRedactionOptions = {},
+  ): TEndpoint {
+    const redactor = this;
+
+    return new Proxy(endpoint, {
+      get(target, property, receiver) {
+        if (property === "chat") {
+          return async (chatOptions: AWSComprehendChatOptions) => {
+            const redactedOptions = await redactor.redactChatOptions(
+              chatOptions,
+              options,
+            );
+            return target.chat(redactedOptions);
+          };
+        }
+
+        return Reflect.get(target, property, receiver);
+      },
+    }) as TEndpoint;
+  }
+
+  wrapEndpoint<TEndpoint extends AWSComprehendChatEndpoint>(
+    endpoint: TEndpoint,
+    options: AWSComprehendRedactionOptions = {},
+  ): TEndpoint {
+    return this.chainEndpoint(endpoint, options);
+  }
+
+  async *redactStream(
+    source: AsyncIterable<string> | Iterable<string>,
+    options: AWSComprehendRedactionOptions = {},
+  ): AsyncGenerator<string> {
+    for await (const chunk of source) {
+      yield await this.redact(chunk, options);
+    }
+  }
+
+  textOperator(
+    options: AWSComprehendRedactionOptions = {},
+  ): (value: string) => Promise<string> {
+    return (value: string) => this.redact(value, options);
+  }
+
+  chatOptionsOperator<TOptions extends AWSComprehendChatOptions>(
+    options: AWSComprehendRedactionOptions = {},
+  ): (value: TOptions) => Promise<TOptions> {
+    return (value: TOptions) => this.redactChatOptions(value, options);
+  }
+
+  streamOperator(
+    options: AWSComprehendRedactionOptions = {},
+  ): (
+    source: AsyncIterable<string> | Iterable<string>,
+  ) => AsyncGenerator<string> {
+    return (source: AsyncIterable<string> | Iterable<string>) =>
+      this.redactStream(source, options);
+  }
+
+  private mergeOptions(
+    options: AWSComprehendRedactionOptions,
+  ): NormalizedRedactionOptions {
+    return {
+      languageCode: options.languageCode || this.defaults.languageCode,
+      minScore: options.minScore ?? this.defaults.minScore,
+      redactTypes: options.redactTypes || this.defaults.redactTypes,
+      replacement: options.replacement ?? this.defaults.replacement,
+    };
+  }
+
+  private createRedactionSpans(
+    text: string,
+    entities: AWSComprehendPiiEntity[],
+    options: NormalizedRedactionOptions,
+  ): RedactionSpan[] {
+    const spans = entities
+      .filter((entity) => this.shouldRedact(entity, options))
+      .map((entity) => this.toRedactionSpan(text, entity, options))
+      .filter((span): span is RedactionSpan => Boolean(span))
+      .sort(
+        (left, right) =>
+          left.begin - right.begin ||
+          right.end - left.end ||
+          right.entity.Score - left.entity.Score,
+      );
+    const acceptedSpans: RedactionSpan[] = [];
+    let lastEnd = -1;
+
+    for (const span of spans) {
+      if (span.begin < lastEnd) {
+        continue;
+      }
+
+      acceptedSpans.push(span);
+      lastEnd = span.end;
+    }
+
+    return acceptedSpans;
+  }
+
+  private toRedactionSpan(
+    text: string,
+    entity: AWSComprehendPiiEntity,
+    options: NormalizedRedactionOptions,
+  ): RedactionSpan | undefined {
+    const begin = codePointOffsetToCodeUnitIndex(text, entity.BeginOffset);
+    const end = codePointOffsetToCodeUnitIndex(text, entity.EndOffset);
+
+    if (begin < 0 || end > text.length || begin >= end) {
+      return undefined;
+    }
+
+    const redactedEntity: AWSComprehendRedactedEntity = {
+      ...entity,
+      Text: text.slice(begin, end),
+      Replacement: "",
+    };
+    redactedEntity.Replacement = this.replacementFor(redactedEntity, options);
+
+    return {
+      begin,
+      end,
+      entity: redactedEntity,
+    };
+  }
+
+  private shouldRedact(
+    entity: AWSComprehendPiiEntity,
+    options: NormalizedRedactionOptions,
+  ): boolean {
+    if ((entity.Score ?? 0) < options.minScore) {
+      return false;
+    }
+
+    if (!options.redactTypes?.length) {
+      return true;
+    }
+
+    const allowedTypes = new Set(
+      options.redactTypes.map((type) => type.toUpperCase()),
+    );
+    return (
+      allowedTypes.has("ALL") || allowedTypes.has(entity.Type.toUpperCase())
+    );
+  }
+
+  private replacementFor(
+    entity: AWSComprehendRedactedEntity,
+    options: NormalizedRedactionOptions,
+  ): string {
+    if (typeof options.replacement === "function") {
+      return options.replacement(entity);
+    }
+
+    if (typeof options.replacement === "string") {
+      return options.replacement.replace("{type}", entity.Type);
+    }
+
+    return `[REDACTED_${entity.Type}]`;
+  }
+}
+
+export class AWSComprehendPIIRedactor extends AWSComprehendRedactor {}
+
+function codePointOffsetToCodeUnitIndex(input: string, offset: number): number {
+  if (offset <= 0) {
+    return 0;
+  }
+
+  let codePointIndex = 0;
+
+  for (let codeUnitIndex = 0; codeUnitIndex < input.length; ) {
+    if (codePointIndex === offset) {
+      return codeUnitIndex;
+    }
+
+    const codePoint = input.codePointAt(codeUnitIndex);
+    codeUnitIndex += codePoint && codePoint > 0xffff ? 2 : 1;
+    codePointIndex += 1;
+  }
+
+  return input.length;
+}
+
+function toAmzDate(date: Date): string {
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function hmac(key: string | Buffer, value: string): Buffer {
+  return createHmac("sha256", key).update(value, "utf8").digest();
+}
+
+function getSignatureKey(
+  secretAccessKey: string,
+  dateStamp: string,
+  region: string,
+  service: string,
+) {
+  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const dateRegionKey = hmac(dateKey, region);
+  const dateRegionServiceKey = hmac(dateRegionKey, service);
+  return hmac(dateRegionServiceKey, "aws4_request");
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehendRedactor.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AWSComprehendPiiClient,
+  AWSComprehendPiiEntity,
+  AWSComprehendPiiEntityType,
+  AWSComprehendRedactor,
+} from "../lib/aws-comprehend/aws-comprehend-redactor.js";
+
+describe("AWSComprehendRedactor", () => {
+  it("redacts detected entities and returns useful metadata", async () => {
+    const text = "Email jane@example.com or call 555-0100.";
+    const client = mockClient([
+      entityFor(text, "jane@example.com", "EMAIL"),
+      entityFor(text, "555-0100", "PHONE"),
+    ]);
+    const redactor = new AWSComprehendRedactor({ client });
+
+    const result = await redactor.redactText(text);
+
+    expect(result.redactedText).toBe(
+      "Email [REDACTED_EMAIL] or call [REDACTED_PHONE].",
+    );
+    expect(result.entities).toMatchObject([
+      {
+        Type: "EMAIL",
+        Text: "jane@example.com",
+        Replacement: "[REDACTED_EMAIL]",
+      },
+      { Type: "PHONE", Text: "555-0100", Replacement: "[REDACTED_PHONE]" },
+    ]);
+    expect(client.detectPiiEntities).toHaveBeenCalledWith({
+      Text: text,
+      LanguageCode: "en",
+    });
+  });
+
+  it("filters by confidence and PII type", async () => {
+    const text = "Jane can be reached at jane@example.com.";
+    const client = mockClient([
+      entityFor(text, "Jane", "NAME", 0.99),
+      entityFor(text, "jane@example.com", "EMAIL", 0.93),
+      entityFor(text, "Jane", "USERNAME", 0.2),
+    ]);
+    const redactor = new AWSComprehendRedactor({
+      client,
+      minScore: 0.9,
+      redactTypes: ["EMAIL"],
+    });
+
+    await expect(redactor.redact(text)).resolves.toBe(
+      "Jane can be reached at [REDACTED_EMAIL].",
+    );
+  });
+
+  it("handles Comprehend code point offsets without corrupting unicode text", async () => {
+    const text = "Customer 😀 Ada uses ada@example.com.";
+    const client = mockClient([entityFor(text, "ada@example.com", "EMAIL")]);
+    const redactor = new AWSComprehendRedactor({ client });
+
+    await expect(redactor.redact(text)).resolves.toBe(
+      "Customer 😀 Ada uses [REDACTED_EMAIL].",
+    );
+  });
+
+  it("skips overlapping spans so redaction does not rewrite generated replacements", async () => {
+    const text = "SSN 123-45-6789 was provided.";
+    const client = mockClient([
+      entityFor(text, "123-45-6789", "SSN", 0.98),
+      entityFor(text, "123-45", "PIN", 0.99),
+    ]);
+    const redactor = new AWSComprehendRedactor({ client });
+
+    const result = await redactor.redactText(text);
+
+    expect(result.redactedText).toBe("SSN [REDACTED_SSN] was provided.");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].Type).toBe("SSN");
+  });
+
+  it("redacts prompt and message chat options before endpoint calls", async () => {
+    const text = "Contact jane@example.com";
+    const client = mockClient([entityFor(text, "jane@example.com", "EMAIL")]);
+    const redactor = new AWSComprehendRedactor({ client });
+    const endpoint = {
+      model: "demo",
+      chat: vi.fn().mockResolvedValue({ content: "ok" }),
+    };
+
+    const wrappedEndpoint = redactor.chainEndpoint(endpoint);
+    const result = await wrappedEndpoint.chat({
+      prompt: text,
+      messages: [{ role: "user", content: text }],
+    });
+
+    expect(result).toEqual({ content: "ok" });
+    expect(wrappedEndpoint.model).toBe("demo");
+    expect(endpoint.chat).toHaveBeenCalledWith({
+      prompt: "Contact [REDACTED_EMAIL]",
+      messages: [{ role: "user", content: "Contact [REDACTED_EMAIL]" }],
+    });
+  });
+
+  it("exposes stream and function operators for observable-style chains", async () => {
+    const text = "Send the update to jane@example.com";
+    const client = mockClient([entityFor(text, "jane@example.com", "EMAIL")]);
+    const redactor = new AWSComprehendRedactor({ client });
+    const output: string[] = [];
+
+    for await (const chunk of redactor.streamOperator()([text])) {
+      output.push(chunk);
+    }
+
+    await expect(redactor.textOperator()(text)).resolves.toBe(
+      "Send the update to [REDACTED_EMAIL]",
+    );
+    expect(output).toEqual(["Send the update to [REDACTED_EMAIL]"]);
+  });
+
+  it("allows custom replacement templates and functions", async () => {
+    const text = "The account is 123456789.";
+    const client = mockClient([
+      entityFor(text, "123456789", "BANK_ACCOUNT_NUMBER"),
+    ]);
+    const redactor = new AWSComprehendRedactor({
+      client,
+      replacement: "<{type}>",
+    });
+
+    await expect(redactor.redact(text)).resolves.toBe(
+      "The account is <BANK_ACCOUNT_NUMBER>.",
+    );
+    await expect(
+      redactor.redact(text, {
+        replacement: (entity) => `***${entity.Text.length}:${entity.Type}***`,
+      }),
+    ).resolves.toBe("The account is ***9:BANK_ACCOUNT_NUMBER***.");
+  });
+});
+
+function mockClient(entities: AWSComprehendPiiEntity[]) {
+  return {
+    detectPiiEntities: vi.fn().mockResolvedValue({ Entities: entities }),
+  } as unknown as AWSComprehendPiiClient & {
+    detectPiiEntities: ReturnType<typeof vi.fn>;
+  };
+}
+
+function entityFor(
+  text: string,
+  snippet: string,
+  type: AWSComprehendPiiEntityType,
+  score = 0.99,
+): AWSComprehendPiiEntity {
+  const start = text.indexOf(snippet);
+
+  if (start < 0) {
+    throw new Error(`Snippet not found: ${snippet}`);
+  }
+
+  const beginOffset = Array.from(text.slice(0, start)).length;
+  const endOffset = beginOffset + Array.from(snippet).length;
+
+  return {
+    Type: type,
+    Score: score,
+    BeginOffset: beginOffset,
+    EndOffset: endOffset,
+  };
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/.gitignore
+++ b/JS/edgechains/examples/aws-comprehend-redaction/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aws-comprehend-redaction",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsc && node ./dist/index.js"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "typescript": "^5.7.0-dev.20241007"
+  }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/readme.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/readme.md
@@ -1,0 +1,12 @@
+# AWS Comprehend redaction example
+
+This example shows how to redact PII from prompts before they are sent to an endpoint-style chat class.
+
+Run the local demo without AWS credentials:
+
+```bash
+npm install
+npm start
+```
+
+The demo uses a mock Comprehend client so it is deterministic. To make a live AWS Comprehend request, set `USE_LIVE_AWS_COMPREHEND=true` along with `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`.

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,77 @@
+import {
+  AWSComprehendPiiClient,
+  AWSComprehendPiiEntity,
+  AWSComprehendRedactor,
+} from "@arakoodev/edgechains.js/ai";
+
+const prompt =
+  "My name is Jane Doe. Email me at jane@example.com and call 555-0100 about invoice INV-42.";
+
+const demoClient: AWSComprehendPiiClient = {
+  async detectPiiEntities({ Text }) {
+    return {
+      Entities: [
+        entityFor(Text, "Jane Doe", "NAME"),
+        entityFor(Text, "jane@example.com", "EMAIL"),
+        entityFor(Text, "555-0100", "PHONE"),
+      ],
+    };
+  },
+};
+
+const chatEndpoint = {
+  async chat({ prompt: redactedPrompt }: { prompt?: string }) {
+    return {
+      content: `Prompt received by endpoint: ${redactedPrompt}`,
+    };
+  },
+};
+
+const redactor = new AWSComprehendRedactor({ client: demoClient });
+const redactedPrompt = await redactor.redact(prompt);
+const protectedEndpoint = redactor.chainEndpoint(chatEndpoint);
+const response = await protectedEndpoint.chat({ prompt });
+
+console.log("Original prompt:");
+console.log(prompt);
+console.log("\nRedacted prompt:");
+console.log(redactedPrompt);
+console.log("\nEndpoint response:");
+console.log(response.content);
+
+const streamOutput: string[] = [];
+for await (const chunk of redactor.redactStream([prompt])) {
+  streamOutput.push(chunk);
+}
+console.log("\nStream output:");
+console.log(streamOutput.join("\n"));
+
+if (process.env.USE_LIVE_AWS_COMPREHEND === "true") {
+  const liveRedactor = new AWSComprehendRedactor({
+    region: process.env.AWS_REGION || "us-east-1",
+  });
+  console.log("\nLive AWS Comprehend redaction:");
+  console.log(await liveRedactor.redact(prompt));
+}
+
+function entityFor(
+  text: string,
+  snippet: string,
+  type: string,
+): AWSComprehendPiiEntity {
+  const start = text.indexOf(snippet);
+
+  if (start < 0) {
+    throw new Error(`Snippet not found: ${snippet}`);
+  }
+
+  const beginOffset = Array.from(text.slice(0, start)).length;
+  const endOffset = beginOffset + Array.from(snippet).length;
+
+  return {
+    Type: type,
+    Score: 0.99,
+    BeginOffset: beginOffset,
+    EndOffset: endOffset,
+  };
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
/claim #290

## Summary

- Add `AWSComprehendRedactor`, `AWSComprehendPIIRedactor`, and `AWSComprehendRestClient` exports from the JS SDK AI package.
- Support direct text redaction, prompt/message redaction, endpoint `chat()` wrapping, and stream/operator helpers for observable-style chains.
- Use an injectable Comprehend-compatible client for tests and a dependency-free SigV4 REST client for live AWS Comprehend calls.
- Add a runnable example under `JS/edgechains/examples/aws-comprehend-redaction` that works without AWS credentials by using a deterministic mock client.

## Requirement Checklist

- JavaScript SDK only: yes
- New chainable redaction classes for endpoint/observable-style usage: yes
- Testcases for the classes: yes
- Full working example under `JS/edgechains/examples`: yes
- Short demo included in this PR: yes
- CLA signed and CI passing: yes

## Validation

- `npx vitest run src/ai/src/tests/awsComprehendRedactor.test.ts`
- `npm run build`
- `npm start` from `JS/edgechains/examples/aws-comprehend-redaction`

## Demo

Short demo GIF:

<img width="720" alt="AWS Comprehend redaction demo" src="https://raw.githubusercontent.com/jonahsills/EdgeChains/codex/demo-assets/demos/aws-comprehend-redaction-demo.gif">

The example prints the original prompt, the redacted prompt, the endpoint-wrapped response, and the stream output. It can also use live AWS Comprehend when `USE_LIVE_AWS_COMPREHEND=true` and AWS credentials are present.

Full demo transcript, included so the output remains reviewable even if GitHub clips the embedded media:

```text
EdgeChains #290 demo: AWS Comprehend redaction
Runnable example with deterministic mock client; live AWS supported by env vars.

$ cd JS/edgechains/examples/aws-comprehend-redaction
$ npm start

Original prompt:
My name is Jane Doe. Email me at jane@example.com and call 555-0100 about invoice INV-42.

Redacted prompt:
My name is [REDACTED_NAME]. Email me at [REDACTED_EMAIL] and call [REDACTED_PHONE] about invoice INV-42.

Endpoint response:
Prompt received by endpoint: My name is [REDACTED_NAME]. Email me at [REDACTED_EMAIL] and call [REDACTED_PHONE] about invoice INV-42.

Stream output:
My name is [REDACTED_NAME]. Email me at [REDACTED_EMAIL] and call [REDACTED_PHONE] about invoice INV-42.

✓ npx vitest run src/ai/src/tests/awsComprehendRedactor.test.ts
```
