### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,380 @@
+type QdrantPointId = string | number;
+type QdrantVector = number[] | Record<string, number[]>;
+type QdrantPayload = Record<string, unknown>;
+
+interface QdrantClient {
+  url: string;
+  apiKey?: string;
+  collectionName?: string;
+  headers: Record<string, string>;
+}
+
+interface CreateCollectionArgs {
+  client: QdrantClient;
+  collectionName?: string;
+  tableName?: string;
+  vectorSize: number;
+  distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+  onDisk?: boolean;
+}
+
+interface InsertVectorDataArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  id?: QdrantPointId;
+  vector?: QdrantVector;
+  embedding?: QdrantVector;
+  payload?: QdrantPayload;
+  content?: unknown;
+  wait?: boolean;
+  [key: string]: unknown;
+}
+
+interface GetDataFromQueryArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  vector?: QdrantVector;
+  embedding?: QdrantVector;
+  limit?: number;
+  filter?: QdrantPayload;
+  withPayload?: boolean | QdrantPayload;
+  withVector?: boolean | string[];
+  scoreThreshold?: number;
+}
+
+interface GetDataArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  limit?: number;
+  offset?: QdrantPointId | QdrantPayload;
+  filter?: QdrantPayload;
+  withPayload?: boolean | QdrantPayload;
+  withVector?: boolean | string[];
+}
+
+interface GetDataByIdArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  id: QdrantPointId;
+  withPayload?: boolean | QdrantPayload;
+  withVector?: boolean | string[];
+}
+
+interface UpdateByIdArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  id: QdrantPointId;
+  updatedContent: QdrantPayload;
+  wait?: boolean;
+}
+
+interface DeleteByIdArgs {
+  client: QdrantClient;
+  tableName?: string;
+  collectionName?: string;
+  id: QdrantPointId;
+  wait?: boolean;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+  collectionName?: string;
+
+  constructor(
+    QDRANT_URL?: string,
+    QDRANT_API_KEY?: string,
+    collectionName?: string,
+  ) {
+    this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(
+      /\/+$/,
+      "",
+    );
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    this.collectionName = collectionName || process.env.QDRANT_COLLECTION_NAME;
+  }
+
+  createClient(): QdrantClient {
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required to create a Qdrant client");
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (this.QDRANT_API_KEY) {
+      headers["api-key"] = this.QDRANT_API_KEY;
+    }
+
+    return {
+      url: this.QDRANT_URL,
+      apiKey: this.QDRANT_API_KEY,
+      collectionName: this.collectionName,
+      headers,
+    };
+  }
+
+  async createCollection({
+    client,
+    collectionName,
+    tableName,
+    vectorSize,
+    distance = "Cosine",
+    onDisk,
+  }: CreateCollectionArgs): Promise<any> {
+    const collection = this.resolveCollectionName(
+      client,
+      collectionName || tableName,
+    );
+
+    return this.request(client, `/collections/${collection}`, {
+      method: "PUT",
+      body: {
+        vectors: {
+          size: vectorSize,
+          distance,
+          ...(onDisk === undefined ? {} : { on_disk: onDisk }),
+        },
+      },
+    });
+  }
+
+  async insertVectorData({
+    client,
+    tableName,
+    collectionName,
+    id,
+    vector,
+    embedding,
+    payload,
+    content,
+    wait = true,
+    ...args
+  }: InsertVectorDataArgs): Promise<any> {
+    const collection = this.resolveCollectionName(
+      client,
+      collectionName || tableName,
+    );
+    const pointVector = vector || embedding;
+
+    if (!pointVector) {
+      throw new Error(
+        "A vector or embedding is required to insert Qdrant vector data",
+      );
+    }
+
+    const pointPayload = {
+      ...(payload || {}),
+      ...(content === undefined ? {} : { content }),
+      ...args,
+    };
+
+    return this.request(
+      client,
+      `/collections/${collection}/points?wait=${wait}`,
+      {
+        method: "PUT",
+        body: {
+          points: [
+            {
+              ...(id === undefined ? {} : { id }),
+              vector: pointVector,
+              payload: pointPayload,
+            },
+          ],
+        },
+      },
+    );
+  }
+
+  async getDataFromQuery({
+    client,
+    tableName,
+    collectionName,
+    vector,
+    embedding,
+    limit = 10,
+    filter,
+    withPayload = true,
+    withVector = false,
+    scoreThreshold,
+  }: GetDataFromQueryArgs): Promise<any> {
+    const collection = this.resolveCollectionName(
+      client,
+      collectionName || tableName,
+    );
+    const queryVector = vector || embedding;
+
+    if (!queryVector) {
+      throw new Error("A vector or embedding is required to query Qdrant");
+    }
+
+    return this.request(client, `/collections/${collection}/points/search`, {
+      method: "POST",
+      body: {
+        vector: queryVector,
+        limit,
+        ...(filter === undefined ? {} : { filter }),
+        with_payload: withPayload,
+        with_vector: withVector,
+        ...(scoreThreshold === undefined
+          ? {}
+          : { score_threshold: scoreThreshold }),
+      },
+    });
+  }
+
+  async getData({
+    client,
+    tableName,
+    collectionName,
+    limit = 10,
+    offset,
+    filter,
+    withPayload = true,
+    withVector = false,
+  }: GetDataArgs): Promise<any> {
+    const collection = this.resolveCollectionName(
+      client,
+      collectionName || tableName,
+    );
+
+    return this.request(client, `/collections/${collection}/points/scroll`, {
+      method: "POST",
+      body: {
+        limit,
+        ...(offset === undefined ? {} : { offset }),
+        ...(filter === undefined ? {} : { filter }),
+        with_payload: withPayload,
+        with_vector: withVector,
+      },
+    });
+  }
+
+  async getDataById({
+    client,
+    tableName,
+    collectionName,
+    id,
+    withPayload = true,
+    withVector = false,
+  }: GetDataByIdArgs): Promise<any> {
+    const collection = this.resolveCollectionName(
+      client,
+      collectionName || tableName,
+    );
+    const response = await this.request(
+      client,
+      `/collections/${collection}/points`,
+      {
+        method: "POST",
+        body: {
+          ids: [id],
+          with_payload: withPayload,
+          with_vector: withVector,
+        },
+      },
+    );
+
+    return response?.result?.[0] ?? response;
+  }
+
+  async updateById({
+    client,
+    tableName,
+    collectionName,
+    id,
+    updatedContent,
+    wait = true,
+  }: UpdateByIdArgs): Promise<any> {
+    const collection = this.resolveCollectionName(
+      client,
+      collectionName || tableName,
+    );
+
+    return this.request(
+      client,
+      `/collections/${collection}/points/payload?wait=${wait}`,
+      {
+        method: "POST",
+        body: {
+          payload: updatedContent,
+          points: [id],
+        },
+      },
+    );
+  }
+
+  async deleteById({
+    client,
+    tableName,
+    collectionName,
+    id,
+    wait = true,
+  }: DeleteByIdArgs): Promise<any> {
+    const collection = this.resolveCollectionName(
+      client,
+      collectionName || tableName,
+    );
+
+    return this.request(
+      client,
+      `/collections/${collection}/points/delete?wait=${wait}`,
+      {
+        method: "POST",
+        body: {
+          points: [id],
+        },
+      },
+    );
+  }
+
+  private resolveCollectionName(
+    client: QdrantClient,
+    collectionName?: string,
+  ): string {
+    const collection = collectionName || client.collectionName;
+    if (!collection) {
+      throw new Error("Qdrant collectionName or tableName is required");
+    }
+    return encodeURIComponent(collection);
+  }
+
+  private async request(
+    client: QdrantClient,
+    path: string,
+    { method, body }: { method: string; body?: QdrantPayload },
+  ): Promise<any> {
+    const response = await fetch(`${client.url}${path}`, {
+      method,
+      headers: client.headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const responseBody = await this.parseResponse(response);
+    if (!response.ok) {
+      throw new Error(
+        `Qdrant request failed with status ${response.status}: ${JSON.stringify(responseBody)}`,
+      );
+    }
+
+    return responseBody;
+  }
+
+  private async parseResponse(response: Response): Promise<any> {
+    const contentType = response.headers.get("content-type") || "";
+
+    if (contentType.includes("application/json")) {
+      return response.json();
+    }
+
+    const text = await response.text();
+    return text ? { message: text } : {};
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+const createJsonResponse = (body: unknown, ok = true, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Qdrant", () => {
+  it("creates a REST client with api-key headers", () => {
+    const qdrant = new Qdrant(
+      "https://qdrant.example.com/",
+      "secret",
+      "documents",
+    );
+    const client = qdrant.createClient();
+
+    expect(client).toEqual({
+      url: "https://qdrant.example.com",
+      apiKey: "secret",
+      collectionName: "documents",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": "secret",
+      },
+    });
+  });
+
+  it("creates a collection using Qdrant REST API fields", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(createJsonResponse({ result: true }));
+    const qdrant = new Qdrant("https://qdrant.example.com", "secret");
+    const client = qdrant.createClient();
+
+    await qdrant.createCollection({
+      client,
+      collectionName: "docs",
+      vectorSize: 1536,
+      distance: "Cosine",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/docs",
+      {
+        method: "PUT",
+        headers: client.headers,
+        body: JSON.stringify({
+          vectors: {
+            size: 1536,
+            distance: "Cosine",
+          },
+        }),
+      },
+    );
+  });
+
+  it("upserts vector data without a qdrant package dependency", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(createJsonResponse({ result: { operation_id: 1 } }));
+    const qdrant = new Qdrant("https://qdrant.example.com", "secret");
+    const client = qdrant.createClient();
+
+    await qdrant.insertVectorData({
+      client,
+      tableName: "docs",
+      id: "doc-1",
+      embedding: [0.1, 0.2, 0.3],
+      content: "Qdrant support",
+      payload: { source: "unit-test" },
+      tag: "vector-db",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/docs/points?wait=true",
+      {
+        method: "PUT",
+        headers: client.headers,
+        body: JSON.stringify({
+          points: [
+            {
+              id: "doc-1",
+              vector: [0.1, 0.2, 0.3],
+              payload: {
+                source: "unit-test",
+                content: "Qdrant support",
+                tag: "vector-db",
+              },
+            },
+          ],
+        }),
+      },
+    );
+  });
+
+  it("searches vectors with filters and returns the Qdrant response", async () => {
+    const responseBody = {
+      result: [{ id: "doc-1", score: 0.91, payload: { content: "match" } }],
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse(responseBody),
+    );
+    const qdrant = new Qdrant("https://qdrant.example.com", "secret");
+    const client = qdrant.createClient();
+
+    const result = await qdrant.getDataFromQuery({
+      client,
+      tableName: "docs",
+      vector: [0.4, 0.5, 0.6],
+      limit: 3,
+      filter: {
+        must: [{ key: "source", match: { value: "unit-test" } }],
+      },
+    });
+
+    expect(result).toEqual(responseBody);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/docs/points/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          vector: [0.4, 0.5, 0.6],
+          limit: 3,
+          filter: {
+            must: [{ key: "source", match: { value: "unit-test" } }],
+          },
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+  });
+
+  it("retrieves a point by id and returns the first result", async () => {
+    const point = { id: "doc-1", payload: { content: "stored" } };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({ result: [point] }),
+    );
+    const qdrant = new Qdrant("https://qdrant.example.com", "secret", "docs");
+    const client = qdrant.createClient();
+
+    await expect(qdrant.getDataById({ client, id: "doc-1" })).resolves.toEqual(
+      point,
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://qdrant.example.com/collections/docs/points",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          ids: ["doc-1"],
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+  });
+
+  it("updates and deletes points by id", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => createJsonResponse({ result: true }));
+    const qdrant = new Qdrant("https://qdrant.example.com", "secret", "docs");
+    const client = qdrant.createClient();
+
+    await qdrant.updateById({
+      client,
+      id: "doc-1",
+      updatedContent: { reviewed: true },
+    });
+    await qdrant.deleteById({ client, id: "doc-1" });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://qdrant.example.com/collections/docs/points/payload?wait=true",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          payload: { reviewed: true },
+          points: ["doc-1"],
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://qdrant.example.com/collections/docs/points/delete?wait=true",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          points: ["doc-1"],
+        }),
+      }),
+    );
+  });
+
+  it("throws useful errors for missing vectors and Qdrant failures", async () => {
+    const qdrant = new Qdrant("https://qdrant.example.com", "secret", "docs");
+    const client = qdrant.createClient();
+
+    await expect(qdrant.insertVectorData({ client })).rejects.toThrow(
+      "A vector or embedding is required",
+    );
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({ status: { error: "bad request" } }, false, 400),
+    );
+
+    await expect(
+      qdrant.getDataFromQuery({
+        client,
+        vector: [0.1, 0.2],
+        tableName: "docs",
+      }),
+    ).rejects.toThrow("Qdrant request failed with status 400");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a dependency-free Qdrant REST client under the JavaScript vector-db package.
- Exports `Qdrant` beside `Supabase`.
- Covers collection creation, vector upsert, search, scroll/retrieve, payload update, delete-by-id, and error handling with mocked tests.

## Bounty
/claim #273

## Validation
- `npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts`
- `npm run build`

## Demo
The test suite exercises the Qdrant API calls without requiring a live Qdrant server. It verifies the direct REST request paths and payloads for create collection, upsert, search, retrieve, update, and delete. No `qdrant` npm package is added.