### PR TITLE
Add AWS Comprehend PII redaction support

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
+        "@aws-sdk/client-comprehend": "^3.1062.0",
         "@hono/node-server": "^0.6.0",
         "@lifeomic/attempt": "^3.1.0",
         "@playwright/test": "^1.45.3",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,9 +3,12 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
-export { ComprehendPIIRedactor } from "./lib/comprehend/comprehend.js";
+export { AWSComprehend, ComprehendPIIRedactor } from "./lib/comprehend/comprehend.js";
 export type {
+    AWSComprehendOptions,
     ComprehendPIIRedactorOptions,
+    RedactableMessage,
+    RedactablePromptOptions,
     RedactPIIOptions,
     RedactPIIResponse,
     RedactionReplacement,

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,10 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { ComprehendPIIRedactor } from "./lib/comprehend/comprehend.js";
+export type {
+    ComprehendPIIRedactorOptions,
+    RedactPIIOptions,
+    RedactPIIResponse,
+    RedactionReplacement,
+} from "./lib/comprehend/comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
@@ -8,7 +8,7 @@ import {
 type ComprehendClientLike = Pick<ComprehendClient, "send">;
 type RedactionReplacement = string | ((entity: PiiEntity) => string);
 
-interface ComprehendPIIRedactorOptions {
+interface AWSComprehendOptions {
     accessKeyId?: string;
     client?: ComprehendClientLike;
     entityTypes?: string[];
@@ -28,20 +28,31 @@ interface RedactPIIOptions {
     text: string;
 }
 
+interface RedactableMessage {
+    content?: string;
+    [key: string]: any;
+}
+
+interface RedactablePromptOptions {
+    messages?: RedactableMessage[];
+    prompt?: string;
+    [key: string]: any;
+}
+
 interface RedactPIIResponse {
     entities: PiiEntity[];
     redactedText: string;
     text: string;
 }
 
-export class ComprehendPIIRedactor {
+export class AWSComprehend {
     private client: ComprehendClientLike;
     private entityTypes?: string[];
     private languageCode: LanguageCode;
     private minScore: number;
     private replacement?: RedactionReplacement;
 
-    constructor(options: ComprehendPIIRedactorOptions = {}) {
+    constructor(options: AWSComprehendOptions = {}) {
         this.client =
             options.client ||
             new ComprehendClient({
@@ -61,16 +72,12 @@ export class ComprehendPIIRedactor {
         this.replacement = options.replacement;
     }
 
-    async detectPiiEntities({
-        entityTypes,
-        languageCode,
-        minScore,
-        text,
-    }: RedactPIIOptions): Promise<PiiEntity[]> {
+    async detectPiiEntities(options: RedactPIIOptions | string): Promise<PiiEntity[]> {
+        const redactOptions = this.normalizeOptions(options);
         const response = await this.client.send(
             new DetectPiiEntitiesCommand({
-                LanguageCode: languageCode || this.languageCode,
-                Text: text,
+                LanguageCode: redactOptions.languageCode || this.languageCode,
+                Text: redactOptions.text,
             })
         );
 
@@ -78,16 +85,16 @@ export class ComprehendPIIRedactor {
             if (entity.BeginOffset === undefined || entity.EndOffset === undefined) {
                 return false;
             }
-            if ((entity.Score || 0) < (minScore ?? this.minScore)) {
+            if ((entity.Score || 0) < (redactOptions.minScore ?? this.minScore)) {
                 return false;
             }
-            const allowedTypes = entityTypes || this.entityTypes;
+            const allowedTypes = redactOptions.entityTypes || this.entityTypes;
             return !allowedTypes || allowedTypes.includes(entity.Type || "");
         });
     }
 
     async redact(options: RedactPIIOptions | string): Promise<RedactPIIResponse> {
-        const redactOptions = typeof options === "string" ? { text: options } : options;
+        const redactOptions = this.normalizeOptions(options);
         const entities = await this.detectPiiEntities(redactOptions);
 
         return {
@@ -99,6 +106,51 @@ export class ComprehendPIIRedactor {
             ),
             text: redactOptions.text,
         };
+    }
+
+    async redactPrompt(options: RedactPIIOptions | string): Promise<string> {
+        const result = await this.redact(options);
+
+        return result.redactedText;
+    }
+
+    async containsPii(options: RedactPIIOptions | string): Promise<boolean> {
+        const entities = await this.detectPiiEntities(options);
+
+        return entities.length > 0;
+    }
+
+    async redactPromptOptions<T extends RedactablePromptOptions>(options: T): Promise<T> {
+        const redactedOptions = { ...options };
+
+        if (typeof options.prompt === "string") {
+            redactedOptions.prompt = await this.redactPrompt(options.prompt);
+        }
+
+        if (Array.isArray(options.messages)) {
+            redactedOptions.messages = await Promise.all(
+                options.messages.map(async (message) => {
+                    if (typeof message.content !== "string") {
+                        return { ...message };
+                    }
+
+                    return {
+                        ...message,
+                        content: await this.redactPrompt(message.content),
+                    };
+                })
+            );
+        }
+
+        return redactedOptions;
+    }
+
+    asPromptMiddleware() {
+        return <T extends RedactablePromptOptions>(options: T) => this.redactPromptOptions(options);
+    }
+
+    private normalizeOptions(options: RedactPIIOptions | string): RedactPIIOptions {
+        return typeof options === "string" ? { text: options } : options;
     }
 
     private redactText(
@@ -125,8 +177,15 @@ export class ComprehendPIIRedactor {
     }
 }
 
+export class ComprehendPIIRedactor extends AWSComprehend {}
+
+type ComprehendPIIRedactorOptions = AWSComprehendOptions;
+
 export type {
+    AWSComprehendOptions,
     ComprehendPIIRedactorOptions,
+    RedactableMessage,
+    RedactablePromptOptions,
     RedactPIIOptions,
     RedactPIIResponse,
     RedactionReplacement,

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
@@ -1,0 +1,133 @@
+import {
+    ComprehendClient,
+    DetectPiiEntitiesCommand,
+    LanguageCode,
+    PiiEntity,
+} from "@aws-sdk/client-comprehend";
+
+type ComprehendClientLike = Pick<ComprehendClient, "send">;
+type RedactionReplacement = string | ((entity: PiiEntity) => string);
+
+interface ComprehendPIIRedactorOptions {
+    accessKeyId?: string;
+    client?: ComprehendClientLike;
+    entityTypes?: string[];
+    languageCode?: LanguageCode;
+    minScore?: number;
+    region?: string;
+    replacement?: RedactionReplacement;
+    secretAccessKey?: string;
+    sessionToken?: string;
+}
+
+interface RedactPIIOptions {
+    entityTypes?: string[];
+    languageCode?: LanguageCode;
+    minScore?: number;
+    replacement?: RedactionReplacement;
+    text: string;
+}
+
+interface RedactPIIResponse {
+    entities: PiiEntity[];
+    redactedText: string;
+    text: string;
+}
+
+export class ComprehendPIIRedactor {
+    private client: ComprehendClientLike;
+    private entityTypes?: string[];
+    private languageCode: LanguageCode;
+    private minScore: number;
+    private replacement?: RedactionReplacement;
+
+    constructor(options: ComprehendPIIRedactorOptions = {}) {
+        this.client =
+            options.client ||
+            new ComprehendClient({
+                region: options.region || process.env.AWS_REGION || "us-east-1",
+                credentials:
+                    options.accessKeyId && options.secretAccessKey
+                        ? {
+                              accessKeyId: options.accessKeyId,
+                              secretAccessKey: options.secretAccessKey,
+                              sessionToken: options.sessionToken,
+                          }
+                        : undefined,
+            });
+        this.entityTypes = options.entityTypes;
+        this.languageCode = options.languageCode || LanguageCode.EN;
+        this.minScore = options.minScore ?? 0;
+        this.replacement = options.replacement;
+    }
+
+    async detectPiiEntities({
+        entityTypes,
+        languageCode,
+        minScore,
+        text,
+    }: RedactPIIOptions): Promise<PiiEntity[]> {
+        const response = await this.client.send(
+            new DetectPiiEntitiesCommand({
+                LanguageCode: languageCode || this.languageCode,
+                Text: text,
+            })
+        );
+
+        return (response.Entities || []).filter((entity) => {
+            if (entity.BeginOffset === undefined || entity.EndOffset === undefined) {
+                return false;
+            }
+            if ((entity.Score || 0) < (minScore ?? this.minScore)) {
+                return false;
+            }
+            const allowedTypes = entityTypes || this.entityTypes;
+            return !allowedTypes || allowedTypes.includes(entity.Type || "");
+        });
+    }
+
+    async redact(options: RedactPIIOptions | string): Promise<RedactPIIResponse> {
+        const redactOptions = typeof options === "string" ? { text: options } : options;
+        const entities = await this.detectPiiEntities(redactOptions);
+
+        return {
+            entities,
+            redactedText: this.redactText(
+                redactOptions.text,
+                entities,
+                redactOptions.replacement || this.replacement
+            ),
+            text: redactOptions.text,
+        };
+    }
+
+    private redactText(
+        text: string,
+        entities: PiiEntity[],
+        replacement?: RedactionReplacement
+    ): string {
+        return [...entities]
+            .sort((a, b) => (b.BeginOffset || 0) - (a.BeginOffset || 0))
+            .reduce((redactedText, entity) => {
+                const beginOffset = entity.BeginOffset || 0;
+                const endOffset = entity.EndOffset || beginOffset;
+                const redaction =
+                    typeof replacement === "function"
+                        ? replacement(entity)
+                        : replacement || `[${entity.Type || "PII"}]`;
+
+                return (
+                    redactedText.slice(0, beginOffset) +
+                    redaction +
+                    redactedText.slice(endOffset)
+                );
+            }, text);
+    }
+}
+
+export type {
+    ComprehendPIIRedactorOptions,
+    RedactPIIOptions,
+    RedactPIIResponse,
+    RedactionReplacement,
+};

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehendPIIRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehendPIIRedactor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { ComprehendPIIRedactor } from "../lib/comprehend/comprehend.js";
+import { AWSComprehend, ComprehendPIIRedactor } from "../lib/comprehend/comprehend.js";
 
-describe("ComprehendPIIRedactor", () => {
+describe("AWSComprehend", () => {
     it("redacts PII entities returned by AWS Comprehend", async () => {
         const send = vi.fn().mockResolvedValue({
             Entities: [
@@ -19,7 +19,7 @@ describe("ComprehendPIIRedactor", () => {
                 },
             ],
         });
-        const redactor = new ComprehendPIIRedactor({
+        const redactor = new AWSComprehend({
             client: { send } as any,
         });
 
@@ -57,7 +57,7 @@ describe("ComprehendPIIRedactor", () => {
                 },
             ],
         });
-        const redactor = new ComprehendPIIRedactor({
+        const redactor = new AWSComprehend({
             client: { send } as any,
             entityTypes: ["PHONE", "EMAIL"],
             minScore: 0.9,
@@ -68,5 +68,78 @@ describe("ComprehendPIIRedactor", () => {
 
         expect(result.redactedText).toBe("Jane Doe at <PHONE> or jane.doe@test.com");
         expect(result.entities.map((entity) => entity.Type)).toEqual(["PHONE"]);
+    });
+
+    it("redacts OpenAI-compatible prompt options without mutating the original", async () => {
+        const send = vi.fn(async (command) => {
+            const text = command.input.Text;
+
+            if (text === "Email jane@example.com") {
+                return {
+                    Entities: [
+                        {
+                            BeginOffset: 6,
+                            EndOffset: 22,
+                            Score: 0.99,
+                            Type: "EMAIL",
+                        },
+                    ],
+                };
+            }
+
+            if (text === "Call 555-010-4444") {
+                return {
+                    Entities: [
+                        {
+                            BeginOffset: 5,
+                            EndOffset: 17,
+                            Score: 0.99,
+                            Type: "PHONE",
+                        },
+                    ],
+                };
+            }
+
+            return { Entities: [] };
+        });
+        const redactor = new AWSComprehend({
+            client: { send } as any,
+        });
+        const chatOptions = {
+            model: "gpt-3.5-turbo",
+            prompt: "Email jane@example.com",
+            messages: [
+                {
+                    role: "user",
+                    content: "Call 555-010-4444",
+                },
+            ],
+        };
+
+        const result = await redactor.redactPromptOptions(chatOptions);
+
+        expect(result).toEqual({
+            model: "gpt-3.5-turbo",
+            prompt: "Email [EMAIL]",
+            messages: [
+                {
+                    role: "user",
+                    content: "Call [PHONE]",
+                },
+            ],
+        });
+        expect(chatOptions.prompt).toBe("Email jane@example.com");
+        expect(chatOptions.messages[0].content).toBe("Call 555-010-4444");
+    });
+
+    it("keeps ComprehendPIIRedactor as a compatibility alias", async () => {
+        const send = vi.fn().mockResolvedValue({
+            Entities: [],
+        });
+        const redactor = new ComprehendPIIRedactor({
+            client: { send } as any,
+        });
+
+        await expect(redactor.containsPii("No sensitive data")).resolves.toBe(false);
     });
 });

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehendPIIRedactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehendPIIRedactor.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { ComprehendPIIRedactor } from "../lib/comprehend/comprehend.js";
+
+describe("ComprehendPIIRedactor", () => {
+    it("redacts PII entities returned by AWS Comprehend", async () => {
+        const send = vi.fn().mockResolvedValue({
+            Entities: [
+                {
+                    BeginOffset: 17,
+                    EndOffset: 33,
+                    Score: 0.99,
+                    Type: "EMAIL",
+                },
+                {
+                    BeginOffset: 5,
+                    EndOffset: 13,
+                    Score: 0.98,
+                    Type: "NAME",
+                },
+            ],
+        });
+        const redactor = new ComprehendPIIRedactor({
+            client: { send } as any,
+        });
+
+        const result = await redactor.redact("Call Jane Doe at jane@example.com");
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0].input).toMatchObject({
+            LanguageCode: "en",
+            Text: "Call Jane Doe at jane@example.com",
+        });
+        expect(result.redactedText).toBe("Call [NAME] at [EMAIL]");
+        expect(result.entities).toHaveLength(2);
+    });
+
+    it("supports custom replacements and entity filters", async () => {
+        const send = vi.fn().mockResolvedValue({
+            Entities: [
+                {
+                    BeginOffset: 0,
+                    EndOffset: 8,
+                    Score: 0.99,
+                    Type: "NAME",
+                },
+                {
+                    BeginOffset: 12,
+                    EndOffset: 24,
+                    Score: 0.95,
+                    Type: "PHONE",
+                },
+                {
+                    BeginOffset: 28,
+                    EndOffset: 45,
+                    Score: 0.25,
+                    Type: "EMAIL",
+                },
+            ],
+        });
+        const redactor = new ComprehendPIIRedactor({
+            client: { send } as any,
+            entityTypes: ["PHONE", "EMAIL"],
+            minScore: 0.9,
+            replacement: (entity) => `<${entity.Type}>`,
+        });
+
+        const result = await redactor.redact("Jane Doe at 555-010-4444 or jane.doe@test.com");
+
+        expect(result.redactedText).toBe("Jane Doe at <PHONE> or jane.doe@test.com");
+        expect(result.entities.map((entity) => entity.Type)).toEqual(["PHONE"]);
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,6 +1,6 @@
 # AWS Comprehend Redaction Example
 
-This example reads a prompt from Jsonnet, detects PII with AWS Comprehend, and prints the redacted prompt.
+This example reads a prompt from Jsonnet, detects PII with AWS Comprehend, and prints prompt options that can be passed to an LLM endpoint after redaction.
 
 ## Installation
 
@@ -28,3 +28,14 @@ npm run start
 ```
 
 The prompt lives in `jsonnet/main.jsonnet` so the example does not hardcode prompt text in TypeScript.
+
+The `AWSComprehend` class can also be chained before existing endpoint calls:
+
+```ts
+const safeChatOptions = await comprehend.redactPromptOptions({
+    prompt: rawPrompt,
+    temperature: 0.2,
+});
+
+await openai.chat(safeChatOptions);
+```

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,30 @@
+# AWS Comprehend Redaction Example
+
+This example reads a prompt from Jsonnet, detects PII with AWS Comprehend, and prints the redacted prompt.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Configuration
+
+Add AWS credentials to `jsonnet/secrets.jsonnet`, or leave them as placeholders and use the default AWS credential chain from your environment.
+
+```jsonnet
+{
+    aws_access_key_id: "YOUR_AWS_ACCESS_KEY_ID",
+    aws_region: "us-east-1",
+    aws_secret_access_key: "YOUR_AWS_SECRET_ACCESS_KEY",
+    aws_session_token: "",
+}
+```
+
+## Usage
+
+```bash
+npm run start
+```
+
+The prompt lives in `jsonnet/main.jsonnet` so the example does not hardcode prompt text in TypeScript.

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,10 @@
+local prompt = |||
+Please summarize this customer message before sending it to a model:
+
+Jane Doe can be reached at jane.doe@example.com or 555-010-4444.
+|||;
+
+{
+    language_code: "en",
+    prompt: prompt,
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/secrets.jsonnet
@@ -1,0 +1,6 @@
+{
+    aws_access_key_id: "YOUR_AWS_ACCESS_KEY_ID",
+    aws_region: "us-east-1",
+    aws_secret_access_key: "YOUR_AWS_SECRET_ACCESS_KEY",
+    aws_session_token: "",
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "aws-comprehend-redaction",
+    "version": "1.0.0",
+    "description": "Redact PII from prompts with AWS Comprehend before sending them to an LLM.",
+    "main": "index.js",
+    "type": "module",
+    "scripts": {
+        "build": "tsc -b",
+        "start": "tsc && node dist/index.js"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0",
+        "path": "^0.12.7"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,64 @@
+import { ComprehendPIIRedactor } from "@arakoodev/edgechains.js/ai";
+import Jsonnet from "@arakoodev/jsonnet";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+type Secrets = {
+    aws_access_key_id?: string;
+    aws_region?: string;
+    aws_secret_access_key?: string;
+    aws_session_token?: string;
+};
+
+type PromptConfig = {
+    language_code?: "en" | "es" | "fr" | "de" | "it" | "pt" | "ar" | "hi" | "ja" | "ko" | "zh" | "zh-TW";
+    prompt: string;
+};
+
+function readJsonnet<T>(filePath: string): T {
+    return JSON.parse(jsonnet.evaluateFile(filePath));
+}
+
+function buildCredentials(secrets: Secrets) {
+    if (
+        !secrets.aws_access_key_id ||
+        !secrets.aws_secret_access_key ||
+        secrets.aws_access_key_id.startsWith("YOUR_")
+    ) {
+        return undefined;
+    }
+
+    return {
+        accessKeyId: secrets.aws_access_key_id,
+        secretAccessKey: secrets.aws_secret_access_key,
+        sessionToken: secrets.aws_session_token || undefined,
+    };
+}
+
+async function main() {
+    const promptConfig = readJsonnet<PromptConfig>(
+        path.join(__dirname, "../jsonnet/main.jsonnet")
+    );
+    const secrets = readJsonnet<Secrets>(path.join(__dirname, "../jsonnet/secrets.jsonnet"));
+    const credentials = buildCredentials(secrets);
+
+    const redactor = new ComprehendPIIRedactor({
+        accessKeyId: credentials?.accessKeyId,
+        languageCode: promptConfig.language_code || "en",
+        region: secrets.aws_region,
+        secretAccessKey: credentials?.secretAccessKey,
+        sessionToken: credentials?.sessionToken,
+    });
+
+    const result = await redactor.redact(promptConfig.prompt);
+
+    console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,4 +1,4 @@
-import { ComprehendPIIRedactor } from "@arakoodev/edgechains.js/ai";
+import { AWSComprehend } from "@arakoodev/edgechains.js/ai";
 import Jsonnet from "@arakoodev/jsonnet";
 import fileURLToPath from "file-uri-to-path";
 import path from "path";
@@ -45,7 +45,7 @@ async function main() {
     const secrets = readJsonnet<Secrets>(path.join(__dirname, "../jsonnet/secrets.jsonnet"));
     const credentials = buildCredentials(secrets);
 
-    const redactor = new ComprehendPIIRedactor({
+    const redactor = new AWSComprehend({
         accessKeyId: credentials?.accessKeyId,
         languageCode: promptConfig.language_code || "en",
         region: secrets.aws_region,
@@ -53,7 +53,9 @@ async function main() {
         sessionToken: credentials?.sessionToken,
     });
 
-    const result = await redactor.redact(promptConfig.prompt);
+    const result = await redactor.redactPromptOptions({
+        prompt: promptConfig.prompt,
+    });
 
     console.log(JSON.stringify(result, null, 2));
 }

--- a/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "NodeNext",
+        "module": "NodeNext",
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true
+    }
+}


### PR DESCRIPTION
## Summary

- add an `AWSComprehend` utility to `@arakoodev/edgechains.js/ai` using the official AWS Comprehend client
- support PII detection, score/entity filtering, custom redaction replacements, `containsPii()`, and `redactPrompt()`
- add `redactPromptOptions()` and `asPromptMiddleware()` so prompt/message options can be redacted before existing endpoint calls
- keep `ComprehendPIIRedactor` as a compatibility alias
- add Vitest coverage for default redaction, filtered custom replacement behavior, prompt-option redaction, and the alias
- add an `aws-comprehend-redaction` Jsonnet example with prompt/config outside TypeScript

/claim #290

Closes #290.

## Validation

- `npx vitest run src/ai/src/tests/comprehendPIIRedactor.test.ts`
- `npm run build` in `JS/edgechains/arakoodev`
- `npm run build` in `JS/edgechains/examples/aws-comprehend-redaction` after building the local package
