### PR TITLE
Add Qdrant vector database support to JS SDK

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -33,6 +33,7 @@
         "cheerio": "^1.0.0-rc.12",
         "cors": "^2.8.5",
         "document": "^0.4.7",
+        "dotenv": "^16.4.7",
         "dts-bundle-generator": "^9.3.1",
         "esbuild": "^0.20.2",
         "hono": "3.9",

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,9 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+    QdrantDistance,
+    QdrantPoint,
+    QdrantSearchArgs,
+    QdrantUpsertArgs,
+    QdrantVectorConfig,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,289 @@
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+type QdrantHeaders = Record<string, string>;
+
+export type QdrantDistance = "Cosine" | "Dot" | "Euclid" | "Manhattan";
+
+export interface QdrantVectorConfig {
+    size: number;
+    distance?: QdrantDistance;
+}
+
+export interface QdrantPoint {
+    id: string | number;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, any>;
+}
+
+export interface QdrantSearchArgs {
+    collectionName: string;
+    vector: number[] | { name: string; vector: number[] } | Record<string, number[]>;
+    limit?: number;
+    filter?: Record<string, any>;
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+    scoreThreshold?: number;
+    params?: Record<string, any>;
+}
+
+export interface QdrantUpsertArgs {
+    collectionName: string;
+    points: QdrantPoint[];
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/+$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL must be provided or set in the environment");
+        }
+    }
+
+    createClient() {
+        return this;
+    }
+
+    async createCollection({
+        collectionName,
+        vectors,
+    }: {
+        collectionName: string;
+        vectors: QdrantVectorConfig | Record<string, QdrantVectorConfig>;
+    }): Promise<any> {
+        const normalizedVectors = this.normalizeVectors(vectors);
+        return this.request(`/collections/${encodeURIComponent(collectionName)}`, {
+            method: "PUT",
+            body: { vectors: normalizedVectors },
+        });
+    }
+
+    async getCollection({ collectionName }: { collectionName: string }): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}`);
+    }
+
+    async deleteCollection({ collectionName }: { collectionName: string }): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}`, {
+            method: "DELETE",
+        });
+    }
+
+    async insertVectorData({ collectionName, points, wait = true }: QdrantUpsertArgs): Promise<any> {
+        return this.upsertPoints({ collectionName, points, wait });
+    }
+
+    async upsertPoints({ collectionName, points, wait = true }: QdrantUpsertArgs): Promise<any> {
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points?wait=${String(wait)}`,
+            {
+                method: "PUT",
+                body: { points },
+            }
+        );
+    }
+
+    async getData({
+        collectionName,
+        limit = 10,
+        offset,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: {
+        collectionName: string;
+        limit?: number;
+        offset?: string | number;
+        filter?: Record<string, any>;
+        withPayload?: boolean | string[];
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points/scroll`, {
+            method: "POST",
+            body: {
+                limit,
+                offset,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+            },
+        });
+    }
+
+    async getDataById({
+        collectionName,
+        id,
+        ids,
+        withPayload = true,
+        withVector = false,
+    }: {
+        collectionName: string;
+        id?: string | number;
+        ids?: Array<string | number>;
+        withPayload?: boolean | string[];
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points`, {
+            method: "POST",
+            body: {
+                ids: ids || (id !== undefined ? [id] : []),
+                with_payload: withPayload,
+                with_vector: withVector,
+            },
+        });
+    }
+
+    async updateById({
+        collectionName,
+        points,
+        wait = true,
+    }: QdrantUpsertArgs): Promise<any> {
+        return this.upsertPoints({ collectionName, points, wait });
+    }
+
+    async deleteById({
+        collectionName,
+        id,
+        ids,
+        points,
+        wait = true,
+    }: {
+        collectionName: string;
+        id?: string | number;
+        ids?: Array<string | number>;
+        points?: Array<string | number>;
+        wait?: boolean;
+    }): Promise<any> {
+        return this.request(
+            `/collections/${encodeURIComponent(collectionName)}/points/delete?wait=${String(wait)}`,
+            {
+                method: "POST",
+                body: { points: points || ids || (id !== undefined ? [id] : []) },
+            }
+        );
+    }
+
+    async search({
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+        params,
+    }: QdrantSearchArgs): Promise<any> {
+        return this.request(`/collections/${encodeURIComponent(collectionName)}/points/search`, {
+            method: "POST",
+            body: {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+                params,
+            },
+        });
+    }
+
+    private normalizeVectors(
+        vectors: QdrantVectorConfig | Record<string, QdrantVectorConfig>
+    ): QdrantVectorConfig | Record<string, QdrantVectorConfig> {
+        if ("size" in vectors) {
+            return {
+                size: vectors.size,
+                distance: vectors.distance || "Cosine",
+            };
+        }
+
+        return Object.fromEntries(
+            Object.entries(vectors).map(([name, vector]) => [
+                name,
+                {
+                    size: vector.size,
+                    distance: vector.distance || "Cosine",
+                },
+            ])
+        );
+    }
+
+    private async request(path: string, options: { method?: string; body?: any } = {}): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    const response = await fetch(`${this.QDRANT_URL}${path}`, {
+                        method: options.method || "GET",
+                        headers: this.headers(),
+                        body: options.body ? JSON.stringify(this.removeUndefined(options.body)) : undefined,
+                    });
+                    const data = await this.readResponse(response);
+
+                    if (!response.ok) {
+                        const message =
+                            data?.status?.error || data?.message || response.statusText || "Qdrant request failed";
+                        if (operation.retry(new Error(message))) {
+                            return;
+                        }
+                        reject(new Error(message));
+                        return;
+                    }
+
+                    resolve(data);
+                } catch (error: any) {
+                    if (operation.retry(error)) {
+                        return;
+                    }
+                    reject(error);
+                }
+            });
+        });
+    }
+
+    private headers(): QdrantHeaders {
+        const headers: QdrantHeaders = {
+            "content-type": "application/json",
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        return headers;
+    }
+
+    private async readResponse(response: Response): Promise<any> {
+        const text = await response.text();
+        return text ? JSON.parse(text) : {};
+    }
+
+    private removeUndefined(value: any): any {
+        if (Array.isArray(value)) {
+            return value.map((item) => this.removeUndefined(item));
+        }
+
+        if (value && typeof value === "object") {
+            return Object.fromEntries(
+                Object.entries(value)
+                    .filter(([, entryValue]) => entryValue !== undefined)
+                    .map(([key, entryValue]) => [key, this.removeUndefined(entryValue)])
+            );
+        }
+
+        return value;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+const createResponse = (body: any, ok = true, statusText = "OK") =>
+    ({
+        ok,
+        statusText,
+        text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+    }) as unknown as Response;
+
+describe("Qdrant", () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    it("creates a collection with default cosine distance", async () => {
+        fetchMock.mockResolvedValue(createResponse({ result: true }));
+
+        const qdrant = new Qdrant("http://localhost:6333", "secret");
+        const result = await qdrant.createCollection({
+            collectionName: "documents",
+            vectors: { size: 1536 },
+        });
+
+        expect(result).toEqual({ result: true });
+        expect(fetchMock).toHaveBeenCalledWith("http://localhost:6333/collections/documents", {
+            method: "PUT",
+            headers: {
+                "content-type": "application/json",
+                "api-key": "secret",
+            },
+            body: JSON.stringify({
+                vectors: {
+                    size: 1536,
+                    distance: "Cosine",
+                },
+            }),
+        });
+    });
+
+    it("upserts points through insertVectorData", async () => {
+        fetchMock.mockResolvedValue(createResponse({ result: { operation_id: 1 } }));
+
+        const qdrant = new Qdrant("http://localhost:6333");
+        await qdrant.insertVectorData({
+            collectionName: "documents",
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2],
+                    payload: { text: "hello" },
+                },
+            ],
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "http://localhost:6333/collections/documents/points?wait=true",
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({
+                    points: [
+                        {
+                            id: 1,
+                            vector: [0.1, 0.2],
+                            payload: { text: "hello" },
+                        },
+                    ],
+                }),
+            })
+        );
+    });
+
+    it("searches points with filters", async () => {
+        fetchMock.mockResolvedValue(createResponse({ result: [{ id: 1, score: 0.99 }] }));
+
+        const qdrant = new Qdrant("http://localhost:6333/");
+        const result = await qdrant.search({
+            collectionName: "documents",
+            vector: [0.1, 0.2],
+            filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+            limit: 3,
+        });
+
+        expect(result.result).toHaveLength(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            "http://localhost:6333/collections/documents/points/search",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    vector: [0.1, 0.2],
+                    limit: 3,
+                    filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+                    with_payload: true,
+                    with_vector: false,
+                }),
+            })
+        );
+    });
+
+    it("gets, updates, and deletes points by id", async () => {
+        fetchMock.mockResolvedValue(createResponse({ result: true }));
+
+        const qdrant = new Qdrant("http://localhost:6333");
+        await qdrant.getDataById({ collectionName: "documents", id: 1 });
+        await qdrant.updateById({
+            collectionName: "documents",
+            points: [{ id: 1, vector: [0.2, 0.3], payload: { text: "updated" } }],
+        });
+        await qdrant.deleteById({ collectionName: "documents", id: 1 });
+
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            1,
+            "http://localhost:6333/collections/documents/points",
+            expect.objectContaining({ method: "POST" })
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            "http://localhost:6333/collections/documents/points?wait=true",
+            expect.objectContaining({ method: "PUT" })
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            3,
+            "http://localhost:6333/collections/documents/points/delete?wait=true",
+            expect.objectContaining({ method: "POST" })
+        );
+    });
+});


### PR DESCRIPTION
Closes #273

Adds Qdrant support to the JS vector-db package.

Changes:
- Add Qdrant HTTP client with collection, upsert, scroll, retrieve, search, update, and delete helpers
- Export Qdrant and related TypeScript types from vector-db
- Add unit tests for Qdrant request behavior
- Add dotenv dependency already used by vector-db code