### PR TITLE
Fix Palm2 Gemini generation config

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,18 @@
 export { OpenAI } from "./lib/openai/openai.js";
-export { GeminiAI } from "./lib/gemini/gemini.js";
+export {
+    GeminiAI,
+    Palm2AI,
+    type GeminiAIChatOptions,
+    type GeminiAIConstructionOptions,
+    type GeminiAIResponse,
+    type GeminiCandidate,
+    type GeminiContent,
+    type GeminiContentPart,
+    type GeminiGenerationConfig,
+    type GeminiResponseMimeType,
+    type GeminiSafetyRating,
+    type GeminiUsageMetadata,
+} from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/gemini/gemini.ts
@@ -1,12 +1,15 @@
 import axios from "axios";
 import { retry } from "@lifeomic/attempt";
-const url = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
 
-interface GeminiAIConstructionOptions {
+const DEFAULT_MODEL = "gemini-1.5-flash";
+const GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models";
+
+export interface GeminiAIConstructionOptions {
     apiKey?: string;
+    baseUrl?: string;
 }
 
-type SafetyRating = {
+export type GeminiSafetyRating = {
     category:
         | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
         | "HARM_CATEGORY_HATE_SPEECH"
@@ -15,77 +18,91 @@ type SafetyRating = {
     probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
 };
 
-type ContentPart = {
+export type GeminiContentPart = {
     text: string;
 };
 
-type Content = {
-    parts: ContentPart[];
-    role: string;
+export type GeminiContent = {
+    parts: GeminiContentPart[];
+    role?: "user" | "model";
 };
 
-type Candidate = {
-    content: Content;
+export type GeminiCandidate = {
+    content: GeminiContent;
     finishReason: string;
     index: number;
-    safetyRatings: SafetyRating[];
+    safetyRatings: GeminiSafetyRating[];
 };
 
-type UsageMetadata = {
+export type GeminiUsageMetadata = {
     promptTokenCount: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
 };
 
-type Response = {
-    candidates: Candidate[];
-    usageMetadata: UsageMetadata;
+export type GeminiAIResponse = {
+    candidates: GeminiCandidate[];
+    usageMetadata: GeminiUsageMetadata;
 };
 
-type responseMimeType = "text/plain" | "application/json";
+export type GeminiResponseMimeType = "text/plain" | "application/json";
 
-interface GeminiAIChatOptions {
+export interface GeminiGenerationConfig {
+    maxOutputTokens?: number;
+    temperature?: number;
+    topP?: number;
+    topK?: number;
+    responseMimeType?: GeminiResponseMimeType;
+}
+
+export interface GeminiAIChatOptions {
     model?: string;
     max_output_tokens?: number;
+    maxOutputTokens?: number;
     temperature?: number;
-    prompt: string;
+    topP?: number;
+    topK?: number;
+    prompt?: string;
+    messages?: GeminiContent[];
     max_retry?: number;
-    responseType?: responseMimeType;
+    responseType?: GeminiResponseMimeType;
+    responseMimeType?: GeminiResponseMimeType;
     delay?: number;
 }
 
 export class GeminiAI {
     apiKey: string;
+    baseUrl: string;
+
     constructor(options: GeminiAIConstructionOptions) {
         this.apiKey = options.apiKey || process.env.GEMINI_API_KEY || "";
+        this.baseUrl = options.baseUrl || GEMINI_API_URL;
     }
 
-    async chat(chatOptions: GeminiAIChatOptions): Promise<Response> {
-        let data = JSON.stringify({
-            contents: [
+    async chat(chatOptions: GeminiAIChatOptions): Promise<GeminiAIResponse> {
+        const data = {
+            contents: chatOptions.messages || [
                 {
                     role: "user",
                     parts: [
                         {
-                            text: chatOptions.prompt,
+                            text: chatOptions.prompt || "",
                         },
                     ],
                 },
             ],
-        });
+            generationConfig: buildGenerationConfig(chatOptions),
+        };
 
-        let config = {
+        const config = {
             method: "post",
             maxBodyLength: Infinity,
-            url,
+            url: `${this.baseUrl}/${chatOptions.model || DEFAULT_MODEL}:generateContent`,
             headers: {
                 "Content-Type": "application/json",
                 "x-goog-api-key": this.apiKey,
             },
-            temperature: chatOptions.temperature || "0.7",
-            responseMimeType: chatOptions.responseType || "text/plain",
-            max_output_tokens: chatOptions.max_output_tokens || 1024,
-            data: data,
+            data,
         };
         return await retry(
             async () => {
@@ -94,4 +111,20 @@ export class GeminiAI {
             { maxAttempts: chatOptions.max_retry || 3, delay: chatOptions.delay || 200 }
         );
     }
+}
+
+export class Palm2AI extends GeminiAI {}
+
+function buildGenerationConfig(
+    options: GeminiAIChatOptions
+): GeminiGenerationConfig {
+    return {
+        maxOutputTokens:
+            options.maxOutputTokens || options.max_output_tokens || 1024,
+        temperature: options.temperature ?? 0.7,
+        topP: options.topP,
+        topK: options.topK,
+        responseMimeType:
+            options.responseMimeType || options.responseType || "text/plain",
+    };
 }

--- a/JS/edgechains/arakoodev/src/ai/src/testcases/palm2/prompt.jsonnet
+++ b/JS/edgechains/arakoodev/src/ai/src/testcases/palm2/prompt.jsonnet
@@ -1,0 +1,9 @@
+{
+  prompt: "Write a one sentence product description for a privacy-safe AI assistant.",
+  model: "gemini-1.5-flash",
+  generation: {
+    temperature: 0.2,
+    maxOutputTokens: 128,
+    responseMimeType: "text/plain",
+  },
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/gemini.test.ts
@@ -1,0 +1,84 @@
+import axios from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { GeminiAI, Palm2AI } from "../../lib/gemini/gemini.js";
+
+vi.mock("axios", () => ({
+    default: {
+        request: vi.fn(async () => ({
+            data: {
+                candidates: [
+                    {
+                        content: { role: "model", parts: [{ text: "Hello from Gemini" }] },
+                        finishReason: "STOP",
+                        index: 0,
+                        safetyRatings: [],
+                    },
+                ],
+                usageMetadata: {
+                    promptTokenCount: 2,
+                    candidatesTokenCount: 3,
+                    totalTokenCount: 5,
+                },
+            },
+        })),
+    },
+}));
+
+const request = vi.mocked(axios.request);
+
+describe("GeminiAI/Palm2AI", () => {
+    it("sends generation settings in generationConfig", async () => {
+        const gemini = new GeminiAI({
+            apiKey: "test-key",
+            baseUrl: "https://generativelanguage.googleapis.com/v1beta/models",
+        });
+
+        await gemini.chat({
+            model: "gemini-1.5-flash",
+            prompt: "Write a short greeting",
+            temperature: 0.2,
+            topP: 0.8,
+            topK: 20,
+            max_output_tokens: 128,
+            responseType: "application/json",
+            max_retry: 1,
+        });
+
+        expect(request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "post",
+                url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-goog-api-key": "test-key",
+                },
+                data: {
+                    contents: [
+                        {
+                            role: "user",
+                            parts: [{ text: "Write a short greeting" }],
+                        },
+                    ],
+                    generationConfig: {
+                        maxOutputTokens: 128,
+                        temperature: 0.2,
+                        topP: 0.8,
+                        topK: 20,
+                        responseMimeType: "application/json",
+                    },
+                },
+            })
+        );
+    });
+
+    it("keeps Palm2AI as a compatible alias for the bounty API", async () => {
+        const palm2 = new Palm2AI({ apiKey: "test-key" });
+
+        const response = await palm2.chat({
+            prompt: "Answer from jsonnet",
+            max_retry: 1,
+        });
+
+        expect(response.candidates[0].content.parts[0].text).toBe("Hello from Gemini");
+    });
+});

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,9 @@
+{
+  prompt: "Write a one sentence product description for a privacy-safe AI assistant.",
+  model: "gemini-1.5-flash",
+  generation: {
+    temperature: 0.2,
+    maxOutputTokens: 128,
+    responseMimeType: "text/plain",
+  },
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "palm2-chat",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "build": "tsc",
+        "dev": "npm run build && node dist/index.js"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.25.0",
+        "file-uri-to-path": "^2.0.0",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/palm2-chat/readme.md
+++ b/JS/edgechains/examples/palm2-chat/readme.md
@@ -1,0 +1,10 @@
+# Palm2/Gemini Chat
+
+This example keeps the prompt and generation settings in Jsonnet, then passes them to `Palm2AI` from the JavaScript SDK.
+
+```bash
+npm install
+npm run dev
+```
+
+Without `GEMINI_API_KEY`, the example prints the request that would be sent. Set `GEMINI_API_KEY` to call the Gemini API.

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,46 @@
+import Jsonnet from "@arakoodev/jsonnet";
+import { Palm2AI } from "@arakoodev/edgechains.js/ai";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const jsonnet = new Jsonnet();
+
+async function run() {
+    const config = JSON.parse(
+        jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"))
+    );
+    const palm2 = new Palm2AI({
+        apiKey: process.env.GEMINI_API_KEY || "demo-key",
+    });
+
+    if (!process.env.GEMINI_API_KEY) {
+        console.log(
+            JSON.stringify(
+                {
+                    mode: "dry-run",
+                    request: {
+                        model: config.model,
+                        prompt: config.prompt,
+                        ...config.generation,
+                    },
+                },
+                null,
+                2
+            )
+        );
+        return;
+    }
+
+    const response = await palm2.chat({
+        model: config.model,
+        prompt: config.prompt,
+        ...config.generation,
+    });
+    console.log(JSON.stringify(response, null, 2));
+}
+
+run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "rootDir": "./src",
+        "outDir": "./dist"
+    }
+}


### PR DESCRIPTION
/claim #279

## Summary
- Fixed the existing Gemini/PaLM-compatible provider so generation options are sent in Google's `generationConfig` body.
- Added exported Gemini request/response TypeScript types and a `Palm2AI` compatibility alias.
- Added mocked Palm2/Gemini unit coverage and a `testcases/palm2` Jsonnet prompt config.
- Added a Jsonnet-driven `palm2-chat` example with dry-run mode when `GEMINI_API_KEY` is not set.

## Demo
https://github.com/Jorel97/bounty-demo-assets/raw/main/edgechains/edgechains-279-demo.mp4

## Validation
- `pnpm exec tsc -b`
- `pnpm exec vitest run src/ai/src/tests/palm2/gemini.test.ts`
- `pnpm run dev` from `JS/edgechains/examples/palm2-chat`