### PR TITLE
feat: add qdrant vector database implementation

### DIFF
--- a/JS/edgechains/arakoodev/README.md
+++ b/JS/edgechains/arakoodev/README.md
@@ -3,3 +3,39 @@ Installation
 ```
 npm install arakoodev
 ```
+
+## Qdrant vector database
+
+`@arakoodev/edgechains.js/vector-db` exports a dependency-free Qdrant REST
+client alongside the existing Supabase integration.
+
+```ts
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db";
+
+const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY);
+
+await qdrant.createCollection({
+    collectionName: "documents",
+    size: 1536,
+});
+
+await qdrant.upsertPoints({
+    collectionName: "documents",
+    points: [
+        {
+            id: 1,
+            vector: embedding,
+            payload: { content: "Text associated with the embedding" },
+        },
+    ],
+});
+
+const matches = await qdrant.searchPoints({
+    collectionName: "documents",
+    vector: queryEmbedding,
+    limit: 5,
+});
+```
+
+The client also exposes `getPointsByIds`, `deletePointsByIds`, and
+`deleteCollection`. `QDRANT_API_KEY` is optional for local Qdrant instances.

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
+export { Qdrant } from "./lib/qdrant/qdrant.js";
 export { Supabase } from "./lib/supabase/supabase.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,146 @@
+type PointId = number | string;
+type Vector = number[] | Record<string, number[]>;
+type Fetch = typeof fetch;
+
+export interface QdrantPoint {
+    id: PointId;
+    vector: Vector;
+    payload?: Record<string, unknown>;
+}
+
+interface CollectionArgs {
+    collectionName: string;
+}
+
+interface CreateCollectionArgs extends CollectionArgs {
+    size: number;
+    distance?: "Cosine" | "Dot" | "Euclid" | "Manhattan";
+}
+
+interface UpsertPointsArgs extends CollectionArgs {
+    points: QdrantPoint[];
+    wait?: boolean;
+}
+
+interface SearchPointsArgs extends CollectionArgs {
+    vector: Vector;
+    limit?: number;
+    filter?: Record<string, unknown>;
+    withPayload?: boolean;
+    withVector?: boolean;
+}
+
+interface GetPointsByIdsArgs extends CollectionArgs {
+    ids: PointId[];
+    withPayload?: boolean;
+    withVector?: boolean;
+}
+
+interface DeletePointsByIdsArgs extends CollectionArgs {
+    ids: PointId[];
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+    private fetchImpl: Fetch;
+
+    constructor(
+        QDRANT_URL: string = process.env.QDRANT_URL || "",
+        QDRANT_API_KEY: string = process.env.QDRANT_API_KEY || "",
+        fetchImpl: Fetch = fetch
+    ) {
+        if (!QDRANT_URL) {
+            throw new Error("QDRANT_URL is required");
+        }
+        this.QDRANT_URL = QDRANT_URL.replace(/\/+$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || undefined;
+        this.fetchImpl = fetchImpl;
+    }
+
+    async createCollection({
+        collectionName,
+        size,
+        distance = "Cosine",
+    }: CreateCollectionArgs): Promise<any> {
+        return this.request("PUT", `/collections/${encodeURIComponent(collectionName)}`, {
+            vectors: { size, distance },
+        });
+    }
+
+    async deleteCollection({ collectionName }: CollectionArgs): Promise<any> {
+        return this.request("DELETE", `/collections/${encodeURIComponent(collectionName)}`);
+    }
+
+    async upsertPoints({
+        collectionName,
+        points,
+        wait = true,
+    }: UpsertPointsArgs): Promise<any> {
+        return this.request(
+            "PUT",
+            `/collections/${encodeURIComponent(collectionName)}/points?wait=${wait}`,
+            { points }
+        );
+    }
+
+    async searchPoints({
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+    }: SearchPointsArgs): Promise<any> {
+        return this.request("POST", `/collections/${encodeURIComponent(collectionName)}/points/search`, {
+            vector,
+            limit,
+            filter,
+            with_payload: withPayload,
+            with_vector: withVector,
+        });
+    }
+
+    async getPointsByIds({
+        collectionName,
+        ids,
+        withPayload = true,
+        withVector = false,
+    }: GetPointsByIdsArgs): Promise<any> {
+        return this.request("POST", `/collections/${encodeURIComponent(collectionName)}/points`, {
+            ids,
+            with_payload: withPayload,
+            with_vector: withVector,
+        });
+    }
+
+    async deletePointsByIds({
+        collectionName,
+        ids,
+        wait = true,
+    }: DeletePointsByIdsArgs): Promise<any> {
+        return this.request(
+            "POST",
+            `/collections/${encodeURIComponent(collectionName)}/points/delete?wait=${wait}`,
+            { points: ids }
+        );
+    }
+
+    private async request(method: string, path: string, body?: unknown): Promise<any> {
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+        const response = await this.fetchImpl(`${this.QDRANT_URL}${path}`, {
+            method,
+            headers,
+            body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        const result = await response.json();
+        if (!response.ok) {
+            throw new Error(`Qdrant request failed (${response.status}): ${JSON.stringify(result)}`);
+        }
+        return result;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,85 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+function mockResponse(result: unknown, ok = true, status = 200): Response {
+    return {
+        ok,
+        status,
+        json: async () => result,
+    } as Response;
+}
+
+describe("Qdrant", () => {
+    it("creates a collection with an API key", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ result: true }));
+        const qdrant = new Qdrant("https://qdrant.example/", "secret", fetchMock);
+
+        await qdrant.createCollection({ collectionName: "documents", size: 3 });
+
+        expect(fetchMock).toHaveBeenCalledWith("https://qdrant.example/collections/documents", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json", "api-key": "secret" },
+            body: JSON.stringify({ vectors: { size: 3, distance: "Cosine" } }),
+        });
+    });
+
+    it("upserts points and waits for acknowledgement by default", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ result: { status: "completed" } }));
+        const qdrant = new Qdrant("https://qdrant.example", "", fetchMock);
+        const points = [{ id: 1, vector: [0.1, 0.2], payload: { content: "hello" } }];
+
+        await qdrant.upsertPoints({ collectionName: "my docs", points });
+
+        expect(fetchMock).toHaveBeenCalledWith("https://qdrant.example/collections/my%20docs/points?wait=true", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ points }),
+        });
+    });
+
+    it("searches points with payload and without vectors by default", async () => {
+        const result = { result: [{ id: 1, score: 0.9 }] };
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse(result));
+        const qdrant = new Qdrant("https://qdrant.example", "", fetchMock);
+
+        await expect(qdrant.searchPoints({ collectionName: "documents", vector: [0.1, 0.2] })).resolves.toEqual(result);
+        expect(fetchMock).toHaveBeenCalledWith("https://qdrant.example/collections/documents/points/search", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                vector: [0.1, 0.2],
+                limit: 10,
+                filter: undefined,
+                with_payload: true,
+                with_vector: false,
+            }),
+        });
+    });
+
+    it("retrieves and deletes selected points", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ result: [] }));
+        const qdrant = new Qdrant("https://qdrant.example", "", fetchMock);
+
+        await qdrant.getPointsByIds({ collectionName: "documents", ids: [1, "point-2"] });
+        await qdrant.deletePointsByIds({ collectionName: "documents", ids: [1, "point-2"] });
+
+        expect(fetchMock).toHaveBeenNthCalledWith(1, "https://qdrant.example/collections/documents/points", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ids: [1, "point-2"], with_payload: true, with_vector: false }),
+        });
+        expect(fetchMock).toHaveBeenNthCalledWith(2, "https://qdrant.example/collections/documents/points/delete?wait=true", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ points: [1, "point-2"] }),
+        });
+    });
+
+    it("surfaces Qdrant errors", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ status: { error: "missing collection" } }, false, 404));
+        const qdrant = new Qdrant("https://qdrant.example", "", fetchMock);
+
+        await expect(qdrant.deleteCollection({ collectionName: "missing" })).rejects.toThrow(
+            'Qdrant request failed (404): {"status":{"error":"missing collection"}}'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Closes #273

This PR adds dependency-free Qdrant REST support to the JavaScript SDK vector
database module.

## Included

- export `Qdrant` alongside the existing `Supabase` integration;
- configure Qdrant from constructor values or `QDRANT_URL` and
  `QDRANT_API_KEY`;
- create and delete collections;
- upsert points with optional payloads;
- search points with optional filters;
- retrieve points by ID;
- delete points by ID;
- URL-encode collection names and surface API errors;
- document a minimal Qdrant usage example;
- add isolated mocked-fetch tests without requiring a live Qdrant server.

## Validation

```text
npm exec -- tsc -b --pretty false

npm exec -- jest src/vector-db/src/tests --runInBand
Test Suites: 7 passed, 7 total
Tests:       12 passed, 12 total
```

The existing Jest configuration emits warnings about `presets` and
`isolatedModules`; this contribution does not introduce those warnings.

## AI assistance disclosure

GPT-5 Codex materially assisted with implementation and validation. The
contributor reviewed the change and remains responsible for the submitted
code.

/claim #273