### PR TITLE
feat(vector-db): add Qdrant REST client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,9 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+  QdrantCollectionConfig,
+  QdrantCollectionVector,
+  QdrantPoint,
+  QdrantScrollArgs,
+  QdrantSearchArgs,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,189 @@
+import { config } from "dotenv";
+config();
+
+type QdrantPayload = Record<string, unknown>;
+
+export interface QdrantPoint {
+  id: number | string;
+  vector: number[] | Record<string, number[]>;
+  payload?: QdrantPayload;
+}
+
+export interface QdrantCollectionVector {
+  size: number;
+  distance: "Cosine" | "Dot" | "Euclid" | "Manhattan";
+}
+
+export interface QdrantCollectionConfig {
+  vectors: QdrantCollectionVector | Record<string, QdrantCollectionVector>;
+  [key: string]: unknown;
+}
+
+export interface QdrantSearchArgs {
+  collectionName: string;
+  vector: number[] | Record<string, number[]>;
+  limit?: number;
+  filter?: QdrantPayload;
+  withPayload?: boolean | string[] | QdrantPayload;
+  withVector?: boolean | string[];
+  [key: string]: unknown;
+}
+
+export interface QdrantScrollArgs {
+  collectionName: string;
+  filter?: QdrantPayload;
+  limit?: number;
+  offset?: number | string;
+  withPayload?: boolean | string[] | QdrantPayload;
+  withVector?: boolean | string[];
+  [key: string]: unknown;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+
+  constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+    this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(
+      /\/+$/,
+      "",
+    );
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+  }
+
+  async createCollection(
+    collectionName: string,
+    config: QdrantCollectionConfig,
+  ): Promise<any> {
+    return this.request(
+      "PUT",
+      `/collections/${encodeURIComponent(collectionName)}`,
+      config,
+    );
+  }
+
+  async deleteCollection(collectionName: string): Promise<any> {
+    return this.request(
+      "DELETE",
+      `/collections/${encodeURIComponent(collectionName)}`,
+    );
+  }
+
+  async upsertPoints(
+    collectionName: string,
+    points: QdrantPoint[],
+  ): Promise<any> {
+    return this.request(
+      "PUT",
+      `/collections/${encodeURIComponent(collectionName)}/points`,
+      {
+        points,
+      },
+    );
+  }
+
+  async search({
+    collectionName,
+    vector,
+    limit = 10,
+    filter,
+    withPayload = true,
+    withVector = false,
+    ...args
+  }: QdrantSearchArgs): Promise<any> {
+    return this.request(
+      "POST",
+      `/collections/${encodeURIComponent(collectionName)}/points/search`,
+      {
+        vector,
+        limit,
+        filter,
+        with_payload: withPayload,
+        with_vector: withVector,
+        ...args,
+      },
+    );
+  }
+
+  async retrievePoints(
+    collectionName: string,
+    ids: Array<number | string>,
+  ): Promise<any> {
+    return this.request(
+      "POST",
+      `/collections/${encodeURIComponent(collectionName)}/points`,
+      {
+        ids,
+      },
+    );
+  }
+
+  async scroll({
+    collectionName,
+    filter,
+    limit = 10,
+    offset,
+    withPayload = true,
+    withVector = false,
+    ...args
+  }: QdrantScrollArgs): Promise<any> {
+    return this.request(
+      "POST",
+      `/collections/${encodeURIComponent(collectionName)}/points/scroll`,
+      {
+        filter,
+        limit,
+        offset,
+        with_payload: withPayload,
+        with_vector: withVector,
+        ...args,
+      },
+    );
+  }
+
+  async deletePoints(
+    collectionName: string,
+    ids: Array<number | string>,
+  ): Promise<any> {
+    return this.request(
+      "POST",
+      `/collections/${encodeURIComponent(collectionName)}/points/delete`,
+      {
+        points: ids,
+      },
+    );
+  }
+
+  private async request(
+    method: string,
+    path: string,
+    body?: QdrantPayload,
+  ): Promise<any> {
+    if (!this.QDRANT_URL) {
+      throw new Error("QDRANT_URL is required to create a Qdrant client");
+    }
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (this.QDRANT_API_KEY) {
+      headers["api-key"] = this.QDRANT_API_KEY;
+    }
+
+    const response = await fetch(`${this.QDRANT_URL}${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await response.text();
+    const payload = text ? JSON.parse(text) : {};
+
+    if (!response.ok) {
+      throw new Error(
+        `Qdrant request failed with status ${response.status}: ${JSON.stringify(payload)}`,
+      );
+    }
+
+    return payload;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,93 @@
+import { Qdrant } from "../../lib/qdrant/qdrant";
+
+const mockFetch = jest.fn();
+
+describe("Qdrant vector database client", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ result: "ok" }),
+    });
+    global.fetch = mockFetch;
+  });
+
+  it("creates collections with direct REST calls and api-key auth", async () => {
+    const qdrant = new Qdrant("https://qdrant.example/", "secret");
+
+    await qdrant.createCollection("docs", {
+      vectors: { size: 1536, distance: "Cosine" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://qdrant.example/collections/docs",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          "api-key": "secret",
+        },
+        body: JSON.stringify({ vectors: { size: 1536, distance: "Cosine" } }),
+      },
+    );
+  });
+
+  it("upserts and searches points without qdrant packages", async () => {
+    const qdrant = new Qdrant("https://qdrant.example");
+
+    await qdrant.upsertPoints("docs", [
+      {
+        id: 1,
+        vector: [0.1, 0.2, 0.3],
+        payload: { text: "hello" },
+      },
+    ]);
+    await qdrant.search({
+      collectionName: "docs",
+      vector: [0.1, 0.2, 0.3],
+      limit: 3,
+      filter: { must: [{ key: "kind", match: { value: "note" } }] },
+    });
+
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://qdrant.example/collections/docs/points",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          points: [
+            { id: 1, vector: [0.1, 0.2, 0.3], payload: { text: "hello" } },
+          ],
+        }),
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://qdrant.example/collections/docs/points/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          vector: [0.1, 0.2, 0.3],
+          limit: 3,
+          filter: { must: [{ key: "kind", match: { value: "note" } }] },
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+  });
+
+  it("throws a useful error when Qdrant returns a failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: async () => JSON.stringify({ status: { error: "not found" } }),
+    });
+    const qdrant = new Qdrant("https://qdrant.example");
+
+    await expect(qdrant.deleteCollection("missing")).rejects.toThrow(
+      "Qdrant request failed with status 404",
+    );
+  });
+});


### PR DESCRIPTION
/claim #273

## Summary
- Adds a dependency-free Qdrant REST client under the JavaScript vector-db package.
- Exports `Qdrant` and its public TypeScript argument types from `@arakoodev/edgechains.js/vector-db`.
- Covers collection creation, point upsert, search, and error handling with mocked REST tests.

## Verification
- `npm install --no-package-lock`
- `npx tsc -b`
- `npx jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand` -> 3 passed
- `npx prettier --check src/vector-db/src/lib/qdrant/qdrant.ts src/vector-db/src/index.ts src/vector-db/src/tests/qdrant/qdrant.test.ts`

Note: `npm run build` invokes `rm -rf`, which is not available in this Windows shell, so I ran the underlying TypeScript build step directly.