### PR TITLE
Add Qdrant vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,286 @@
+export interface QdrantClient {
+  url: string;
+  apiKey?: string;
+  fetch: typeof fetch;
+}
+
+export interface QdrantOptions {
+  url?: string;
+  apiKey?: string;
+  fetch?: typeof fetch;
+}
+
+interface QdrantRequestOptions {
+  method?: string;
+  body?: unknown;
+}
+
+interface QdrantPoint {
+  id: string | number;
+  vector: number[];
+  payload?: Record<string, unknown>;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+  private readonly fetcher: typeof fetch;
+
+  constructor(
+    QDRANT_URL?: string,
+    QDRANT_API_KEY?: string,
+    options: QdrantOptions = {},
+  ) {
+    this.QDRANT_URL = options.url || QDRANT_URL || process.env.QDRANT_URL || "";
+    this.QDRANT_API_KEY =
+      options.apiKey || QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    this.fetcher = options.fetch || fetch;
+  }
+
+  createClient(): QdrantClient {
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required to create a Qdrant client");
+    }
+
+    return {
+      url: this.QDRANT_URL.replace(/\/$/, ""),
+      apiKey: this.QDRANT_API_KEY,
+      fetch: this.fetcher,
+    };
+  }
+
+  async createCollection({
+    client,
+    collectionName,
+    vectorSize,
+    distance = "Cosine",
+  }: {
+    client: QdrantClient;
+    collectionName: string;
+    vectorSize: number;
+    distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+  }): Promise<any> {
+    return this.request(client, `/collections/${collectionName}`, {
+      method: "PUT",
+      body: {
+        vectors: {
+          size: vectorSize,
+          distance,
+        },
+      },
+    });
+  }
+
+  async insertVectorData({
+    client,
+    collectionName,
+    points,
+    wait = true,
+    id,
+    vector,
+    payload,
+  }: {
+    client: QdrantClient;
+    collectionName: string;
+    points?: QdrantPoint[];
+    wait?: boolean;
+    id?: string | number;
+    vector?: number[];
+    payload?: Record<string, unknown>;
+  }): Promise<any> {
+    const vectorPoints = points || [
+      {
+        id: id!,
+        vector: vector!,
+        payload,
+      },
+    ];
+
+    if (vectorPoints.some((point) => point.id === undefined || !point.vector)) {
+      throw new Error(
+        "Qdrant insertVectorData requires points or an id and vector",
+      );
+    }
+
+    return this.request(
+      client,
+      `/collections/${collectionName}/points?wait=${wait}`,
+      {
+        method: "PUT",
+        body: {
+          points: vectorPoints,
+        },
+      },
+    );
+  }
+
+  async getDataFromQuery({
+    client,
+    collectionName,
+    vector,
+    limit = 10,
+    filter,
+    withPayload = true,
+    withVector = false,
+  }: {
+    client: QdrantClient;
+    collectionName: string;
+    vector: number[];
+    limit?: number;
+    filter?: Record<string, unknown>;
+    withPayload?: boolean;
+    withVector?: boolean;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${collectionName}/points/search`,
+      {
+        method: "POST",
+        body: {
+          vector,
+          limit,
+          filter,
+          with_payload: withPayload,
+          with_vector: withVector,
+        },
+      },
+    );
+  }
+
+  async getData({
+    client,
+    collectionName,
+    limit = 10,
+    offset,
+    filter,
+    withPayload = true,
+    withVector = false,
+  }: {
+    client: QdrantClient;
+    collectionName: string;
+    limit?: number;
+    offset?: string | number;
+    filter?: Record<string, unknown>;
+    withPayload?: boolean;
+    withVector?: boolean;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${collectionName}/points/scroll`,
+      {
+        method: "POST",
+        body: {
+          limit,
+          offset,
+          filter,
+          with_payload: withPayload,
+          with_vector: withVector,
+        },
+      },
+    );
+  }
+
+  async getDataById({
+    client,
+    collectionName,
+    id,
+    withPayload = true,
+    withVector = false,
+  }: {
+    client: QdrantClient;
+    collectionName: string;
+    id: string | number;
+    withPayload?: boolean;
+    withVector?: boolean;
+  }): Promise<any> {
+    return this.request(client, `/collections/${collectionName}/points`, {
+      method: "POST",
+      body: {
+        ids: [id],
+        with_payload: withPayload,
+        with_vector: withVector,
+      },
+    });
+  }
+
+  async updateById({
+    client,
+    collectionName,
+    id,
+    updatedContent,
+    wait = true,
+  }: {
+    client: QdrantClient;
+    collectionName: string;
+    id: string | number;
+    updatedContent: Record<string, unknown>;
+    wait?: boolean;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${collectionName}/points/payload?wait=${wait}`,
+      {
+        method: "POST",
+        body: {
+          payload: updatedContent,
+          points: [id],
+        },
+      },
+    );
+  }
+
+  async deleteById({
+    client,
+    collectionName,
+    id,
+    wait = true,
+  }: {
+    client: QdrantClient;
+    collectionName: string;
+    id: string | number;
+    wait?: boolean;
+  }): Promise<any> {
+    return this.request(
+      client,
+      `/collections/${collectionName}/points/delete?wait=${wait}`,
+      {
+        method: "POST",
+        body: {
+          points: [id],
+        },
+      },
+    );
+  }
+
+  private async request(
+    client: QdrantClient,
+    path: string,
+    options: QdrantRequestOptions = {},
+  ): Promise<any> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (client.apiKey) {
+      headers["api-key"] = client.apiKey;
+    }
+
+    const response = await client.fetch(`${client.url}${path}`, {
+      method: options.method || "GET",
+      headers,
+      body:
+        options.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      throw new Error(
+        `Qdrant request failed with status ${response.status}: ${JSON.stringify(data)}`,
+      );
+    }
+
+    return data?.result ?? data;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,150 @@
+import { Qdrant } from "../../lib/qdrant/qdrant";
+import { describe, expect, it, vi } from "vitest";
+
+const jsonResponse = (body: unknown, ok = true, status = 200) =>
+  ({
+    ok,
+    status,
+    text: async () => JSON.stringify(body),
+  }) as Response;
+
+describe("Qdrant", () => {
+  it("creates a client from constructor values", () => {
+    const fetchMock = vi.fn();
+    const qdrant = new Qdrant("https://qdrant.example/", "secret", {
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(qdrant.createClient()).toEqual({
+      url: "https://qdrant.example",
+      apiKey: "secret",
+      fetch: fetchMock,
+    });
+  });
+
+  it("creates collections with Qdrant vector settings", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ result: { status: "ok" } }));
+    const qdrant = new Qdrant("https://qdrant.example", "secret", {
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await qdrant.createCollection({
+      client: qdrant.createClient(),
+      collectionName: "documents",
+      vectorSize: 1536,
+      distance: "Dot",
+    });
+
+    expect(result).toEqual({ status: "ok" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents",
+      expect.objectContaining({
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "api-key": "secret",
+        },
+        body: JSON.stringify({
+          vectors: {
+            size: 1536,
+            distance: "Dot",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("upserts vector points", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ result: { operation_id: 1 } }));
+    const qdrant = new Qdrant("https://qdrant.example", undefined, {
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await qdrant.insertVectorData({
+      client: qdrant.createClient(),
+      collectionName: "documents",
+      id: "doc-1",
+      vector: [0.1, 0.2],
+      payload: { content: "hello" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents/points?wait=true",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          points: [
+            {
+              id: "doc-1",
+              vector: [0.1, 0.2],
+              payload: { content: "hello" },
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("searches vectors through getDataFromQuery", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ result: [{ id: "doc-1", score: 0.9 }] }),
+      );
+    const qdrant = new Qdrant("https://qdrant.example", undefined, {
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const result = await qdrant.getDataFromQuery({
+      client: qdrant.createClient(),
+      collectionName: "documents",
+      vector: [0.1, 0.2],
+      limit: 3,
+      filter: { must: [{ key: "source", match: { value: "docs" } }] },
+    });
+
+    expect(result).toEqual([{ id: "doc-1", score: 0.9 }]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents/points/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          vector: [0.1, 0.2],
+          limit: 3,
+          filter: { must: [{ key: "source", match: { value: "docs" } }] },
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+  });
+
+  it("deletes points by id", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ result: { status: "ok" } }));
+    const qdrant = new Qdrant("https://qdrant.example", undefined, {
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await qdrant.deleteById({
+      client: qdrant.createClient(),
+      collectionName: "documents",
+      id: 42,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/documents/points/delete?wait=true",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          points: [42],
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a dependency-free Qdrant REST client for the JavaScript vector-db package
- export `Qdrant` alongside `Supabase` from `@arakoodev/edgechains.js/vector-db`
- support collection creation, point upsert, vector search, scroll, retrieve-by-id, payload update, and delete-by-id
- add mocked Vitest coverage for the request shapes and result handling

## Validation
- `npm test -- --run src/vector-db/src/tests/qdrant/qdrant.test.ts`
- `npm run build`
- `npx prettier --check src/vector-db/src/lib/qdrant/qdrant.ts src/vector-db/src/tests/qdrant/qdrant.test.ts src/vector-db/src/index.ts`
- `git diff --check`

/claim #273