### PR TITLE
[codex] Add Qdrant REST vector client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,8 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export {
+    Qdrant,
+    QdrantCollectionConfig,
+    QdrantPoint,
+    QdrantSearchOptions,
+    QdrantSearchResult,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,179 @@
+import axios, { AxiosInstance } from "axios";
+
+type QdrantPointId = string | number;
+
+export interface QdrantPoint {
+    id: QdrantPointId;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+export interface QdrantSearchResult {
+    id: QdrantPointId;
+    score: number;
+    payload?: Record<string, any>;
+    vector?: number[] | Record<string, number[]>;
+}
+
+export interface QdrantCollectionConfig {
+    vectors:
+        | {
+              size: number;
+              distance: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+          }
+        | Record<
+              string,
+              {
+                  size: number;
+                  distance: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+              }
+          >;
+    shard_number?: number;
+    replication_factor?: number;
+    write_consistency_factor?: number;
+    on_disk_payload?: boolean;
+}
+
+export interface QdrantSearchOptions {
+    vector: number[] | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, any>;
+    with_payload?: boolean | string[] | Record<string, any>;
+    with_vector?: boolean | string[];
+    score_threshold?: number;
+}
+
+export class Qdrant {
+    client: AxiosInstance;
+
+    constructor({
+        url,
+        apiKey,
+    }: {
+        url?: string;
+        apiKey?: string;
+    }) {
+        const baseURL = (url || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        const key = apiKey || process.env.QDRANT_API_KEY || "";
+
+        this.client = axios.create({
+            baseURL,
+            headers: {
+                "Content-Type": "application/json",
+                ...(key ? { "api-key": key } : {}),
+            },
+        });
+    }
+
+    async createCollection({
+        collectionName,
+        config,
+    }: {
+        collectionName: string;
+        config: QdrantCollectionConfig;
+    }): Promise<any> {
+        const response = await this.client.put(`/collections/${collectionName}`, config);
+        return response.data;
+    }
+
+    async getCollection({ collectionName }: { collectionName: string }): Promise<any> {
+        const response = await this.client.get(`/collections/${collectionName}`);
+        return response.data;
+    }
+
+    async deleteCollection({ collectionName }: { collectionName: string }): Promise<any> {
+        const response = await this.client.delete(`/collections/${collectionName}`);
+        return response.data;
+    }
+
+    async upsertPoints({
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        const response = await this.client.put(
+            `/collections/${collectionName}/points`,
+            { points },
+            { params: { wait } }
+        );
+        return response.data;
+    }
+
+    async searchPoints({
+        collectionName,
+        ...searchOptions
+    }: {
+        collectionName: string;
+    } & QdrantSearchOptions): Promise<QdrantSearchResult[]> {
+        const response = await this.client.post(
+            `/collections/${collectionName}/points/search`,
+            searchOptions
+        );
+        return response.data.result;
+    }
+
+    async retrievePoints({
+        collectionName,
+        ids,
+        with_payload = true,
+        with_vector = false,
+    }: {
+        collectionName: string;
+        ids: QdrantPointId[];
+        with_payload?: boolean | string[] | Record<string, any>;
+        with_vector?: boolean | string[];
+    }): Promise<any[]> {
+        const response = await this.client.post(`/collections/${collectionName}/points`, {
+            ids,
+            with_payload,
+            with_vector,
+        });
+        return response.data.result;
+    }
+
+    async deletePoints({
+        collectionName,
+        ids,
+        wait = true,
+    }: {
+        collectionName: string;
+        ids: QdrantPointId[];
+        wait?: boolean;
+    }): Promise<any> {
+        const response = await this.client.post(
+            `/collections/${collectionName}/points/delete`,
+            { points: ids },
+            { params: { wait } }
+        );
+        return response.data;
+    }
+
+    async scrollPoints({
+        collectionName,
+        limit = 10,
+        offset,
+        filter,
+        with_payload = true,
+        with_vector = false,
+    }: {
+        collectionName: string;
+        limit?: number;
+        offset?: QdrantPointId;
+        filter?: Record<string, any>;
+        with_payload?: boolean | string[] | Record<string, any>;
+        with_vector?: boolean | string[];
+    }): Promise<any> {
+        const response = await this.client.post(`/collections/${collectionName}/points/scroll`, {
+            limit,
+            offset,
+            filter,
+            with_payload,
+            with_vector,
+        });
+        return response.data.result;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,141 @@
+import axios from "axios";
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+const put = jest.fn();
+const post = jest.fn();
+const get = jest.fn();
+const del = jest.fn();
+
+jest.mock("axios", () => ({
+    __esModule: true,
+    default: {
+        create: jest.fn(() => ({
+            put,
+            post,
+            get,
+            delete: del,
+        })),
+    },
+}));
+
+describe("Qdrant", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("creates an axios client with Qdrant cloud headers", () => {
+        new Qdrant({
+            url: "https://example.qdrant.cloud/",
+            apiKey: "test-key",
+        });
+
+        expect(axios.create).toHaveBeenCalledWith({
+            baseURL: "https://example.qdrant.cloud",
+            headers: {
+                "Content-Type": "application/json",
+                "api-key": "test-key",
+            },
+        });
+    });
+
+    it("creates a collection through the REST API", async () => {
+        put.mockResolvedValueOnce({ data: { result: true } });
+        const qdrant = new Qdrant({ url: "http://localhost:6333" });
+
+        const result = await qdrant.createCollection({
+            collectionName: "documents",
+            config: {
+                vectors: {
+                    size: 1536,
+                    distance: "Cosine",
+                },
+            },
+        });
+
+        expect(put).toHaveBeenCalledWith("/collections/documents", {
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
+        expect(result).toEqual({ result: true });
+    });
+
+    it("upserts vector points without a Qdrant SDK", async () => {
+        put.mockResolvedValueOnce({ data: { result: { operation_id: 1 } } });
+        const qdrant = new Qdrant({ url: "http://localhost:6333" });
+
+        await qdrant.upsertPoints({
+            collectionName: "documents",
+            points: [
+                {
+                    id: "doc-1",
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { text: "hello" },
+                },
+            ],
+        });
+
+        expect(put).toHaveBeenCalledWith(
+            "/collections/documents/points",
+            {
+                points: [
+                    {
+                        id: "doc-1",
+                        vector: [0.1, 0.2, 0.3],
+                        payload: { text: "hello" },
+                    },
+                ],
+            },
+            { params: { wait: true } }
+        );
+    });
+
+    it("searches vector points and returns Qdrant results", async () => {
+        post.mockResolvedValueOnce({
+            data: {
+                result: [{ id: "doc-1", score: 0.98, payload: { text: "hello" } }],
+            },
+        });
+        const qdrant = new Qdrant({ url: "http://localhost:6333" });
+
+        const result = await qdrant.searchPoints({
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 1,
+            with_payload: true,
+        });
+
+        expect(post).toHaveBeenCalledWith("/collections/documents/points/search", {
+            vector: [0.1, 0.2, 0.3],
+            limit: 1,
+            with_payload: true,
+        });
+        expect(result).toEqual([{ id: "doc-1", score: 0.98, payload: { text: "hello" } }]);
+    });
+
+    it("retrieves and deletes points through REST endpoints", async () => {
+        post.mockResolvedValueOnce({ data: { result: [{ id: "doc-1" }] } });
+        post.mockResolvedValueOnce({ data: { result: { status: "acknowledged" } } });
+        const qdrant = new Qdrant({ url: "http://localhost:6333" });
+
+        await expect(
+            qdrant.retrievePoints({ collectionName: "documents", ids: ["doc-1"] })
+        ).resolves.toEqual([{ id: "doc-1" }]);
+        await qdrant.deletePoints({ collectionName: "documents", ids: ["doc-1"] });
+
+        expect(post).toHaveBeenNthCalledWith(1, "/collections/documents/points", {
+            ids: ["doc-1"],
+            with_payload: true,
+            with_vector: false,
+        });
+        expect(post).toHaveBeenNthCalledWith(
+            2,
+            "/collections/documents/points/delete",
+            {
+                points: ["doc-1"],
+            },
+            { params: { wait: true } }
+        );
+    });
+});


### PR DESCRIPTION
/claim #273

## Summary
- Adds a `Qdrant` vector database REST client to the JavaScript SDK without adding any Qdrant package dependency.
- Exports `Qdrant` and its TypeScript types from `@arakoodev/edgechains.js/vector-db`.
- Covers collection creation, point upsert, search, retrieve, and delete behavior with mocked Jest tests.

## Validation
- `npx tsc -b`
- `npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand`

## Notes
- The implementation calls Qdrant's REST endpoints directly through the package's existing `axios` dependency.
- `wait` is passed as a request query parameter for point mutations to match the Qdrant REST API.