### PR TITLE
feat(vector-db): add Qdrant support to JS SDK

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,189 @@
+import axios, { AxiosInstance } from "axios";
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+interface QdrantPoint {
+    id: string | number;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+interface QdrantFilter {
+    [key: string]: any;
+}
+
+type QdrantQuery = string | number | number[] | Record<string, any>;
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL!;
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(): AxiosInstance {
+        return axios.create({
+            baseURL: this.QDRANT_URL,
+            headers: this.QDRANT_API_KEY ? { "api-key": this.QDRANT_API_KEY } : undefined,
+        });
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectorSize,
+        distance = "Cosine",
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        vectorSize: number;
+        distance?: "Cosine" | "Dot" | "Euclid" | "Manhattan";
+    }): Promise<any> {
+        return this.withRetry(() =>
+            client.put(`/collections/${collectionName}`, {
+                vectors: {
+                    size: vectorSize,
+                    distance,
+                },
+            })
+        );
+    }
+
+    async upsertVectorData({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        return this.withRetry(() =>
+            client.put(`/collections/${collectionName}/points`, { points }, { params: { wait } })
+        );
+    }
+
+    async searchVectorData({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        vector: number[] | Record<string, number[]>;
+        limit?: number;
+        filter?: QdrantFilter;
+        withPayload?: boolean;
+    }): Promise<any> {
+        return this.withRetry(() =>
+            client.post(`/collections/${collectionName}/points/search`, {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+            })
+        );
+    }
+
+    async queryVectorData({
+        client,
+        collectionName,
+        query,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        query: QdrantQuery;
+        limit?: number;
+        filter?: QdrantFilter;
+        withPayload?: boolean;
+        withVector?: boolean;
+    }): Promise<any> {
+        return this.withRetry(() =>
+            client.post(`/collections/${collectionName}/points/query`, {
+                query,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+            })
+        );
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        id: string | number;
+        withPayload?: boolean;
+        withVector?: boolean;
+    }): Promise<any> {
+        return this.withRetry(() =>
+            client.get(`/collections/${collectionName}/points/${id}`, {
+                params: {
+                    with_payload: withPayload,
+                    with_vector: withVector,
+                },
+            })
+        );
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        ids,
+        wait = true,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        ids: Array<string | number>;
+        wait?: boolean;
+    }): Promise<any> {
+        return this.withRetry(() =>
+            client.post(
+                `/collections/${collectionName}/points/delete`,
+                {
+                    points: ids,
+                },
+                { params: { wait } }
+            )
+        );
+    }
+
+    private async withRetry(operationToRun: () => Promise<any>): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    resolve(await operationToRun());
+                } catch (error: any) {
+                    if (operation.retry(error)) return;
+                    reject(error);
+                }
+            });
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,119 @@
+import axios from "axios";
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Qdrant", () => {
+    const mockClient = {
+        put: jest.fn(),
+        post: jest.fn(),
+        get: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedAxios.create.mockReturnValue(mockClient as any);
+    });
+
+    it("should create a client with an api key header", () => {
+        const qdrant = new Qdrant("https://qdrant.example", "mock-api-key");
+        const client = qdrant.createClient();
+
+        expect(client).toBe(mockClient);
+        expect(mockedAxios.create).toHaveBeenCalledWith({
+            baseURL: "https://qdrant.example",
+            headers: { "api-key": "mock-api-key" },
+        });
+    });
+
+    it("should upsert vector points into a collection", async () => {
+        mockClient.put.mockResolvedValue({ data: { status: "ok" } });
+        const qdrant = new Qdrant("https://qdrant.example", "mock-api-key");
+        const client = qdrant.createClient();
+        const points = [
+            {
+                id: 1,
+                vector: [0.1, 0.2, 0.3],
+                payload: { content: "test" },
+            },
+        ];
+
+        const result = await qdrant.upsertVectorData({
+            client,
+            collectionName: "documents",
+            points,
+        });
+
+        expect(result).toEqual({ data: { status: "ok" } });
+        expect(mockClient.put).toHaveBeenCalledWith(
+            "/collections/documents/points",
+            { points },
+            { params: { wait: true } }
+        );
+    });
+
+    it("should create a collection", async () => {
+        mockClient.put.mockResolvedValue({ data: { result: true } });
+        const qdrant = new Qdrant("https://qdrant.example", "mock-api-key");
+        const client = qdrant.createClient();
+
+        const result = await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+        });
+
+        expect(result).toEqual({ data: { result: true } });
+        expect(mockClient.put).toHaveBeenCalledWith("/collections/documents", {
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
+    });
+
+    it("should search vector data in a collection", async () => {
+        mockClient.post.mockResolvedValue({ data: { result: [] } });
+        const qdrant = new Qdrant("https://qdrant.example", "mock-api-key");
+        const client = qdrant.createClient();
+
+        const result = await qdrant.searchVectorData({
+            client,
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+        });
+
+        expect(result).toEqual({ data: { result: [] } });
+        expect(mockClient.post).toHaveBeenCalledWith("/collections/documents/points/search", {
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: undefined,
+            with_payload: true,
+        });
+    });
+
+    it("should query vector data in a collection", async () => {
+        mockClient.post.mockResolvedValue({ data: { result: { points: [] } } });
+        const qdrant = new Qdrant("https://qdrant.example", "mock-api-key");
+        const client = qdrant.createClient();
+
+        const result = await qdrant.queryVectorData({
+            client,
+            collectionName: "documents",
+            query: [0.1, 0.2, 0.3],
+            limit: 3,
+        });
+
+        expect(result).toEqual({ data: { result: { points: [] } } });
+        expect(mockClient.post).toHaveBeenCalledWith("/collections/documents/points/query", {
+            query: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: undefined,
+            with_payload: true,
+            with_vector: false,
+        });
+    });
+});


### PR DESCRIPTION
Adds Qdrant support to the JS SDK via REST API without introducing Qdrant-specific packages.
/claim #273