### PR TITLE
Add AWS Comprehend PII redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
+        "@aws-sdk/client-comprehend": "^3.1057.0",
         "@hono/node-server": "^0.6.0",
         "@lifeomic/attempt": "^3.1.0",
         "@playwright/test": "^1.45.3",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,4 +1,5 @@
 export { OpenAI } from "./lib/openai/openai.js";
+export { ComprehendPiiRedactor } from "./lib/aws/comprehend-pii-redactor.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehend-pii-redactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws/comprehend-pii-redactor.ts
@@ -1,0 +1,165 @@
+import {
+    ComprehendClient,
+    DetectPiiEntitiesCommand,
+    type DetectPiiEntitiesCommandOutput,
+    type LanguageCode,
+    type PiiEntity,
+} from "@aws-sdk/client-comprehend";
+
+export interface ComprehendPiiRedactorClient {
+    send(
+        command: DetectPiiEntitiesCommand,
+    ): Promise<DetectPiiEntitiesCommandOutput>;
+}
+
+export interface RedactableMessage {
+    role: string;
+    content: string;
+    name?: string;
+}
+
+export interface RedactableChatOptions {
+    prompt?: string;
+    messages?: RedactableMessage[];
+    [key: string]: unknown;
+}
+
+export interface ChatEndpoint<TOptions extends RedactableChatOptions, TResult> {
+    chat(options: TOptions): Promise<TResult>;
+}
+
+export interface ComprehendPiiRedactorOptions {
+    client?: ComprehendPiiRedactorClient;
+    languageCode?: LanguageCode;
+    maxConcurrency?: number;
+    replacementForEntity?: (entity: PiiEntity) => string;
+    region?: string;
+}
+
+export class ComprehendPiiRedactor {
+    private client: ComprehendPiiRedactorClient;
+    private languageCode: LanguageCode;
+    private maxConcurrency: number;
+    private replacementForEntity: (entity: PiiEntity) => string;
+
+    constructor(options: ComprehendPiiRedactorOptions = {}) {
+        this.client =
+            options.client ||
+            new ComprehendClient({
+                region:
+                    options.region ||
+                    process.env.AWS_REGION ||
+                    process.env.AWS_DEFAULT_REGION ||
+                    "us-east-1",
+            });
+        this.languageCode = options.languageCode || "en";
+        this.maxConcurrency = Math.max(1, options.maxConcurrency || 1);
+        this.replacementForEntity =
+            options.replacementForEntity ||
+            ((entity) => `[${entity.Type || "PII"}]`);
+    }
+
+    async redactText(text: string): Promise<string> {
+        if (!text) return text;
+
+        const response = await this.client.send(
+            new DetectPiiEntitiesCommand({
+                Text: text,
+                LanguageCode: this.languageCode,
+            }),
+        );
+
+        return this.applyRedactions(text, response.Entities || []);
+    }
+
+    async redactMessages<TMessage extends RedactableMessage>(
+        messages: TMessage[],
+    ): Promise<TMessage[]> {
+        return this.mapWithConcurrency(messages, async (message) => ({
+            ...message,
+            content: await this.redactText(message.content),
+        }));
+    }
+
+    async redactChatOptions<TOptions extends RedactableChatOptions>(
+        options: TOptions,
+    ): Promise<TOptions> {
+        const redactedOptions = { ...options };
+
+        if (typeof options.prompt === "string") {
+            redactedOptions.prompt = await this.redactText(options.prompt);
+        }
+
+        if (options.messages) {
+            redactedOptions.messages = await this.redactMessages(
+                options.messages,
+            );
+        }
+
+        return redactedOptions;
+    }
+
+    wrap<TOptions extends RedactableChatOptions, TResult>(
+        endpoint: ChatEndpoint<TOptions, TResult>,
+    ): ChatEndpoint<TOptions, TResult> {
+        return {
+            chat: async (options: TOptions) =>
+                endpoint.chat(await this.redactChatOptions(options)),
+        };
+    }
+
+    pipe<TOptions extends RedactableChatOptions, TResult>(
+        endpoint: ChatEndpoint<TOptions, TResult>,
+    ): ChatEndpoint<TOptions, TResult> {
+        return this.wrap(endpoint);
+    }
+
+    private async mapWithConcurrency<TItem, TResult>(
+        items: TItem[],
+        mapper: (item: TItem) => Promise<TResult>,
+    ): Promise<TResult[]> {
+        const results: TResult[] = [];
+        let nextIndex = 0;
+        const workerCount = Math.min(this.maxConcurrency, items.length);
+        const workers = Array.from({ length: workerCount }, async () => {
+            while (nextIndex < items.length) {
+                const currentIndex = nextIndex;
+                nextIndex += 1;
+                results[currentIndex] = await mapper(items[currentIndex]);
+            }
+        });
+
+        await Promise.all(workers);
+
+        return results;
+    }
+
+    private applyRedactions(text: string, entities: PiiEntity[]): string {
+        const codePoints = Array.from(text);
+
+        return entities
+            .filter(
+                (
+                    entity,
+                ): entity is PiiEntity & {
+                    BeginOffset: number;
+                    EndOffset: number;
+                } =>
+                    typeof entity.BeginOffset === "number" &&
+                    typeof entity.EndOffset === "number" &&
+                    entity.BeginOffset < entity.EndOffset &&
+                    entity.EndOffset <= codePoints.length,
+            )
+            .sort((left, right) => right.BeginOffset - left.BeginOffset)
+            .reduce((redactedCodePoints, entity) => {
+                redactedCodePoints.splice(
+                    entity.BeginOffset,
+                    entity.EndOffset - entity.BeginOffset,
+                    this.replacementForEntity(entity),
+                );
+
+                return redactedCodePoints;
+            }, codePoints)
+            .join("");
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehendPiiRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehendPiiRedactor.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { DetectPiiEntitiesCommand } from "@aws-sdk/client-comprehend";
+import { ComprehendPiiRedactor } from "../lib/aws/comprehend-pii-redactor.js";
+
+describe("ComprehendPiiRedactor", () => {
+    test("redacts detected PII entities in text", async () => {
+        const sentCommands: DetectPiiEntitiesCommand[] = [];
+        const redactor = new ComprehendPiiRedactor({
+            client: {
+                send: async (command) => {
+                    sentCommands.push(command);
+                    return {
+                        Entities: [
+                            { Type: "NAME", BeginOffset: 0, EndOffset: 5 },
+                            { Type: "EMAIL", BeginOffset: 14, EndOffset: 27 },
+                        ],
+                    };
+                },
+            },
+        });
+
+        const result = await redactor.redactText("Alice emailed a@example.com");
+
+        expect(result).toBe("[NAME] emailed [EMAIL]");
+        expect(sentCommands[0].input).toEqual({
+            Text: "Alice emailed a@example.com",
+            LanguageCode: "en",
+        });
+    });
+
+    test("redacts unsorted entities using AWS code point offsets", async () => {
+        const redactor = new ComprehendPiiRedactor({
+            client: {
+                send: async () => ({
+                    Entities: [
+                        { Type: "NAME", BeginOffset: 13, EndOffset: 16 },
+                        { Type: "NAME", BeginOffset: 2, EndOffset: 7 },
+                    ],
+                }),
+            },
+        });
+
+        const result = await redactor.redactText("🙂 Alice paid Bob");
+
+        expect(result).toBe("🙂 [NAME] paid [NAME]");
+    });
+
+    test("redacts prompt before calling a wrapped endpoint", async () => {
+        let receivedPrompt = "";
+        const redactor = new ComprehendPiiRedactor({
+            client: {
+                send: async () => ({
+                    Entities: [
+                        { Type: "PHONE", BeginOffset: 8, EndOffset: 20 },
+                    ],
+                }),
+            },
+        });
+        const endpoint = redactor.wrap({
+            chat: async (options: { prompt: string; temperature?: number }) => {
+                receivedPrompt = options.prompt;
+                return { content: "ok" };
+            },
+        });
+
+        const result = await endpoint.chat({
+            prompt: "Call me 555-123-4567",
+            temperature: 0.1,
+        });
+
+        expect(result).toEqual({ content: "ok" });
+        expect(receivedPrompt).toBe("Call me [PHONE]");
+    });
+
+    test("redacts chat messages while preserving message metadata", async () => {
+        const redactor = new ComprehendPiiRedactor({
+            client: {
+                send: async (command) => {
+                    const text = command.input.Text || "";
+                    if (text.includes("passport")) {
+                        return {
+                            Entities: [
+                                {
+                                    Type: "ID",
+                                    BeginOffset: 12,
+                                    EndOffset: text.length,
+                                },
+                            ],
+                        };
+                    }
+                    return { Entities: [] };
+                },
+            },
+        });
+
+        const result = await redactor.redactMessages([
+            { role: "system", content: "Be concise" },
+            { role: "user", content: "My passport AB123456", name: "customer" },
+        ]);
+
+        expect(result).toEqual([
+            { role: "system", content: "Be concise" },
+            { role: "user", content: "My passport [ID]", name: "customer" },
+        ]);
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,17 @@
+# AWS Comprehend PII Redaction
+
+This example shows how to redact PII from a prompt with AWS Comprehend before sending it to an EdgeChains AI endpoint.
+
+## Setup
+
+```bash
+npm install
+AWS_REGION=us-east-1 OPENAI_API_KEY=... npm start
+```
+
+The `ComprehendPiiRedactor` can wrap any endpoint with a `chat(...)` method:
+
+```ts
+const safeOpenAI = redactor.pipe(openAI);
+await safeOpenAI.chat({ prompt: "Call Alice at 555-123-4567" });
+```

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "aws-comprehend-redaction-example",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "start": "tsx src/index.ts"
+    },
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@aws-sdk/client-comprehend": "^3.1057.0",
+        "tsx": "^4.19.2"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,26 @@
+import { ComprehendPiiRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+async function main() {
+    const openAI = new OpenAI({
+        apiKey: process.env.OPENAI_API_KEY,
+        orgId: process.env.OPENAI_ORG_ID,
+    });
+
+    const redactor = new ComprehendPiiRedactor({
+        region: process.env.AWS_REGION || "us-east-1",
+    });
+
+    const safeOpenAI = redactor.pipe(openAI);
+
+    const response = await safeOpenAI.chat({
+        prompt: "Summarize this support note: Alice called from 555-123-4567 about invoice INV-100.",
+        temperature: 0.2,
+    });
+
+    console.log(response);
+}
+
+main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #290.

## Summary
- adds `ComprehendPiiRedactor`, backed by AWS Comprehend `DetectPiiEntitiesCommand`
- supports `redactText`, `redactMessages`, `redactChatOptions`, plus `wrap`/`pipe` for chaining before any endpoint with `chat(...)`
- exports the utility from `@arakoodev/edgechains.js/ai`
- adds an `examples/aws-comprehend-redaction` example and README

## Tests
- `npx vitest run src/ai/src/tests/comprehendPiiRedactor.test.ts`
- `npm run build`

## Note
A full `npx vitest run` still fails on pre-existing suites that rely on Jest globals, old `dist/openai/...` import paths, missing Playwright browser install, and one scraper test receiving a 403 from the target site. The new redactor test and package build pass locally.