### PR TITLE
Fix Gemini Palm2 request config

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,5 @@
 export { OpenAI } from "./lib/openai/openai.js";
-export { GeminiAI } from "./lib/gemini/gemini.js";
+export { GeminiAI, Palm2AI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
@@ -1,97 +1,112 @@
 import axios from "axios";
 import { retry } from "@lifeomic/attempt";
-const url = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
+const DEFAULT_MODEL = "gemini-pro";
+const googleGenerativeLanguageUrl = (model: string) =>
+  `https://generativelanguage.googleapis.com/v1/models/${model}:generateContent`;
 
-interface GeminiAIConstructionOptions {
-    apiKey?: string;
+export interface GeminiAIConstructionOptions {
+  apiKey?: string;
 }
 
-type SafetyRating = {
-    category:
-        | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
-        | "HARM_CATEGORY_HATE_SPEECH"
-        | "HARM_CATEGORY_HARASSMENT"
-        | "HARM_CATEGORY_DANGEROUS_CONTENT";
-    probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
+export type SafetyRating = {
+  category:
+    | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
+    | "HARM_CATEGORY_HATE_SPEECH"
+    | "HARM_CATEGORY_HARASSMENT"
+    | "HARM_CATEGORY_DANGEROUS_CONTENT";
+  probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
 };
 
-type ContentPart = {
-    text: string;
+export type ContentPart = {
+  text: string;
 };
 
-type Content = {
-    parts: ContentPart[];
-    role: string;
+export type Content = {
+  parts: ContentPart[];
+  role: string;
 };
 
-type Candidate = {
-    content: Content;
-    finishReason: string;
-    index: number;
-    safetyRatings: SafetyRating[];
+export type Candidate = {
+  content: Content;
+  finishReason: string;
+  index: number;
+  safetyRatings: SafetyRating[];
 };
 
-type UsageMetadata = {
-    promptTokenCount: number;
-    candidatesTokenCount: number;
-    totalTokenCount: number;
+export type UsageMetadata = {
+  promptTokenCount: number;
+  candidatesTokenCount: number;
+  totalTokenCount: number;
 };
 
-type Response = {
-    candidates: Candidate[];
-    usageMetadata: UsageMetadata;
+export type GeminiAIResponse = {
+  candidates: Candidate[];
+  usageMetadata: UsageMetadata;
 };
 
-type responseMimeType = "text/plain" | "application/json";
+export type ResponseMimeType = "text/plain" | "application/json";
 
-interface GeminiAIChatOptions {
-    model?: string;
-    max_output_tokens?: number;
-    temperature?: number;
-    prompt: string;
-    max_retry?: number;
-    responseType?: responseMimeType;
-    delay?: number;
+export interface GeminiAIChatOptions {
+  model?: string;
+  max_output_tokens?: number;
+  maxOutputTokens?: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  prompt: string;
+  max_retry?: number;
+  responseType?: ResponseMimeType;
+  delay?: number;
 }
 
 export class GeminiAI {
-    apiKey: string;
-    constructor(options: GeminiAIConstructionOptions) {
-        this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
-    }
+  apiKey: string;
+  constructor(options: GeminiAIConstructionOptions) {
+    this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
+  }
 
-    async chat(chatOptions: GeminiAIChatOptions): Promise<Response> {
-        let data = JSON.stringify({
-            contents: [
-                {
-                    role: "user",
-                    parts: [
-                        {
-                            text: chatOptions.prompt,
-                        },
-                    ],
-                },
-            ],
-        });
+  async chat(chatOptions: GeminiAIChatOptions): Promise<GeminiAIResponse> {
+    const data = JSON.stringify({
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: chatOptions.prompt,
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: chatOptions.temperature ?? 0.7,
+        responseMimeType: chatOptions.responseType || "text/plain",
+        maxOutputTokens:
+          chatOptions.maxOutputTokens || chatOptions.max_output_tokens || 1024,
+        ...(chatOptions.topP === undefined ? {} : { topP: chatOptions.topP }),
+        ...(chatOptions.topK === undefined ? {} : { topK: chatOptions.topK }),
+      },
+    });
 
-        let config = {
-            method: "post",
-            maxBodyLength: Infinity,
-            url,
-            headers: {
-                "Content-Type": "application/json",
-                "x-goog-api-key": this.apiKey,
-            },
-            temperature: chatOptions.temperature || "0.7",
-            responseMimeType: chatOptions.responseType || "text/plain",
-            max_output_tokens: chatOptions.max_output_tokens || 1024,
-            data: data,
-        };
-        return await retry(
-            async () => {
-                return (await axios.request(config)).data;
-            },
-            { maxAttempts: chatOptions.max_retry || 3, delay: chatOptions.delay || 200 }
-        );
-    }
+    const config = {
+      method: "post",
+      maxBodyLength: Infinity,
+      url: googleGenerativeLanguageUrl(chatOptions.model || DEFAULT_MODEL),
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": this.apiKey,
+      },
+      data,
+    };
+    return await retry(
+      async () => {
+        return (await axios.request(config)).data;
+      },
+      {
+        maxAttempts: chatOptions.max_retry || 3,
+        delay: chatOptions.delay || 200,
+      },
+    );
+  }
 }
+
+export class Palm2AI extends GeminiAI {}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
@@ -1,0 +1,110 @@
+import axios from "axios";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GeminiAI, Palm2AI } from "../../lib/gemini/gemini.js";
+
+vi.mock("axios", () => ({
+  default: {
+    request: vi.fn(),
+  },
+}));
+
+const mockedAxios = vi.mocked(axios);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GeminiAI Palm2-compatible requests", () => {
+  it("sends prompt and generation settings in the Google request body", async () => {
+    mockedAxios.request.mockResolvedValueOnce({
+      data: {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ text: "Paris" }],
+            },
+            finishReason: "STOP",
+            index: 0,
+            safetyRatings: [],
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 1,
+          totalTokenCount: 6,
+        },
+      },
+    });
+
+    const gemini = new GeminiAI({ apiKey: "test-api-key" });
+    const response = await gemini.chat({
+      model: "gemini-pro",
+      prompt: "What is the capital of France?",
+      temperature: 0.2,
+      max_output_tokens: 64,
+      responseType: "text/plain",
+      topP: 0.9,
+      topK: 20,
+      max_retry: 1,
+    });
+
+    expect(response.candidates[0].content.parts[0].text).toBe("Paris");
+    expect(mockedAxios.request).toHaveBeenCalledWith({
+      method: "post",
+      maxBodyLength: Infinity,
+      url: "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": "test-api-key",
+      },
+      data: JSON.stringify({
+        contents: [
+          {
+            role: "user",
+            parts: [
+              {
+                text: "What is the capital of France?",
+              },
+            ],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.2,
+          responseMimeType: "text/plain",
+          maxOutputTokens: 64,
+          topP: 0.9,
+          topK: 20,
+        },
+      }),
+    });
+  });
+
+  it("keeps a Palm2AI export for issue-compatible usage", async () => {
+    mockedAxios.request.mockResolvedValueOnce({
+      data: {
+        candidates: [],
+        usageMetadata: {
+          promptTokenCount: 0,
+          candidatesTokenCount: 0,
+          totalTokenCount: 0,
+        },
+      },
+    });
+
+    const palm2 = new Palm2AI({ apiKey: "test-api-key" });
+    await palm2.chat({
+      prompt: "Return JSON",
+      responseType: "application/json",
+      maxOutputTokens: 32,
+      max_retry: 1,
+    });
+
+    const request = mockedAxios.request.mock.calls[0][0];
+    expect(JSON.parse(request.data).generationConfig).toEqual({
+      temperature: 0.7,
+      responseMimeType: "application/json",
+      maxOutputTokens: 32,
+    });
+  });
+});

--- a/JS/edgechains/arakoodev/testcases/palm2/chat.jsonnet
+++ b/JS/edgechains/arakoodev/testcases/palm2/chat.jsonnet
@@ -1,0 +1,10 @@
+{
+  prompt: |||
+    Answer the following question in one concise sentence:
+    %(question)s
+  |||,
+  model: 'gemini-pro',
+  responseType: 'text/plain',
+  temperature: 0.2,
+  maxOutputTokens: 128,
+}

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,13 @@
+local config = import '../../../arakoodev/testcases/palm2/chat.jsonnet';
+local key = std.extVar('gemini_api_key');
+local question = std.extVar('question');
+local prompt = std.strReplace(config.prompt, '%(question)s', question);
+
+{
+  apiKey: key,
+  model: config.model,
+  prompt: prompt,
+  responseType: config.responseType,
+  temperature: config.temperature,
+  maxOutputTokens: config.maxOutputTokens,
+}

--- a/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
@@ -1,0 +1,3 @@
+{
+  gemini_api_key: std.extVar('GEMINI_API_KEY'),
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "palm2-chat",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsc && node ./dist/index.js"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "@arakoodev/jsonnet": "^0.24.0",
+    "file-uri-to-path": "^2.0.0",
+    "path": "^0.12.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "typescript": "^5.7.0-dev.20241007"
+  }
+}

--- a/JS/edgechains/examples/palm2-chat/readme.md
+++ b/JS/edgechains/examples/palm2-chat/readme.md
@@ -1,0 +1,7 @@
+# Palm2 Chat
+
+This example reads the Gemini/PaLM-compatible prompt and generation settings from Jsonnet, then calls the `Palm2AI` export.
+
+```sh
+GEMINI_API_KEY=... PALM2_QUESTION="What is EdgeChains?" npm start
+```

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,30 @@
+import { Palm2AI } from "@arakoodev/edgechains.js/ai";
+import Jsonnet from "@arakoodev/jsonnet";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+jsonnet.extString("GEMINI_API_KEY", process.env.GEMINI_API_KEY || "");
+jsonnet.extString("gemini_api_key", process.env.GEMINI_API_KEY || "");
+jsonnet.extString(
+  "question",
+  process.env.PALM2_QUESTION || "What can Gemini do?",
+);
+
+const promptConfig = JSON.parse(
+  jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet")),
+);
+
+const palm2 = new Palm2AI({ apiKey: promptConfig.apiKey });
+
+const response = await palm2.chat({
+  model: promptConfig.model,
+  prompt: promptConfig.prompt,
+  responseType: promptConfig.responseType,
+  temperature: promptConfig.temperature,
+  maxOutputTokens: promptConfig.maxOutputTokens,
+});
+
+console.log(JSON.stringify(response, null, 2));

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Fixes the Gemini/PaLM-compatible client so Google generation settings are sent in `generationConfig` rather than Axios config fields.
- Exports `Palm2AI` plus typed Gemini request/response types from the AI package.
- Adds mocked Palm2/Gemini unit coverage, a `testcases/palm2` Jsonnet prompt config, and a Jsonnet-driven `palm2-chat` example.

## Bounty
/claim #279

## Validation
- `npx vitest run src/ai/src/tests/palm2/gemini.test.ts`
- `npm run build`
- `npx prettier --check JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts JS/edgechains/arakoodev/src/ai/src/index.ts JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts JS/edgechains/examples/palm2-chat/package.json JS/edgechains/examples/palm2-chat/src/index.ts JS/edgechains/examples/palm2-chat/tsconfig.json JS/edgechains/examples/palm2-chat/readme.md`

## Demo
The focused test demonstrates the request generated from a prompt and confirms that model, API key header, contents, response MIME type, token limit, temperature, topP, and topK are sent to the Google Generative Language API in the expected shape. The example keeps the prompt text in Jsonnet rather than hardcoding it in TypeScript.