### PR TITLE
Add Qdrant vector database support

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,3 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type { QdrantClient, QdrantPoint } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,216 @@
+import axios, { AxiosRequestConfig, Method } from "axios";
+import { config } from "dotenv";
+config();
+
+type QdrantPointId = number | string;
+type QdrantVector = number[] | Record<string, number[]>;
+type QdrantPayload = Record<string, any>;
+type QdrantDistance = "Cosine" | "Euclid" | "Dot" | "Manhattan";
+
+export interface QdrantPoint {
+  id: QdrantPointId;
+  vector: QdrantVector;
+  payload?: QdrantPayload;
+}
+
+export interface QdrantClient {
+  url: string;
+  apiKey?: string;
+  timeout?: number;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+  timeout: number;
+
+  constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string, timeout = 30000) {
+    this.QDRANT_URL = (
+      QDRANT_URL ||
+      process.env.QDRANT_URL ||
+      "http://localhost:6333"
+    ).replace(/\/$/, "");
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    this.timeout = timeout;
+  }
+
+  createClient(): QdrantClient {
+    return {
+      url: this.QDRANT_URL,
+      apiKey: this.QDRANT_API_KEY,
+      timeout: this.timeout,
+    };
+  }
+
+  async createCollection({
+    client,
+    collectionName,
+    vectorSize,
+    distance = "Cosine",
+    vectors,
+    sparseVectors,
+    ...args
+  }: {
+    client?: QdrantClient;
+    collectionName: string;
+    vectorSize?: number;
+    distance?: QdrantDistance;
+    vectors?: Record<string, any>;
+    sparseVectors?: Record<string, any>;
+    [key: string]: any;
+  }): Promise<any> {
+    const body = {
+      vectors: vectors || {
+        size: vectorSize,
+        distance,
+      },
+      ...(sparseVectors ? { sparse_vectors: sparseVectors } : {}),
+      ...args,
+    };
+
+    return this.request({
+      client,
+      method: "PUT",
+      path: `/collections/${collectionName}`,
+      data: body,
+    });
+  }
+
+  async insertVectorData({
+    client,
+    collectionName,
+    points,
+    wait,
+    ordering,
+  }: {
+    client?: QdrantClient;
+    collectionName: string;
+    points: QdrantPoint[];
+    wait?: boolean;
+    ordering?: "weak" | "medium" | "strong";
+  }): Promise<any> {
+    return this.request({
+      client,
+      method: "PUT",
+      path: `/collections/${collectionName}/points`,
+      params: { wait, ordering },
+      data: { points },
+    });
+  }
+
+  async queryVectorData({
+    client,
+    collectionName,
+    query,
+    limit = 10,
+    using,
+    filter,
+    withPayload = true,
+    withVector = false,
+    ...args
+  }: {
+    client?: QdrantClient;
+    collectionName: string;
+    query: QdrantPointId | number[] | Record<string, any>;
+    limit?: number;
+    using?: string;
+    filter?: Record<string, any>;
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+    [key: string]: any;
+  }): Promise<any> {
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${collectionName}/points/query`,
+      data: {
+        query,
+        limit,
+        ...(using ? { using } : {}),
+        ...(filter ? { filter } : {}),
+        with_payload: withPayload,
+        with_vector: withVector,
+        ...args,
+      },
+    });
+  }
+
+  async getDataById({
+    client,
+    collectionName,
+    ids,
+    withPayload = true,
+    withVector = false,
+  }: {
+    client?: QdrantClient;
+    collectionName: string;
+    ids: QdrantPointId[];
+    withPayload?: boolean | string[];
+    withVector?: boolean | string[];
+  }): Promise<any> {
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${collectionName}/points`,
+      data: {
+        ids,
+        with_payload: withPayload,
+        with_vector: withVector,
+      },
+    });
+  }
+
+  async deleteById({
+    client,
+    collectionName,
+    ids,
+    wait,
+    ordering,
+  }: {
+    client?: QdrantClient;
+    collectionName: string;
+    ids: QdrantPointId[];
+    wait?: boolean;
+    ordering?: "weak" | "medium" | "strong";
+  }): Promise<any> {
+    return this.request({
+      client,
+      method: "POST",
+      path: `/collections/${collectionName}/points/delete`,
+      params: { wait, ordering },
+      data: {
+        points: ids,
+      },
+    });
+  }
+
+  private async request({
+    client,
+    method,
+    path,
+    data,
+    params,
+  }: {
+    client?: QdrantClient;
+    method: Method;
+    path: string;
+    data?: any;
+    params?: Record<string, any>;
+  }): Promise<any> {
+    const qdrantClient = client || this.createClient();
+    const config: AxiosRequestConfig = {
+      method,
+      url: `${qdrantClient.url}${path}`,
+      data,
+      params,
+      timeout: qdrantClient.timeout || this.timeout,
+      headers: {
+        "Content-Type": "application/json",
+        ...(qdrantClient.apiKey ? { "api-key": qdrantClient.apiKey } : {}),
+      },
+    };
+
+    const response = await axios.request(config);
+    return response.data;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,117 @@
+import axios from "axios";
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+jest.mock("axios");
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Qdrant", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAxios.request.mockResolvedValue({ data: { status: "ok" } });
+  });
+
+  it("creates a collection using the Qdrant REST API", async () => {
+    const qdrant = new Qdrant("http://localhost:6333", "mock-api-key");
+    const client = qdrant.createClient();
+
+    const result = await qdrant.createCollection({
+      client,
+      collectionName: "documents",
+      vectorSize: 1536,
+    });
+
+    expect(result).toEqual({ status: "ok" });
+    expect(mockedAxios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "PUT",
+        url: "http://localhost:6333/collections/documents",
+        data: {
+          vectors: {
+            size: 1536,
+            distance: "Cosine",
+          },
+        },
+        headers: expect.objectContaining({
+          "api-key": "mock-api-key",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("upserts vector points without the Qdrant package", async () => {
+    const qdrant = new Qdrant("http://localhost:6333");
+
+    await qdrant.insertVectorData({
+      collectionName: "documents",
+      points: [
+        {
+          id: 1,
+          vector: [0.1, 0.2, 0.3],
+          payload: { content: "hello" },
+        },
+      ],
+      wait: true,
+    });
+
+    expect(mockedAxios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "PUT",
+        url: "http://localhost:6333/collections/documents/points",
+        params: { wait: true, ordering: undefined },
+        data: {
+          points: [
+            {
+              id: 1,
+              vector: [0.1, 0.2, 0.3],
+              payload: { content: "hello" },
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("queries vector points", async () => {
+    const qdrant = new Qdrant("http://localhost:6333");
+
+    await qdrant.queryVectorData({
+      collectionName: "documents",
+      query: [0.1, 0.2, 0.3],
+      limit: 5,
+    });
+
+    expect(mockedAxios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: "http://localhost:6333/collections/documents/points/query",
+        data: expect.objectContaining({
+          query: [0.1, 0.2, 0.3],
+          limit: 5,
+          with_payload: true,
+          with_vector: false,
+        }),
+      }),
+    );
+  });
+
+  it("deletes points by id", async () => {
+    const qdrant = new Qdrant("http://localhost:6333");
+
+    await qdrant.deleteById({
+      collectionName: "documents",
+      ids: [1, "5c56c793-69f3-4fbf-87e6-c4bf54c28c26"],
+    });
+
+    expect(mockedAxios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: "http://localhost:6333/collections/documents/points/delete",
+        data: {
+          points: [1, "5c56c793-69f3-4fbf-87e6-c4bf54c28c26"],
+        },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a Qdrant vector database client that uses the REST API directly via axios
- support collection creation, point upsert, vector query, point retrieval, and deletion
- export Qdrant from the vector-db package

## Tests
- npx.cmd tsc -b
- npx.cmd jest src/vector-db/src/tests/qdrant/qdrant.test.ts --runInBand

Closes #273