### PR TITLE
feat: add AWS Comprehend PII redactor

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -30,6 +30,7 @@
         "@supabase/supabase-js": "^2.42.3",
         "axios": "^1.7.4",
         "axios-retry": "^4.1.0",
+        "@aws-sdk/client-comprehend": "^3.600.0",
         "cheerio": "^1.0.0-rc.12",
         "cors": "^2.8.5",
         "document": "^0.4.7",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,11 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { AWSComprehendPIIRedactor } from "./lib/comprehend/comprehend.js";
+export type {
+  AWSComprehendPIIRedactorOptions,
+  ComprehendCompatibleClient,
+  ComprehendPiiEntity,
+  ComprehendRedactionOptions,
+  ComprehendRedactionResult,
+} from "./lib/comprehend/comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
@@ -1,0 +1,228 @@
+import {
+  ComprehendClient,
+  DetectPiiEntitiesCommand,
+} from "@aws-sdk/client-comprehend";
+
+type ChatMessage = {
+  role: string;
+  content: string;
+  name?: string;
+};
+
+export type ComprehendPiiEntity = {
+  Type?: string;
+  BeginOffset?: number;
+  EndOffset?: number;
+  Score?: number;
+};
+
+export type DetectPiiInput = {
+  Text: string;
+  LanguageCode: string;
+};
+
+export type DetectPiiOutput = {
+  Entities?: ComprehendPiiEntity[];
+};
+
+export type ComprehendCompatibleClient = {
+  detectPiiEntities(input: DetectPiiInput): Promise<DetectPiiOutput>;
+};
+
+export type ComprehendRedactionMode = "entity" | "mask";
+
+export type ComprehendRedactionOptions = {
+  languageCode?: string;
+  minScore?: number;
+  entityTypes?: string[];
+  mode?: ComprehendRedactionMode;
+  maskChar?: string;
+};
+
+export type ComprehendRedactionResult = {
+  originalText: string;
+  redactedText: string;
+  entities: ComprehendPiiEntity[];
+};
+
+export type AWSComprehendPIIRedactorOptions = {
+  region?: string;
+  languageCode?: string;
+  minScore?: number;
+  client?: ComprehendCompatibleClient;
+};
+
+type ChatEndpoint<TOptions, TResult> = {
+  chat(options: TOptions): Promise<TResult>;
+};
+
+export class AWSComprehendPIIRedactor {
+  private client: ComprehendCompatibleClient;
+  private languageCode: string;
+  private minScore: number;
+
+  constructor(options: AWSComprehendPIIRedactorOptions = {}) {
+    this.client = options.client || createAWSComprehendClient(options.region);
+    this.languageCode = options.languageCode || "en";
+    this.minScore = options.minScore ?? 0;
+  }
+
+  async detectPii(
+    text: string,
+    options: Pick<ComprehendRedactionOptions, "languageCode"> = {},
+  ): Promise<ComprehendPiiEntity[]> {
+    if (!text) return [];
+
+    const result = await this.client.detectPiiEntities({
+      Text: text,
+      LanguageCode: options.languageCode || this.languageCode,
+    });
+
+    return result.Entities || [];
+  }
+
+  async redact(
+    text: string,
+    options: ComprehendRedactionOptions = {},
+  ): Promise<ComprehendRedactionResult> {
+    const entities = await this.detectPii(text, options);
+    return {
+      originalText: text,
+      redactedText: AWSComprehendPIIRedactor.applyRedaction(text, entities, {
+        ...options,
+        minScore: options.minScore ?? this.minScore,
+      }),
+      entities,
+    };
+  }
+
+  async redactMessages(
+    messages: ChatMessage[],
+    options: ComprehendRedactionOptions = {},
+  ): Promise<ChatMessage[]> {
+    return await Promise.all(
+      messages.map(async (message) => ({
+        ...message,
+        content: (await this.redact(message.content, options)).redactedText,
+      })),
+    );
+  }
+
+  async redactChatOptions<
+    TOptions extends { prompt?: string; messages?: ChatMessage[] },
+  >(
+    chatOptions: TOptions,
+    options: ComprehendRedactionOptions = {},
+  ): Promise<TOptions> {
+    const redactedOptions = { ...chatOptions };
+
+    if (chatOptions.prompt) {
+      redactedOptions.prompt = (
+        await this.redact(chatOptions.prompt, options)
+      ).redactedText;
+    }
+
+    if (chatOptions.messages) {
+      redactedOptions.messages = await this.redactMessages(
+        chatOptions.messages,
+        options,
+      );
+    }
+
+    return redactedOptions;
+  }
+
+  async chat<
+    TOptions extends { prompt?: string; messages?: ChatMessage[] },
+    TResult,
+  >(
+    endpoint: ChatEndpoint<TOptions, TResult>,
+    chatOptions: TOptions,
+    options: ComprehendRedactionOptions = {},
+  ): Promise<TResult> {
+    return endpoint.chat(await this.redactChatOptions(chatOptions, options));
+  }
+
+  wrapChat<
+    TOptions extends { prompt?: string; messages?: ChatMessage[] },
+    TResult,
+  >(
+    endpoint: ChatEndpoint<TOptions, TResult>,
+    options: ComprehendRedactionOptions = {},
+  ): ChatEndpoint<TOptions, TResult> {
+    return {
+      chat: async (chatOptions: TOptions) =>
+        this.chat(endpoint, chatOptions, options),
+    };
+  }
+
+  static applyRedaction(
+    text: string,
+    entities: ComprehendPiiEntity[],
+    options: ComprehendRedactionOptions = {},
+  ): string {
+    const codePoints = Array.from(text);
+    const minScore = options.minScore ?? 0;
+    const allowedTypes = options.entityTypes
+      ? new Set(options.entityTypes)
+      : undefined;
+    const safeEntities = entities
+      .filter((entity) => {
+        const type = entity.Type || "PII";
+        const score = entity.Score ?? 1;
+        return (
+          typeof entity.BeginOffset === "number" &&
+          typeof entity.EndOffset === "number" &&
+          entity.BeginOffset >= 0 &&
+          entity.EndOffset > entity.BeginOffset &&
+          entity.EndOffset <= codePoints.length &&
+          score >= minScore &&
+          (!allowedTypes || allowedTypes.has(type))
+        );
+      })
+      .sort(
+        (left, right) => (right.BeginOffset || 0) - (left.BeginOffset || 0),
+      );
+
+    for (const entity of safeEntities) {
+      const begin = entity.BeginOffset || 0;
+      const end = entity.EndOffset || begin;
+      codePoints.splice(begin, end - begin, replacementFor(entity, options));
+    }
+
+    return codePoints.join("");
+  }
+}
+
+function createAWSComprehendClient(
+  region?: string,
+): ComprehendCompatibleClient {
+  const client = new ComprehendClient({
+    region: region || process.env.AWS_REGION || "us-east-1",
+  });
+  return {
+    detectPiiEntities: async (input: DetectPiiInput) =>
+      await client.send(
+        new DetectPiiEntitiesCommand({
+          Text: input.Text,
+          LanguageCode: input.LanguageCode as any,
+        }),
+      ),
+  };
+}
+
+function replacementFor(
+  entity: ComprehendPiiEntity,
+  options: ComprehendRedactionOptions,
+): string {
+  const type = entity.Type || "PII";
+  if (options.mode === "mask") {
+    const width = Math.max(
+      (entity.EndOffset || 0) - (entity.BeginOffset || 0),
+      1,
+    );
+    return (options.maskChar || "*").repeat(width);
+  }
+
+  return `[${type}]`;
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AWSComprehendPIIRedactor,
+  ComprehendCompatibleClient,
+} from "../lib/comprehend/comprehend";
+
+function mockClient(): ComprehendCompatibleClient {
+  return {
+    detectPiiEntities: vi.fn(async ({ Text }) => {
+      const name = "Jane Doe";
+      const email = "jane@example.com";
+      return {
+        Entities: [
+          {
+            Type: "NAME",
+            BeginOffset: Text.indexOf(name),
+            EndOffset: Text.indexOf(name) + name.length,
+            Score: 0.99,
+          },
+          {
+            Type: "EMAIL",
+            BeginOffset: Text.indexOf(email),
+            EndOffset: Text.indexOf(email) + email.length,
+            Score: 0.98,
+          },
+        ],
+      };
+    }),
+  };
+}
+
+describe("AWSComprehendPIIRedactor", () => {
+  it("redacts detected PII with entity labels", async () => {
+    const redactor = new AWSComprehendPIIRedactor({ client: mockClient() });
+    const result = await redactor.redact(
+      "Contact Jane Doe at jane@example.com",
+    );
+
+    expect(result.redactedText).toBe("Contact [NAME] at [EMAIL]");
+    expect(result.entities).toHaveLength(2);
+  });
+
+  it("can mask sensitive spans without shifting later offsets", () => {
+    const result = AWSComprehendPIIRedactor.applyRedaction(
+      "Call 555-1111 or email jane@example.com",
+      [
+        { Type: "PHONE", BeginOffset: 5, EndOffset: 13, Score: 0.99 },
+        { Type: "EMAIL", BeginOffset: 23, EndOffset: 39, Score: 0.99 },
+      ],
+      { mode: "mask", maskChar: "x" },
+    );
+
+    expect(result).toBe("Call xxxxxxxx or email xxxxxxxxxxxxxxxx");
+  });
+
+  it("filters entities by confidence and type", () => {
+    const result = AWSComprehendPIIRedactor.applyRedaction(
+      "Jane uses 555-1111",
+      [
+        { Type: "NAME", BeginOffset: 0, EndOffset: 4, Score: 0.5 },
+        { Type: "PHONE", BeginOffset: 10, EndOffset: 18, Score: 0.99 },
+      ],
+      { minScore: 0.9, entityTypes: ["PHONE"] },
+    );
+
+    expect(result).toBe("Jane uses [PHONE]");
+  });
+
+  it("redacts prompt and message chat options before calling an endpoint", async () => {
+    const redactor = new AWSComprehendPIIRedactor({ client: mockClient() });
+    const endpoint = {
+      chat: vi.fn(async (options: { prompt?: string }) => ({
+        content: options.prompt || "",
+      })),
+    };
+
+    const result = await redactor.chat(endpoint, {
+      prompt: "Contact Jane Doe at jane@example.com",
+    });
+
+    expect(endpoint.chat).toHaveBeenCalledWith({
+      prompt: "Contact [NAME] at [EMAIL]",
+    });
+    expect(result.content).toBe("Contact [NAME] at [EMAIL]");
+  });
+});

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/README.md
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/README.md
@@ -1,0 +1,40 @@
+# AWS Comprehend PII Redaction
+
+This example shows how to redact sensitive prompt data before calling an AI endpoint.
+
+```ts
+import { AWSComprehendPIIRedactor, OpenAI } from "@arakoodev/edgechains.js/ai";
+
+const redactor = new AWSComprehendPIIRedactor({ region: "us-east-1" });
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const safeOpenAI = redactor.wrapChat(openai);
+const response = await safeOpenAI.chat({
+  prompt:
+    "Summarize this customer note: Jane Doe, jane@example.com, called about billing.",
+});
+```
+
+For local demos and tests, inject a mock `detectPiiEntities` client. This keeps verification fast and does not require AWS credentials.
+
+Run the credential-free local demo:
+
+```bash
+npm install
+npm run start
+```
+
+```ts
+const redactor = new AWSComprehendPIIRedactor({
+  client: {
+    async detectPiiEntities() {
+      return {
+        Entities: [
+          { Type: "NAME", BeginOffset: 30, EndOffset: 38, Score: 0.99 },
+          { Type: "EMAIL", BeginOffset: 40, EndOffset: 56, Score: 0.99 },
+        ],
+      };
+    },
+  },
+});
+```

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aws-comprehend-pii-redaction-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "ts-node --esm src/index.ts"
+  },
+  "dependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/src/index.ts
@@ -1,0 +1,41 @@
+import { AWSComprehendPIIRedactor } from "../../../arakoodev/src/ai/src/lib/comprehend/comprehend.ts";
+
+const prompt =
+  "Summarize this customer note: Jane Doe, jane@example.com, called about billing.";
+
+const redactor = new AWSComprehendPIIRedactor({
+  client: {
+    async detectPiiEntities({ Text }) {
+      const name = "Jane Doe";
+      const email = "jane@example.com";
+      return {
+        Entities: [
+          {
+            Type: "NAME",
+            BeginOffset: Text.indexOf(name),
+            EndOffset: Text.indexOf(name) + name.length,
+            Score: 0.99,
+          },
+          {
+            Type: "EMAIL",
+            BeginOffset: Text.indexOf(email),
+            EndOffset: Text.indexOf(email) + email.length,
+            Score: 0.99,
+          },
+        ],
+      };
+    },
+  },
+});
+
+const safeEndpoint = redactor.wrapChat({
+  async chat({ prompt }: { prompt?: string }) {
+    return {
+      content: `Endpoint received: ${prompt}`,
+    };
+  },
+});
+
+const response = await safeEndpoint.chat({ prompt });
+
+console.log(response.content);

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
/claim #290

## Summary

Adds an AWS Comprehend PII redaction utility to the JavaScript SDK.

## What changed

- Added `AWSComprehendPIIRedactor` in the AI package.
- Supports direct text redaction, chat prompt redaction, chat message redaction, and `wrapChat()` for endpoint-style chaining before existing `chat()` calls.
- Uses the official AWS Comprehend client by default, with an injectable `detectPiiEntities` client for local tests and examples.
- Handles reverse-order redaction so replacing earlier entities does not shift later offsets.
- Adds a credential-free local example in `JS/edgechains/examples/aws-comprehend-pii-redaction`.

## Demo evidence

- Video demo repo: https://github.com/Deivid00007/edgechains-290-demo
- Direct video file: https://github.com/Deivid00007/edgechains-290-demo/blob/master/edgechains_290_demo.mp4
- Credential-free demo evidence comment: https://github.com/arakoodev/EdgeChains/pull/613#issuecomment-4703845771
- Demo output shows the endpoint receiving: `Summarize this customer note: [NAME], [EMAIL], called about billing.`

The demo does not require AWS credentials, private data, camera access, or any paid service.

## Verification

- `npx vitest run src/ai/src/tests/comprehend.test.ts` - 4 tests passed
- `npx tsc -p tsconfig.json --noEmit` - passed
- `npm run start` in `JS/edgechains/examples/aws-comprehend-pii-redaction`

Example output:

```text
Endpoint received: Summarize this customer note: [NAME], [EMAIL], called about billing.
```