### PR TITLE
feat: add smart endpoint router

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,12 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { SmartEndpointRouter } from "./lib/smart-router/smartRouter.js";
+export type {
+  SmartRouterCallbacks,
+  SmartRouterChatOptions,
+  SmartRouterChatResponse,
+  SmartRouterDeployment,
+  SmartRouterMessage,
+  SmartRouterProvider,
+} from "./lib/smart-router/smartRouter.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/smart-router/smartRouter.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/smart-router/smartRouter.ts
@@ -1,0 +1,317 @@
+import axios, { AxiosError } from "axios";
+import { role } from "../../types/index.js";
+
+export type SmartRouterProvider = "openai" | "palm" | "cohere";
+
+export interface SmartRouterMessage {
+  role: role;
+  content: string;
+  name?: string;
+}
+
+export interface SmartRouterDeployment {
+  id: string;
+  provider: SmartRouterProvider;
+  apiKey: string;
+  model: string;
+  orgId?: string;
+  url?: string;
+  tokenLimit?: number;
+  cooldownMs?: number;
+}
+
+export interface SmartRouterChatOptions {
+  prompt?: string;
+  messages?: SmartRouterMessage[];
+  max_tokens?: number;
+  temperature?: number;
+  retryCount?: number;
+}
+
+export interface SmartRouterChatResponse {
+  content: string;
+  provider: SmartRouterProvider;
+  deploymentId: string;
+  raw: unknown;
+  usage: {
+    totalTokens: number;
+    promptTokens?: number;
+    completionTokens?: number;
+  };
+}
+
+export interface SmartRouterCallbackPayload {
+  deployment: SmartRouterDeployment;
+  options: SmartRouterChatOptions;
+  response?: SmartRouterChatResponse;
+  error?: unknown;
+  attempt: number;
+}
+
+export interface SmartRouterCallbacks {
+  onPreCall?: (payload: SmartRouterCallbackPayload) => void | Promise<void>;
+  onSuccess?: (payload: SmartRouterCallbackPayload) => void | Promise<void>;
+  onError?: (payload: SmartRouterCallbackPayload) => void | Promise<void>;
+}
+
+type SmartRouterTransport = (request: {
+  deployment: SmartRouterDeployment;
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+}) => Promise<unknown>;
+
+interface DeploymentState {
+  tokensUsed: number;
+  requestCount: number;
+  coolingDownUntil: number;
+  lastError?: unknown;
+}
+
+export interface SmartRouterOptions {
+  deployments: SmartRouterDeployment[];
+  callbacks?: SmartRouterCallbacks;
+  now?: () => number;
+  transport?: SmartRouterTransport;
+}
+
+const DEFAULT_COOLDOWN_MS = 30_000;
+
+export class SmartEndpointRouter {
+  private deployments: SmartRouterDeployment[];
+  private callbacks: SmartRouterCallbacks;
+  private state = new Map<string, DeploymentState>();
+  private now: () => number;
+  private transport: SmartRouterTransport;
+
+  constructor(options: SmartRouterOptions) {
+    if (!options.deployments.length) {
+      throw new Error("SmartEndpointRouter requires at least one deployment.");
+    }
+
+    this.deployments = options.deployments;
+    this.callbacks = options.callbacks || {};
+    this.now = options.now || Date.now;
+    this.transport = options.transport || this.defaultTransport;
+
+    for (const deployment of this.deployments) {
+      this.state.set(deployment.id, {
+        tokensUsed: 0,
+        requestCount: 0,
+        coolingDownUntil: 0,
+      });
+    }
+  }
+
+  getDeploymentState(deploymentId: string): DeploymentState | undefined {
+    return this.state.get(deploymentId);
+  }
+
+  async chat(
+    options: SmartRouterChatOptions,
+  ): Promise<SmartRouterChatResponse> {
+    const retryCount = options.retryCount ?? this.deployments.length;
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= retryCount; attempt += 1) {
+      const deployment = this.pickDeployment();
+      if (!deployment) {
+        throw new Error("No healthy deployment is available for routing.");
+      }
+
+      try {
+        await this.callbacks.onPreCall?.({ deployment, options, attempt });
+
+        const request = this.buildRequest(deployment, options);
+        const raw = await this.transport({
+          deployment,
+          ...request,
+        });
+        const response = this.normalizeResponse(deployment, raw);
+
+        this.recordSuccess(deployment.id, response.usage.totalTokens);
+        await this.callbacks.onSuccess?.({
+          deployment,
+          options,
+          response,
+          attempt,
+        });
+        return response;
+      } catch (error) {
+        lastError = error;
+        this.recordError(deployment, error);
+        await this.callbacks.onError?.({ deployment, options, error, attempt });
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("All routed deployments failed.");
+  }
+
+  private pickDeployment(): SmartRouterDeployment | undefined {
+    const now = this.now();
+
+    return this.deployments
+      .filter((deployment) => {
+        const state = this.state.get(deployment.id);
+        if (!state) return false;
+        if (state.coolingDownUntil > now) return false;
+        if (deployment.tokenLimit && state.tokensUsed >= deployment.tokenLimit)
+          return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const aState = this.state.get(a.id);
+        const bState = this.state.get(b.id);
+        return (aState?.tokensUsed || 0) - (bState?.tokensUsed || 0);
+      })[0];
+  }
+
+  private buildRequest(
+    deployment: SmartRouterDeployment,
+    options: SmartRouterChatOptions,
+  ): {
+    url: string;
+    headers: Record<string, string>;
+    body: Record<string, unknown>;
+  } {
+    const messages = options.prompt
+      ? [{ role: "user" as role, content: options.prompt }]
+      : options.messages || [];
+
+    if (deployment.provider === "openai") {
+      return {
+        url: deployment.url || "https://api.openai.com/v1/chat/completions",
+        headers: {
+          Authorization: `Bearer ${deployment.apiKey}`,
+          "Content-Type": "application/json",
+          ...(deployment.orgId
+            ? { "OpenAI-Organization": deployment.orgId }
+            : {}),
+        },
+        body: {
+          model: deployment.model,
+          messages,
+          max_tokens: options.max_tokens || 256,
+          temperature: options.temperature || 0.7,
+        },
+      };
+    }
+
+    if (deployment.provider === "palm") {
+      return {
+        url:
+          deployment.url ||
+          `https://generativelanguage.googleapis.com/v1beta/models/${deployment.model}:generateContent?key=${deployment.apiKey}`,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          contents: messages.map((message) => ({
+            role: message.role === "assistant" ? "model" : "user",
+            parts: [{ text: message.content }],
+          })),
+          generationConfig: {
+            maxOutputTokens: options.max_tokens || 256,
+            temperature: options.temperature || 0.7,
+          },
+        },
+      };
+    }
+
+    return {
+      url: deployment.url || "https://api.cohere.ai/v1/chat",
+      headers: {
+        Authorization: `Bearer ${deployment.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: {
+        model: deployment.model,
+        message: messages.map((message) => message.content).join("\n"),
+        temperature: options.temperature || 0.7,
+        max_tokens: options.max_tokens || 256,
+      },
+    };
+  }
+
+  private normalizeResponse(
+    deployment: SmartRouterDeployment,
+    raw: any,
+  ): SmartRouterChatResponse {
+    if (deployment.provider === "openai") {
+      return {
+        content: raw.choices?.[0]?.message?.content || "",
+        provider: deployment.provider,
+        deploymentId: deployment.id,
+        raw,
+        usage: {
+          totalTokens: raw.usage?.total_tokens || 0,
+          promptTokens: raw.usage?.prompt_tokens,
+          completionTokens: raw.usage?.completion_tokens,
+        },
+      };
+    }
+
+    if (deployment.provider === "palm") {
+      return {
+        content: raw.candidates?.[0]?.content?.parts?.[0]?.text || "",
+        provider: deployment.provider,
+        deploymentId: deployment.id,
+        raw,
+        usage: {
+          totalTokens: raw.usageMetadata?.totalTokenCount || 0,
+          promptTokens: raw.usageMetadata?.promptTokenCount,
+          completionTokens: raw.usageMetadata?.candidatesTokenCount,
+        },
+      };
+    }
+
+    return {
+      content: raw.text || raw.message?.content?.[0]?.text || "",
+      provider: deployment.provider,
+      deploymentId: deployment.id,
+      raw,
+      usage: {
+        totalTokens:
+          raw.meta?.tokens?.input_tokens + raw.meta?.tokens?.output_tokens || 0,
+        promptTokens: raw.meta?.tokens?.input_tokens,
+        completionTokens: raw.meta?.tokens?.output_tokens,
+      },
+    };
+  }
+
+  private recordSuccess(deploymentId: string, totalTokens: number): void {
+    const state = this.state.get(deploymentId);
+    if (!state) return;
+
+    state.tokensUsed += totalTokens;
+    state.requestCount += 1;
+    state.lastError = undefined;
+  }
+
+  private recordError(deployment: SmartRouterDeployment, error: unknown): void {
+    const state = this.state.get(deployment.id);
+    if (!state) return;
+
+    state.lastError = error;
+    if (this.shouldCooldown(error)) {
+      state.coolingDownUntil =
+        this.now() + (deployment.cooldownMs || DEFAULT_COOLDOWN_MS);
+    }
+  }
+
+  private shouldCooldown(error: unknown): boolean {
+    const status = (error as AxiosError)?.response?.status;
+    return status === 429 || (!!status && status >= 500);
+  }
+
+  private defaultTransport: SmartRouterTransport = async ({
+    url,
+    headers,
+    body,
+  }) => {
+    const response = await axios.post(url, body, { headers });
+    return response.data;
+  };
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/smartRouter.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/smartRouter.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  SmartEndpointRouter,
+  SmartRouterDeployment,
+} from "../lib/smart-router/smartRouter.js";
+
+const deployments: SmartRouterDeployment[] = [
+  {
+    id: "openai-primary",
+    provider: "openai",
+    apiKey: "openai-key",
+    model: "gpt-4o",
+    tokenLimit: 100,
+  },
+  {
+    id: "cohere-backup",
+    provider: "cohere",
+    apiKey: "cohere-key",
+    model: "command-r",
+    tokenLimit: 100,
+  },
+];
+
+describe("SmartEndpointRouter", () => {
+  it("routes to the healthy deployment with the least token usage", async () => {
+    const transport = vi
+      .fn()
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: "first" } }],
+        usage: { total_tokens: 90 },
+      })
+      .mockResolvedValueOnce({
+        text: "second",
+        meta: { tokens: { input_tokens: 2, output_tokens: 3 } },
+      });
+
+    const router = new SmartEndpointRouter({ deployments, transport });
+
+    const first = await router.chat({ prompt: "hello" });
+    const second = await router.chat({ prompt: "hello again" });
+
+    expect(first.deploymentId).toBe("openai-primary");
+    expect(second.deploymentId).toBe("cohere-backup");
+    expect(transport).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        deployment: expect.objectContaining({ id: "cohere-backup" }),
+      }),
+    );
+  });
+
+  it("puts rate-limited deployments on cooldown and retries another deployment", async () => {
+    let now = 1_000;
+    const transport = vi
+      .fn()
+      .mockRejectedValueOnce({ response: { status: 429 } })
+      .mockResolvedValueOnce({
+        text: "backup",
+        meta: { tokens: { input_tokens: 1, output_tokens: 1 } },
+      })
+      .mockResolvedValue({
+        text: "backup again",
+        meta: { tokens: { input_tokens: 1, output_tokens: 1 } },
+      });
+
+    const router = new SmartEndpointRouter({
+      deployments: [{ ...deployments[0], cooldownMs: 5_000 }, deployments[1]],
+      now: () => now,
+      transport,
+    });
+
+    const response = await router.chat({ prompt: "retry me", retryCount: 2 });
+
+    expect(response.deploymentId).toBe("cohere-backup");
+    expect(router.getDeploymentState("openai-primary")?.coolingDownUntil).toBe(
+      6_000,
+    );
+
+    now = 2_000;
+    await router.chat({ prompt: "still cooling" });
+
+    expect(transport).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        deployment: expect.objectContaining({ id: "cohere-backup" }),
+      }),
+    );
+  });
+
+  it("emits observability callbacks for successful calls", async () => {
+    const onPreCall = vi.fn();
+    const onSuccess = vi.fn();
+    const transport = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "observed" } }],
+      usage: { total_tokens: 4 },
+    });
+
+    const router = new SmartEndpointRouter({
+      deployments: [deployments[0]],
+      callbacks: { onPreCall, onSuccess },
+      transport,
+    });
+
+    const response = await router.chat({ prompt: "track this" });
+
+    expect(response.content).toBe("observed");
+    expect(onPreCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deployment: expect.objectContaining({ id: "openai-primary" }),
+        attempt: 1,
+      }),
+    );
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        response: expect.objectContaining({ content: "observed" }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Summary
- Adds SmartEndpointRouter for OpenAI, PaLM/Gemini-style, and Cohere deployments.
- Routes requests to the healthy deployment with the least token usage.
- Supports token limits, cooldown after 429/5xx failures, retries across deployments, and observability callbacks.
- Adds mocked tests for routing, cooldown retry behavior, and callback emission.

/claim #286

Validation
- npx.cmd -y prettier@3.2.5 --check src/ai/src/lib/smart-router/smartRouter.ts src/ai/src/tests/smartRouter.test.ts src/ai/src/index.ts
- npx.cmd -y vitest@2.0.3 run src/ai/src/tests/smartRouter.test.ts
- npx.cmd -y esbuild@0.20.2 src/ai/src/index.ts --bundle --external:* --platform=node --format=esm --outfile=$env:TEMP\edgechains-ai-router.mjs --log-level=error
- npx.cmd -p typescript@5.6.3 tsc -p tsconfig.json --emitDeclarationOnly --outDir <temp>