### PR TITLE
feat: add support for qdrant vector database in javascript sdk

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,439 @@
+import axios from "axios";
+import retry from "retry";
+import crypto from "crypto";
+import { config } from "dotenv";
+config();
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL!;
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY!;
+    }
+
+    // Function to create a Qdrant client object
+    createClient() {
+        return {
+            url: this.QDRANT_URL,
+            apiKey: this.QDRANT_API_KEY,
+        };
+    }
+
+    /**
+     * Create a Qdrant collection.
+     * @param collectionName The name of the collection.
+     * @param vectorSize The dimensionality of the vector.
+     * @param distance Distance metric to use ("Cosine" | "Dot" | "Euclid").
+     * @param client The Qdrant client options.
+     */
+    async createCollection(
+        collectionName: string,
+        vectorSize: number,
+        distance: "Cosine" | "Dot" | "Euclid" = "Cosine",
+        client?: any
+    ): Promise<any> {
+        const url = (client?.url || this.QDRANT_URL).replace(/\/$/, "");
+        const apiKey = client?.apiKey || this.QDRANT_API_KEY;
+
+        const headers: any = {};
+        if (apiKey) {
+            headers["api-key"] = apiKey;
+        }
+
+        const response = await axios.put(
+            `${url}/collections/${collectionName}`,
+            {
+                vectors: {
+                    size: vectorSize,
+                    distance: distance,
+                },
+            },
+            { headers }
+        );
+        return response.data;
+    }
+
+    /**
+     * Insert data into a vector database.
+     * @param client The Qdrant client instance.
+     * @param tableName The name of the collection (alias for compatibility).
+     * @param collectionName The name of the collection.
+     * @param id The point ID. If not provided, a random UUID will be generated.
+     * @param embedding The embedding vector (alias for compatibility).
+     * @param vector The embedding vector.
+     * @returns The inserted data response.
+     */
+    async insertVectorData({
+        client,
+        tableName,
+        collectionName,
+        id,
+        embedding,
+        vector,
+        ...payload
+    }: any): Promise<any> {
+        const url = (client?.url || this.QDRANT_URL).replace(/\/$/, "");
+        const apiKey = client?.apiKey || this.QDRANT_API_KEY;
+        const collName = collectionName || tableName;
+
+        const pointId = id || crypto.randomUUID();
+        const vec = embedding || vector;
+
+        if (!collName) {
+            throw new Error("collectionName or tableName is required");
+        }
+        if (!vec) {
+            throw new Error("embedding or vector is required");
+        }
+
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            const headers: any = {};
+            if (apiKey) {
+                headers["api-key"] = apiKey;
+            }
+
+            operation.attempt(async () => {
+                try {
+                    const response = await axios.put(
+                        `${url}/collections/${collName}/points?wait=true`,
+                        {
+                            points: [
+                                {
+                                    id: pointId,
+                                    vector: vec,
+                                    payload: payload,
+                                },
+                            ],
+                        },
+                        { headers }
+                    );
+                    resolve(response.data);
+                } catch (error: any) {
+                    if (operation.retry(error)) {
+                        return;
+                    }
+                    reject(error);
+                }
+            });
+        });
+    }
+
+    /**
+     * Fetch search results from Qdrant vector database.
+     * Maps response to a flat object format compatible with Supabase style output.
+     */
+    async getDataFromQuery({
+        client,
+        collectionName,
+        tableName,
+        query_embedding,
+        vector,
+        similarity_threshold,
+        score_threshold,
+        match_count,
+        limit,
+        filter,
+        params,
+    }: any): Promise<any> {
+        const url = (client?.url || this.QDRANT_URL).replace(/\/$/, "");
+        const apiKey = client?.apiKey || this.QDRANT_API_KEY;
+        const collName = collectionName || tableName;
+
+        const vec = query_embedding || vector;
+        const threshold = similarity_threshold !== undefined ? similarity_threshold : score_threshold;
+        const limitCount = match_count !== undefined ? match_count : limit;
+
+        if (!collName) {
+            throw new Error("collectionName or tableName is required");
+        }
+        if (!vec) {
+            throw new Error("query_embedding or vector is required");
+        }
+
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            const headers: any = {};
+            if (apiKey) {
+                headers["api-key"] = apiKey;
+            }
+
+            const body: any = {
+                vector: vec,
+                limit: limitCount || 10,
+                with_payload: true,
+                with_vector: false,
+            };
+
+            if (threshold !== undefined) {
+                body.score_threshold = threshold;
+            }
+            if (filter !== undefined) {
+                body.filter = filter;
+            }
+            if (params !== undefined) {
+                body.params = params;
+            }
+
+            operation.attempt(async () => {
+                try {
+                    const response = await axios.post(
+                        `${url}/collections/${collName}/points/search`,
+                        body,
+                        { headers }
+                    );
+
+                    const mapped = response.data.result.map((match: any) => ({
+                        id: match.id,
+                        similarity: match.score,
+                        score: match.score,
+                        ...match.payload,
+                    }));
+                    resolve(mapped);
+                } catch (error: any) {
+                    if (operation.retry(error)) {
+                        return;
+                    }
+                    reject(error);
+                }
+            });
+        });
+    }
+
+    /**
+     * Scroll points from the collection.
+     */
+    async getData({
+        client,
+        collectionName,
+        tableName,
+        limit,
+        filter,
+        withVector = true,
+    }: any): Promise<any> {
+        const url = (client?.url || this.QDRANT_URL).replace(/\/$/, "");
+        const apiKey = client?.apiKey || this.QDRANT_API_KEY;
+        const collName = collectionName || tableName;
+
+        if (!collName) {
+            throw new Error("collectionName or tableName is required");
+        }
+
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            const headers: any = {};
+            if (apiKey) {
+                headers["api-key"] = apiKey;
+            }
+
+            const body: any = {
+                limit: limit || 100,
+                with_payload: true,
+                with_vector: withVector,
+            };
+            if (filter !== undefined) {
+                body.filter = filter;
+            }
+
+            operation.attempt(async () => {
+                try {
+                    const response = await axios.post(
+                        `${url}/collections/${collName}/points/scroll`,
+                        body,
+                        { headers }
+                    );
+
+                    const mapped = response.data.result.points.map((point: any) => ({
+                        id: point.id,
+                        vector: point.vector,
+                        ...point.payload,
+                    }));
+                    resolve(mapped);
+                } catch (error: any) {
+                    if (operation.retry(error)) {
+                        return;
+                    }
+                    reject(error);
+                }
+            });
+        });
+    }
+
+    /**
+     * Retrieve a point by its ID.
+     */
+    async getDataById({
+        client,
+        collectionName,
+        tableName,
+        id,
+    }: any): Promise<any> {
+        const url = (client?.url || this.QDRANT_URL).replace(/\/$/, "");
+        const apiKey = client?.apiKey || this.QDRANT_API_KEY;
+        const collName = collectionName || tableName;
+
+        if (!collName) {
+            throw new Error("collectionName or tableName is required");
+        }
+        if (id === undefined) {
+            throw new Error("id is required");
+        }
+
+        const headers: any = {};
+        if (apiKey) {
+            headers["api-key"] = apiKey;
+        }
+
+        try {
+            const response = await axios.get(
+                `${url}/collections/${collName}/points/${id}`,
+                { headers }
+            );
+
+            const point = response.data.result;
+            if (point) {
+                return {
+                    id: point.id,
+                    vector: point.vector,
+                    ...point.payload,
+                };
+            }
+            return null;
+        } catch (error: any) {
+            console.error("Error retrieving data from Qdrant:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Update payload and/or vector of a point.
+     */
+    async updateById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        updatedContent,
+    }: any): Promise<any> {
+        const url = (client?.url || this.QDRANT_URL).replace(/\/$/, "");
+        const apiKey = client?.apiKey || this.QDRANT_API_KEY;
+        const collName = collectionName || tableName;
+
+        if (!collName) {
+            throw new Error("collectionName or tableName is required");
+        }
+        if (id === undefined) {
+            throw new Error("id is required");
+        }
+        if (!updatedContent) {
+            throw new Error("updatedContent is required");
+        }
+
+        const headers: any = {};
+        if (apiKey) {
+            headers["api-key"] = apiKey;
+        }
+
+        try {
+            const { embedding, vector, ...payload } = updatedContent;
+            const vec = embedding || vector;
+
+            // Update vector if provided
+            if (vec) {
+                await axios.put(
+                    `${url}/collections/${collName}/points/vectors?wait=true`,
+                    {
+                        points: [
+                            {
+                                id,
+                                vector: vec,
+                            },
+                        ],
+                    },
+                    { headers }
+                );
+            }
+
+            // Update payload if provided
+            if (Object.keys(payload).length > 0) {
+                await axios.post(
+                    `${url}/collections/${collName}/points/payload?wait=true`,
+                    {
+                        payload,
+                        points: [id],
+                    },
+                    { headers }
+                );
+            }
+
+            return await this.getDataById({ client, collectionName: collName, id });
+        } catch (error: any) {
+            console.error("Error updating data in Qdrant:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Delete a point by its ID.
+     */
+    async deleteById({
+        client,
+        collectionName,
+        tableName,
+        id,
+    }: any): Promise<any> {
+        const url = (client?.url || this.QDRANT_URL).replace(/\/$/, "");
+        const apiKey = client?.apiKey || this.QDRANT_API_KEY;
+        const collName = collectionName || tableName;
+
+        if (!collName) {
+            throw new Error("collectionName or tableName is required");
+        }
+        if (id === undefined) {
+            throw new Error("id is required");
+        }
+
+        const headers: any = {};
+        if (apiKey) {
+            headers["api-key"] = apiKey;
+        }
+
+        try {
+            const response = await axios.post(
+                `${url}/collections/${collName}/points/delete?wait=true`,
+                {
+                    points: [id],
+                },
+                { headers }
+            );
+
+            return { status: response.status, messages: response.statusText || "OK" };
+        } catch (error: any) {
+            console.error("Error deleting data from Qdrant:", error);
+            throw error;
+        }
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrantClient.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrantClient.test.ts
@@ -1,0 +1,314 @@
+import axios from "axios";
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+// Mock axios library
+jest.mock("axios");
+
+describe("Qdrant Client", () => {
+    let qdrant: Qdrant;
+    const MOCK_URL = "http://localhost:6333";
+    const MOCK_API_KEY = "test-api-key";
+
+    beforeEach(() => {
+        qdrant = new Qdrant(MOCK_URL, MOCK_API_KEY);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("createClient should return url and apiKey", () => {
+        const client = qdrant.createClient();
+        expect(client.url).toBe(MOCK_URL);
+        expect(client.apiKey).toBe(MOCK_API_KEY);
+    });
+
+    test("createCollection should send correct request", async () => {
+        const mockResponse = { data: { result: true, status: "ok" } };
+        (axios.put as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        const result = await qdrant.createCollection("test_collection", 1536, "Cosine");
+
+        expect(axios.put).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection`,
+            {
+                vectors: {
+                    size: 1536,
+                    distance: "Cosine",
+                },
+            },
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+        expect(result).toEqual(mockResponse.data);
+    });
+
+    test("insertVectorData should send correct points request", async () => {
+        const mockResponse = { data: { result: { status: "acknowledged" }, status: "ok" } };
+        (axios.put as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        const client = qdrant.createClient();
+        const result = await qdrant.insertVectorData({
+            client,
+            tableName: "test_collection",
+            id: "test-id-123",
+            embedding: [0.1, 0.2, 0.3],
+            customField: "hello",
+        });
+
+        expect(axios.put).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection/points?wait=true`,
+            {
+                points: [
+                    {
+                        id: "test-id-123",
+                        vector: [0.1, 0.2, 0.3],
+                        payload: {
+                            customField: "hello",
+                        },
+                    },
+                ],
+            },
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+        expect(result).toEqual(mockResponse.data);
+    });
+
+    test("getDataFromQuery should send search request and map output correctly", async () => {
+        const searchResponse = {
+            data: {
+                result: [
+                    {
+                        id: "point-1",
+                        score: 0.85,
+                        payload: {
+                            content: "matched text content",
+                            meta: "info",
+                        },
+                    },
+                ],
+            },
+        };
+        (axios.post as jest.Mock).mockResolvedValueOnce(searchResponse);
+
+        const client = qdrant.createClient();
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "test_collection",
+            query_embedding: [0.1, 0.2, 0.3],
+            similarity_threshold: 0.7,
+            match_count: 5,
+        });
+
+        expect(axios.post).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection/points/search`,
+            {
+                vector: [0.1, 0.2, 0.3],
+                limit: 5,
+                with_payload: true,
+                with_vector: false,
+                score_threshold: 0.7,
+            },
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+
+        expect(result).toEqual([
+            {
+                id: "point-1",
+                similarity: 0.85,
+                score: 0.85,
+                content: "matched text content",
+                meta: "info",
+            },
+        ]);
+    });
+
+    test("getData should scroll points correctly", async () => {
+        const scrollResponse = {
+            data: {
+                result: {
+                    points: [
+                        {
+                            id: "point-1",
+                            vector: [0.1, 0.2],
+                            payload: {
+                                name: "point 1",
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+        (axios.post as jest.Mock).mockResolvedValueOnce(scrollResponse);
+
+        const client = qdrant.createClient();
+        const result = await qdrant.getData({
+            client,
+            tableName: "test_collection",
+            limit: 50,
+        });
+
+        expect(axios.post).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection/points/scroll`,
+            {
+                limit: 50,
+                with_payload: true,
+                with_vector: true,
+            },
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+
+        expect(result).toEqual([
+            {
+                id: "point-1",
+                vector: [0.1, 0.2],
+                name: "point 1",
+            },
+        ]);
+    });
+
+    test("getDataById should retrieve single point by id", async () => {
+        const getResponse = {
+            data: {
+                result: {
+                    id: "point-1",
+                    vector: [0.9, 0.8],
+                    payload: {
+                        description: "awesome point",
+                    },
+                },
+            },
+        };
+        (axios.get as jest.Mock).mockResolvedValueOnce(getResponse);
+
+        const client = qdrant.createClient();
+        const result = await qdrant.getDataById({
+            client,
+            collectionName: "test_collection",
+            id: "point-1",
+        });
+
+        expect(axios.get).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection/points/point-1`,
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+
+        expect(result).toEqual({
+            id: "point-1",
+            vector: [0.9, 0.8],
+            description: "awesome point",
+        });
+    });
+
+    test("updateById should call payload and vector updates and return latest point data", async () => {
+        const getResponse = {
+            data: {
+                result: {
+                    id: "point-1",
+                    vector: [0.4, 0.5],
+                    payload: {
+                        field1: "new val",
+                    },
+                },
+            },
+        };
+        (axios.put as jest.Mock).mockResolvedValueOnce({});
+        (axios.post as jest.Mock).mockResolvedValueOnce({});
+        (axios.get as jest.Mock).mockResolvedValueOnce(getResponse);
+
+        const client = qdrant.createClient();
+        const result = await qdrant.updateById({
+            client,
+            collectionName: "test_collection",
+            id: "point-1",
+            updatedContent: {
+                vector: [0.4, 0.5],
+                field1: "new val",
+            },
+        });
+
+        // Verify vectors PUT
+        expect(axios.put).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection/points/vectors?wait=true`,
+            {
+                points: [{ id: "point-1", vector: [0.4, 0.5] }],
+            },
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+
+        // Verify payload POST
+        expect(axios.post).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection/points/payload?wait=true`,
+            {
+                payload: { field1: "new val" },
+                points: ["point-1"],
+            },
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+
+        expect(result).toEqual({
+            id: "point-1",
+            vector: [0.4, 0.5],
+            field1: "new val",
+        });
+    });
+
+    test("deleteById should send correct delete request", async () => {
+        const deleteResponse = {
+            status: 200,
+            statusText: "OK",
+        };
+        (axios.post as jest.Mock).mockResolvedValueOnce(deleteResponse);
+
+        const client = qdrant.createClient();
+        const result = await qdrant.deleteById({
+            client,
+            tableName: "test_collection",
+            id: "point-1",
+        });
+
+        expect(axios.post).toHaveBeenCalledWith(
+            `${MOCK_URL}/collections/test_collection/points/delete?wait=true`,
+            {
+                points: ["point-1"],
+            },
+            {
+                headers: {
+                    "api-key": MOCK_API_KEY,
+                },
+            }
+        );
+
+        expect(result).toEqual({
+            status: 200,
+            messages: "OK",
+        });
+    });
+});


### PR DESCRIPTION
This PR adds support for Qdrant vector database in the JavaScript SDK, as requested in issue #273. It wraps Qdrant REST APIs using axios, ensuring identical signatures and flat compatibility with existing Supabase client methods. It also adds a comprehensive unit test suite.