### PR TITLE
fix: resolve #290

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,4 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { Comprehend, RedactChain } from "./lib/comprehend/comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
@@ -1,0 +1,211 @@
+import axios from "axios";
+import { createHash, createHmac } from "crypto";
+
+const ALGORITHM = "AWS4-HMAC-SHA256";
+const SERVICE = "comprehend";
+const API_VERSION = "Comprehend_20171127";
+
+interface ComprehendConstructionOptions {
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    sessionToken?: string;
+    region?: string;
+}
+
+interface PiiEntity {
+    Score: number;
+    Type: string;
+    BeginOffset: number;
+    EndOffset: number;
+}
+
+interface DetectPiiEntitiesOptions {
+    text: string;
+    languageCode?: string;
+}
+
+interface RedactOptions {
+    text: string;
+    languageCode?: string;
+    // When provided, every detected PII span is replaced by this character
+    // repeated to the length of the span (e.g. "*"). When omitted, the span is
+    // replaced by its entity type tag (e.g. "[EMAIL]").
+    maskCharacter?: string;
+    // Restrict redaction to these Comprehend entity types (e.g. ["EMAIL", "SSN"]).
+    types?: string[];
+}
+
+interface RedactableEndpoint {
+    chat(chatOptions: {
+        prompt?: string;
+        messages?: { content: string }[];
+        [key: string]: any;
+    }): Promise<any>;
+}
+
+function hmac(key: Buffer | string, data: string): Buffer {
+    return createHmac("sha256", key).update(data, "utf8").digest();
+}
+
+function sha256Hex(data: string): string {
+    return createHash("sha256").update(data, "utf8").digest("hex");
+}
+
+export class Comprehend {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken: string;
+    region: string;
+
+    constructor(options: ComprehendConstructionOptions = {}) {
+        this.accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+        this.secretAccessKey = options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY || "";
+        this.sessionToken = options.sessionToken || process.env.AWS_SESSION_TOKEN || "";
+        this.region = options.region || process.env.AWS_REGION || "us-east-1";
+        this.checkKeys();
+    }
+
+    private checkKeys(): void {
+        if (!this.accessKeyId || !this.secretAccessKey) {
+            console.error(
+                "AWS credentials are missing. Please provide a valid accessKeyId and secretAccessKey. You can add them in .env file as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
+            );
+        }
+    }
+
+    private sign(action: string, payload: string): Record<string, string> {
+        const host = `comprehend.${this.region}.amazonaws.com`;
+        const target = `${API_VERSION}.${action}`;
+        const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, "");
+        const dateStamp = amzDate.slice(0, 8);
+
+        const canonicalHeaders =
+            `content-type:application/x-amz-json-1.1\n` +
+            `host:${host}\n` +
+            `x-amz-date:${amzDate}\n` +
+            `x-amz-target:${target}\n`;
+        const signedHeaders = "content-type;host;x-amz-date;x-amz-target";
+        const canonicalRequest = [
+            "POST",
+            "/",
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            sha256Hex(payload),
+        ].join("\n");
+
+        const credentialScope = `${dateStamp}/${this.region}/${SERVICE}/aws4_request`;
+        const stringToSign = [
+            ALGORITHM,
+            amzDate,
+            credentialScope,
+            sha256Hex(canonicalRequest),
+        ].join("\n");
+
+        const kDate = hmac(`AWS4${this.secretAccessKey}`, dateStamp);
+        const kRegion = hmac(kDate, this.region);
+        const kService = hmac(kRegion, SERVICE);
+        const kSigning = hmac(kService, "aws4_request");
+        const signature = createHmac("sha256", kSigning)
+            .update(stringToSign, "utf8")
+            .digest("hex");
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Date": amzDate,
+            "X-Amz-Target": target,
+            Authorization: `${ALGORITHM} Credential=${this.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+        };
+        if (this.sessionToken) {
+            headers["X-Amz-Security-Token"] = this.sessionToken;
+        }
+        return headers;
+    }
+
+    async detectPiiEntities(options: DetectPiiEntitiesOptions): Promise<PiiEntity[]> {
+        const payload = JSON.stringify({
+            Text: options.text,
+            LanguageCode: options.languageCode || "en",
+        });
+        const response = await axios
+            .post(`https://comprehend.${this.region}.amazonaws.com/`, payload, {
+                headers: this.sign("DetectPiiEntities", payload),
+            })
+            .then((response) => response.data.Entities || [])
+            .catch((error) => {
+                if (error.response) {
+                    console.log("Server responded with status code:", error.response.status);
+                    console.log("Response data:", error.response.data);
+                } else if (error.request) {
+                    console.log("No response received:", error);
+                } else {
+                    console.log("Error creating request:", error.message);
+                }
+                return [];
+            });
+        return response;
+    }
+
+    async redact(options: RedactOptions): Promise<string> {
+        const entities = await this.detectPiiEntities({
+            text: options.text,
+            languageCode: options.languageCode,
+        });
+        // Replace from the end of the string so earlier offsets stay valid.
+        const sorted = [...entities].sort((a, b) => b.BeginOffset - a.BeginOffset);
+        let redacted = options.text;
+        for (const entity of sorted) {
+            if (options.types && !options.types.includes(entity.Type)) continue;
+            const replacement =
+                options.maskCharacter !== undefined
+                    ? options.maskCharacter.repeat(entity.EndOffset - entity.BeginOffset)
+                    : `[${entity.Type}]`;
+            redacted =
+                redacted.slice(0, entity.BeginOffset) +
+                replacement +
+                redacted.slice(entity.EndOffset);
+        }
+        return redacted;
+    }
+
+    // Chain this redactor in front of any Endpoint class (OpenAI, GeminiAI, ...).
+    // The returned RedactChain redacts the prompt/messages before the endpoint
+    // observes them, so sensitive information never leaves the application.
+    pipe(endpoint: RedactableEndpoint, options: Omit<RedactOptions, "text"> = {}): RedactChain {
+        return new RedactChain(this, endpoint, options);
+    }
+}
+
+export class RedactChain {
+    constructor(
+        private comprehend: Comprehend,
+        private endpoint: RedactableEndpoint,
+        private options: Omit<RedactOptions, "text"> = {}
+    ) {}
+
+    async chat(chatOptions: {
+        prompt?: string;
+        messages?: { content: string; [key: string]: any }[];
+        [key: string]: any;
+    }): Promise<any> {
+        const redactedOptions = { ...chatOptions };
+        if (chatOptions.prompt) {
+            redactedOptions.prompt = await this.comprehend.redact({
+                text: chatOptions.prompt,
+                ...this.options,
+            });
+        }
+        if (chatOptions.messages) {
+            redactedOptions.messages = await Promise.all(
+                chatOptions.messages.map(async (message) => ({
+                    ...message,
+                    content: await this.comprehend.redact({
+                        text: message.content,
+                        ...this.options,
+                    }),
+                }))
+            );
+        }
+        return this.endpoint.chat(redactedOptions);
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
@@ -1,0 +1,62 @@
+import axios from "axios";
+import { Comprehend } from "../lib/comprehend/comprehend";
+
+jest.mock("axios");
+
+// "My email is john@example.com" — the email occupies offsets [12, 28).
+const emailEntities = [{ Score: 0.99, Type: "EMAIL", BeginOffset: 12, EndOffset: 28 }];
+
+describe("Comprehend", () => {
+    describe("detectPiiEntities", () => {
+        test("should return PII entities detected by AWS Comprehend", async () => {
+            axios.post = jest.fn().mockResolvedValueOnce({ data: { Entities: emailEntities } });
+            const comprehend = new Comprehend({ accessKeyId: "id", secretAccessKey: "secret" });
+            const entities = await comprehend.detectPiiEntities({
+                text: "My email is john@example.com",
+            });
+            expect(entities).toEqual(emailEntities);
+        });
+    });
+
+    describe("redact", () => {
+        test("should replace PII spans with their entity type tag", async () => {
+            axios.post = jest.fn().mockResolvedValueOnce({ data: { Entities: emailEntities } });
+            const comprehend = new Comprehend({ accessKeyId: "id", secretAccessKey: "secret" });
+            const redacted = await comprehend.redact({ text: "My email is john@example.com" });
+            expect(redacted).toEqual("My email is [EMAIL]");
+        });
+
+        test("should mask PII spans with a mask character when provided", async () => {
+            axios.post = jest.fn().mockResolvedValueOnce({ data: { Entities: emailEntities } });
+            const comprehend = new Comprehend({ accessKeyId: "id", secretAccessKey: "secret" });
+            const redacted = await comprehend.redact({
+                text: "My email is john@example.com",
+                maskCharacter: "*",
+            });
+            expect(redacted).toEqual("My email is ****************");
+        });
+
+        test("should only redact the requested entity types", async () => {
+            axios.post = jest.fn().mockResolvedValueOnce({ data: { Entities: emailEntities } });
+            const comprehend = new Comprehend({ accessKeyId: "id", secretAccessKey: "secret" });
+            const redacted = await comprehend.redact({
+                text: "My email is john@example.com",
+                types: ["SSN"],
+            });
+            expect(redacted).toEqual("My email is john@example.com");
+        });
+    });
+
+    describe("pipe", () => {
+        test("should redact the prompt before the endpoint observes it", async () => {
+            axios.post = jest.fn().mockResolvedValueOnce({ data: { Entities: emailEntities } });
+            const comprehend = new Comprehend({ accessKeyId: "id", secretAccessKey: "secret" });
+            const endpoint = { chat: jest.fn().mockResolvedValue({ content: "ok" }) };
+            const response = await comprehend
+                .pipe(endpoint)
+                .chat({ prompt: "My email is john@example.com" });
+            expect(endpoint.chat).toHaveBeenCalledWith({ prompt: "My email is [EMAIL]" });
+            expect(response).toEqual({ content: "ok" });
+        });
+    });
+});

--- a/JS/edgechains/examples/redact-pii/package.json
+++ b/JS/edgechains/examples/redact-pii/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "redact-pii",
+    "version": "1.0.0",
+    "description": "Redact PII from prompts with AWS Comprehend before sending them to an LLM endpoint.",
+    "main": "index.js",
+    "type": "module",
+    "keywords": [],
+    "author": "",
+    "scripts": {
+        "start": "tsc && node ./dist/index.js"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/redact-pii/readme.md
+++ b/JS/edgechains/examples/redact-pii/readme.md
@@ -1,0 +1,61 @@
+# Redact PII with AWS Comprehend
+
+This example shows how to use the `Comprehend` utility to redact sensitive
+information (PII) from prompts before they reach an LLM endpoint. The redactor
+**chains** with the existing Endpoint classes (`OpenAI`, `GeminiAI`, ...) so the
+endpoint only ever observes the redacted prompt.
+
+## Video
+
+<!-- Loom walkthrough -->
+https://www.loom.com/share/your-video-id
+
+## Installation
+
+1. Install the required dependencies:
+
+    ```bash
+    npm install
+    ```
+
+## Configuration
+
+Provide your AWS credentials (used to call [Amazon Comprehend
+`DetectPiiEntities`](https://docs.aws.amazon.com/comprehend/latest/APIReference/API_DetectPiiEntities.html))
+and your OpenAI key as environment variables:
+
+```bash
+export AWS_ACCESS_KEY_ID="..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_REGION="us-east-1"
+export OPENAI_API_KEY="sk-..."
+```
+
+## Usage
+
+```bash
+npm run start
+```
+
+Expected output for the sample prompt:
+
+```
+Original : Hi, my name is John Doe, my email is john.doe@example.com and my SSN is 123-45-6789.
+Redacted : Hi, my name is [NAME], my email is [EMAIL] and my SSN is [SSN].
+Masked   : Hi, my name is ********, my email is ******************** and my SSN is ***********.
+```
+
+## How it works
+
+```ts
+import { Comprehend, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+const comprehend = new Comprehend({ region: "us-east-1" });
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// redact a prompt directly
+const safe = await comprehend.redact({ text: "my email is john@example.com" });
+
+// or chain the redactor in front of any Endpoint class
+const response = await comprehend.pipe(openai).chat({ prompt: userPrompt });
+```

--- a/JS/edgechains/examples/redact-pii/src/index.ts
+++ b/JS/edgechains/examples/redact-pii/src/index.ts
@@ -1,0 +1,27 @@
+import { Comprehend, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+// AWS credentials are read from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION
+// (or pass them explicitly to the constructor).
+const comprehend = new Comprehend({ region: process.env.AWS_REGION || "us-east-1" });
+
+const prompt =
+    "Hi, my name is John Doe, my email is john.doe@example.com and my SSN is 123-45-6789.";
+
+async function main() {
+    // 1. Redact PII directly. Each detected entity becomes its type tag, e.g. [EMAIL].
+    const redacted = await comprehend.redact({ text: prompt });
+    console.log("Original :", prompt);
+    console.log("Redacted :", redacted);
+
+    // You can also mask with a character instead of the type tag.
+    const masked = await comprehend.redact({ text: prompt, maskCharacter: "*" });
+    console.log("Masked   :", masked);
+
+    // 2. Chain the redactor in front of an Endpoint class. The OpenAI endpoint
+    //    only ever observes the redacted prompt, so PII never leaves the app.
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const response = await comprehend.pipe(openai).chat({ prompt });
+    console.log("LLM reply:", response);
+}
+
+main().catch((error) => console.error(error));

--- a/JS/edgechains/examples/redact-pii/tsconfig.json
+++ b/JS/edgechains/examples/redact-pii/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "NodeNext",
+        "module": "NodeNext",
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "exclude": ["./**/*.test.ts"]
+}


### PR DESCRIPTION
Resolves #290.

Added AWS Comprehend PII-redaction to the EdgeChains JS SDK — a `Comprehend` client (axios + built-in-crypto SigV4, no new deps) and a chainable `RedactChain` (`comprehend.pipe(endpoint).chat(...)`) that redacts prompts before any Endpoint class observes them, plus jest tests and a runnable example; existing endpoints left intact per the bounty's "chain with" criterion (loom video placeholder must be filled in manually).

/claim #290