### PR TITLE
Add AWS Comprehend prompt redaction utility

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,9 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AwsComprehendRedactor } from "./lib/aws-comprehend/comprehend-redactor.js";
+export type {
+  ComprehendPiiEntity,
+  ComprehendPiiEntityType,
+  ComprehendRedactorOptions,
+} from "./lib/aws-comprehend/comprehend-redactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend-redactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/aws-comprehend/comprehend-redactor.ts
@@ -1,0 +1,293 @@
+import crypto from "node:crypto";
+
+export type ComprehendPiiEntityType =
+  | "BANK_ACCOUNT_NUMBER"
+  | "BANK_ROUTING"
+  | "CREDIT_DEBIT_NUMBER"
+  | "CREDIT_DEBIT_CVV"
+  | "CREDIT_DEBIT_EXPIRY"
+  | "PIN"
+  | "EMAIL"
+  | "ADDRESS"
+  | "NAME"
+  | "PHONE"
+  | "SSN"
+  | "DATE_TIME"
+  | "PASSPORT_NUMBER"
+  | "DRIVER_ID"
+  | "URL"
+  | "AGE"
+  | "USERNAME"
+  | "PASSWORD"
+  | "AWS_ACCESS_KEY"
+  | "AWS_SECRET_KEY"
+  | "IP_ADDRESS"
+  | "MAC_ADDRESS"
+  | "ALL";
+
+export interface ComprehendPiiEntity {
+  Type: ComprehendPiiEntityType;
+  Score: number;
+  BeginOffset: number;
+  EndOffset: number;
+}
+
+export interface ComprehendRedactorOptions {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+  region?: string;
+  languageCode?: string;
+  minScore?: number;
+  entityTypes?: ComprehendPiiEntityType[];
+  replacement?:
+    | string
+    | ((entity: ComprehendPiiEntity, text: string) => string);
+  endpoint?: string;
+  fetchFn?: typeof fetch;
+}
+
+interface RedactTextOptions {
+  text: string;
+  languageCode?: string;
+  minScore?: number;
+  entityTypes?: ComprehendPiiEntityType[];
+  replacement?:
+    | string
+    | ((entity: ComprehendPiiEntity, text: string) => string);
+}
+
+interface MessageOption {
+  role: string;
+  content: string;
+  name?: string;
+}
+
+const service = "comprehend";
+const algorithm = "AWS4-HMAC-SHA256";
+
+export class AwsComprehendRedactor {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  region: string;
+  languageCode: string;
+  minScore: number;
+  entityTypes?: ComprehendPiiEntityType[];
+  replacement: string | ((entity: ComprehendPiiEntity, text: string) => string);
+  endpoint?: string;
+  fetchFn: typeof fetch;
+
+  constructor(options: ComprehendRedactorOptions = {}) {
+    this.accessKeyId =
+      options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+    this.secretAccessKey =
+      options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "";
+    this.sessionToken = options.sessionToken || process.env.AWS_SESSION_TOKEN;
+    this.region = options.region || process.env.AWS_REGION || "us-east-1";
+    this.languageCode = options.languageCode || "en";
+    this.minScore = options.minScore ?? 0;
+    this.entityTypes = options.entityTypes;
+    this.replacement =
+      options.replacement || ((entity) => `[REDACTED_${entity.Type}]`);
+    this.endpoint = options.endpoint;
+    this.fetchFn = options.fetchFn || fetch;
+  }
+
+  async redactPrompt(prompt: string): Promise<string> {
+    return this.redactText({ text: prompt });
+  }
+
+  async redactMessages<T extends MessageOption>(messages: T[]): Promise<T[]> {
+    return Promise.all(
+      messages.map(async (message) => ({
+        ...message,
+        content: await this.redactPrompt(message.content),
+      })),
+    );
+  }
+
+  async redactText(options: RedactTextOptions): Promise<string> {
+    const text = options.text;
+    const entities = await this.detectPiiEntities({
+      text,
+      languageCode: options.languageCode,
+    });
+
+    return this.redactDetectedEntities(text, entities, {
+      minScore: options.minScore,
+      entityTypes: options.entityTypes,
+      replacement: options.replacement,
+    });
+  }
+
+  async redactEndpointPrompt<T>(
+    endpointCall: (options: T) => Promise<any>,
+    options: T & { prompt?: string; messages?: MessageOption[] },
+  ): Promise<any> {
+    const redactedOptions = { ...options };
+    if (redactedOptions.prompt) {
+      redactedOptions.prompt = await this.redactPrompt(redactedOptions.prompt);
+    }
+    if (redactedOptions.messages) {
+      redactedOptions.messages = await this.redactMessages(
+        redactedOptions.messages,
+      );
+    }
+    return endpointCall(redactedOptions);
+  }
+
+  redactDetectedEntities(
+    text: string,
+    entities: ComprehendPiiEntity[],
+    options: Omit<RedactTextOptions, "text" | "languageCode"> = {},
+  ): string {
+    const minScore = options.minScore ?? this.minScore;
+    const entityTypes = options.entityTypes ?? this.entityTypes;
+    const replacement = options.replacement ?? this.replacement;
+    const filteredEntities = entities
+      .filter((entity) => entity.Score >= minScore)
+      .filter(
+        (entity) =>
+          !entityTypes ||
+          entityTypes.includes("ALL") ||
+          entityTypes.includes(entity.Type),
+      )
+      .sort((a, b) => b.BeginOffset - a.BeginOffset);
+
+    let redactedText = text;
+    for (const entity of filteredEntities) {
+      const originalValue = text.slice(entity.BeginOffset, entity.EndOffset);
+      const replacementValue =
+        typeof replacement === "function"
+          ? replacement(entity, originalValue)
+          : replacement;
+      redactedText =
+        redactedText.slice(0, entity.BeginOffset) +
+        replacementValue +
+        redactedText.slice(entity.EndOffset);
+    }
+    return redactedText;
+  }
+
+  async detectPiiEntities({
+    text,
+    languageCode,
+  }: {
+    text: string;
+    languageCode?: string;
+  }): Promise<ComprehendPiiEntity[]> {
+    const body = JSON.stringify({
+      Text: text,
+      LanguageCode: languageCode || this.languageCode,
+    });
+    const endpoint =
+      this.endpoint || `https://comprehend.${this.region}.amazonaws.com/`;
+    const headers = this.createSignedHeaders(body, endpoint);
+    const response = await this.fetchFn(endpoint, {
+      method: "POST",
+      headers,
+      body,
+    });
+    const responseBody = await response.json();
+
+    if (!response.ok) {
+      throw new Error(
+        `AWS Comprehend DetectPiiEntities failed with status ${response.status}: ${JSON.stringify(
+          responseBody,
+        )}`,
+      );
+    }
+
+    return responseBody.Entities || [];
+  }
+
+  private createSignedHeaders(
+    body: string,
+    endpoint: string,
+  ): Record<string, string> {
+    if (!this.accessKeyId || !this.secretAccessKey) {
+      throw new Error(
+        "AWS credentials are required. Provide accessKeyId/secretAccessKey or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.",
+      );
+    }
+
+    const now = new Date();
+    const amzDate = this.toAmzDate(now);
+    const dateStamp = amzDate.slice(0, 8);
+    const url = new URL(endpoint);
+    const canonicalUri = url.pathname || "/";
+    const canonicalQueryString = "";
+    const payloadHash = this.sha256(body);
+    const credentialScope = `${dateStamp}/${this.region}/${service}/aws4_request`;
+    const baseHeaders: Record<string, string> = {
+      "content-type": "application/x-amz-json-1.1",
+      host: url.host,
+      "x-amz-date": amzDate,
+      "x-amz-target": "Comprehend_20171127.DetectPiiEntities",
+    };
+
+    if (this.sessionToken) {
+      baseHeaders["x-amz-security-token"] = this.sessionToken;
+    }
+
+    const signedHeaders = Object.keys(baseHeaders).sort().join(";");
+    const canonicalHeaders = Object.keys(baseHeaders)
+      .sort()
+      .map((key) => `${key}:${baseHeaders[key]}\n`)
+      .join("");
+    const canonicalRequest = [
+      "POST",
+      canonicalUri,
+      canonicalQueryString,
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join("\n");
+    const stringToSign = [
+      algorithm,
+      amzDate,
+      credentialScope,
+      this.sha256(canonicalRequest),
+    ].join("\n");
+    const signingKey = this.getSignatureKey(
+      this.secretAccessKey,
+      dateStamp,
+      this.region,
+      service,
+    );
+    const signature = crypto
+      .createHmac("sha256", signingKey)
+      .update(stringToSign)
+      .digest("hex");
+
+    return {
+      ...baseHeaders,
+      Authorization: `${algorithm} Credential=${this.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    };
+  }
+
+  private toAmzDate(date: Date): string {
+    return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+  }
+
+  private sha256(value: string): string {
+    return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+  }
+
+  private hmac(key: Buffer | string, value: string): Buffer {
+    return crypto.createHmac("sha256", key).update(value, "utf8").digest();
+  }
+
+  private getSignatureKey(
+    key: string,
+    dateStamp: string,
+    regionName: string,
+    serviceName: string,
+  ): Buffer {
+    const kDate = this.hmac(`AWS4${key}`, dateStamp);
+    const kRegion = this.hmac(kDate, regionName);
+    const kService = this.hmac(kRegion, serviceName);
+    return this.hmac(kService, "aws4_request");
+  }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend-redactor.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/aws-comprehend-redactor.test.ts
@@ -1,0 +1,126 @@
+import { AwsComprehendRedactor } from "../lib/aws-comprehend/comprehend-redactor";
+import { describe, expect, it, vi } from "vitest";
+
+describe("AwsComprehendRedactor", () => {
+  it("redacts detected entities from the end of the string first", () => {
+    const redactor = new AwsComprehendRedactor({
+      accessKeyId: "access-key",
+      secretAccessKey: "secret-key",
+    });
+
+    const redacted = redactor.redactDetectedEntities(
+      "Email jane@example.com or call 555-0100",
+      [
+        {
+          Type: "EMAIL",
+          Score: 0.99,
+          BeginOffset: 6,
+          EndOffset: 22,
+        },
+        {
+          Type: "PHONE",
+          Score: 0.99,
+          BeginOffset: 31,
+          EndOffset: 39,
+        },
+      ],
+    );
+
+    expect(redacted).toBe("Email [REDACTED_EMAIL] or call [REDACTED_PHONE]");
+  });
+
+  it("filters entities by score and type", () => {
+    const redactor = new AwsComprehendRedactor({
+      accessKeyId: "access-key",
+      secretAccessKey: "secret-key",
+      minScore: 0.9,
+      entityTypes: ["EMAIL"],
+      replacement: "[PRIVATE]",
+    });
+
+    const redacted = redactor.redactDetectedEntities("Jane jane@example.com", [
+      {
+        Type: "NAME",
+        Score: 0.99,
+        BeginOffset: 0,
+        EndOffset: 4,
+      },
+      {
+        Type: "EMAIL",
+        Score: 0.89,
+        BeginOffset: 5,
+        EndOffset: 21,
+      },
+    ]);
+
+    expect(redacted).toBe("Jane jane@example.com");
+  });
+
+  it("redacts messages and chains into endpoint calls", async () => {
+    const redactor = new AwsComprehendRedactor({
+      accessKeyId: "access-key",
+      secretAccessKey: "secret-key",
+    });
+    vi.spyOn(redactor, "detectPiiEntities").mockResolvedValue([
+      {
+        Type: "EMAIL",
+        Score: 0.99,
+        BeginOffset: 8,
+        EndOffset: 24,
+      },
+    ]);
+    const endpointCall = vi.fn().mockResolvedValue({ content: "ok" });
+
+    const response = await redactor.redactEndpointPrompt(endpointCall, {
+      prompt: "Contact jane@example.com",
+    });
+
+    expect(response).toEqual({ content: "ok" });
+    expect(endpointCall).toHaveBeenCalledWith({
+      prompt: "Contact [REDACTED_EMAIL]",
+    });
+  });
+
+  it("calls AWS Comprehend DetectPiiEntities with signed headers", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        Entities: [
+          {
+            Type: "EMAIL",
+            Score: 0.99,
+            BeginOffset: 0,
+            EndOffset: 16,
+          },
+        ],
+      }),
+    });
+    const redactor = new AwsComprehendRedactor({
+      accessKeyId: "access-key",
+      secretAccessKey: "secret-key",
+      region: "us-west-2",
+      fetchFn,
+    });
+
+    const entities = await redactor.detectPiiEntities({
+      text: "jane@example.com",
+    });
+
+    expect(entities).toHaveLength(1);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://comprehend.us-west-2.amazonaws.com/",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "content-type": "application/x-amz-json-1.1",
+          "x-amz-target": "Comprehend_20171127.DetectPiiEntities",
+          Authorization: expect.stringContaining("AWS4-HMAC-SHA256"),
+        }),
+        body: JSON.stringify({
+          Text: "jane@example.com",
+          LanguageCode: "en",
+        }),
+      }),
+    );
+  });
+});

--- a/JS/edgechains/examples/aws-comprehend-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-redaction/README.md
@@ -1,0 +1,21 @@
+# AWS Comprehend Redaction Example
+
+This example redacts PII from a prompt with AWS Comprehend before sending the prompt to an existing EdgeChains endpoint.
+
+## Setup
+
+Set credentials in your shell or `.env`:
+
+```sh
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=us-east-1
+OPENAI_API_KEY=...
+```
+
+The prompt is stored in `jsonnet/main.jsonnet`.
+
+```sh
+npm install
+npm run start
+```

--- a/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,5 @@
+{
+    "prompt": "Draft a customer support reply for Jane Doe at jane@example.com about her account.",
+    "model": "gpt-3.5-turbo",
+    "max_tokens": 128
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-redaction/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "aws-comprehend-redaction",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "tsx": "^4.19.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-redaction/src/index.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import { AwsComprehendRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+const config = JSON.parse(fs.readFileSync("jsonnet/main.jsonnet", "utf8"));
+
+const redactor = new AwsComprehendRedactor({
+  region: process.env.AWS_REGION || "us-east-1",
+});
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  orgId: process.env.OPENAI_ORG_ID,
+});
+
+const response = await redactor.redactEndpointPrompt(openai.chat.bind(openai), {
+  prompt: config.prompt,
+  model: config.model,
+  max_tokens: config.max_tokens,
+});
+
+console.log(response);


### PR DESCRIPTION
Fixes arakoodev/EdgeChains#290

Summary:
- Adds `AwsComprehendRedactor` to the JavaScript SDK AI package.
- Uses AWS Comprehend `DetectPiiEntities` with SigV4-signed HTTP requests, so no AWS SDK dependency is required.
- Provides prompt and chat-message redaction helpers plus `redactEndpointPrompt` to redact before calling existing endpoint methods.
- Adds tests for span-safe redaction, score/type filtering, endpoint chaining, and signed AWS request construction.
- Adds a working example under `JS/edgechains/examples/aws-comprehend-redaction` with the prompt stored in `jsonnet/main.jsonnet`.

Verification:
- `npx prettier --check src/ai/src/lib/aws-comprehend/comprehend-redactor.ts src/ai/src/index.ts src/ai/src/tests/aws-comprehend-redactor.test.ts ..\examples\aws-comprehend-redaction\package.json ..\examples\aws-comprehend-redaction\README.md ..\examples\aws-comprehend-redaction\src\index.ts`
- `npx tsc -b`
- `npx vitest run src/ai/src/tests/aws-comprehend-redactor.test.ts`

Note:
- I could not provide a Loom demo from this environment. The example is included and ready to run with AWS/OpenAI credentials.
