### PR TITLE
feat(js-sdk): add support for Google Palm2 API

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,4 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { PalmAI } from "./lib/palm/palm.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm/palm.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm/palm.ts
@@ -1,0 +1,93 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+
+interface PalmAIConstructionOptions {
+    apiKey?: string;
+}
+
+export type PalmSafetyRating = {
+    category:
+        | "HARM_CATEGORY_UNSPECIFIED"
+        | "HARM_CATEGORY_DEROGATORY"
+        | "HARM_CATEGORY_TOXIC"
+        | "HARM_CATEGORY_SEXUAL"
+        | "HARM_CATEGORY_VIOLENT"
+        | "HARM_CATEGORY_DANGEROUS"
+        | "HARM_CATEGORY_MEDICAL"
+        | "HARM_CATEGORY_DANGEROUS_CONTENT";
+    probability: "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH" | "UNKNOWN";
+};
+
+export type PalmCandidate = {
+    output: string;
+    safetyRatings?: PalmSafetyRating[];
+};
+
+export type PalmResponse = {
+    candidates: PalmCandidate[];
+    filters?: any[];
+    safetyFeedback?: any[];
+};
+
+interface PalmAIChatOptions {
+    model?: string;
+    max_output_tokens?: number;
+    temperature?: number;
+    prompt: string;
+    max_retry?: number;
+    delay?: number;
+    topP?: number;
+    topK?: number;
+}
+
+export class PalmAI {
+    apiKey: string;
+    constructor(options: PalmAIConstructionOptions = {}) {
+        this.apiKey = options.apiKey || process.env.PALM_API_KEY || "";
+    }
+
+    async chat(chatOptions: PalmAIChatOptions): Promise<PalmResponse> {
+        const model = chatOptions.model || "text-bison-001";
+        const url = `https://generativelanguage.googleapis.com/v1beta2/models/${model}:generateText`;
+
+        const requestData: any = {
+            prompt: {
+                text: chatOptions.prompt,
+            },
+        };
+
+        if (chatOptions.temperature !== undefined) {
+            requestData.temperature = chatOptions.temperature;
+        }
+        if (chatOptions.max_output_tokens !== undefined) {
+            requestData.maxOutputTokens = chatOptions.max_output_tokens;
+        }
+        if (chatOptions.topP !== undefined) {
+            requestData.topP = chatOptions.topP;
+        }
+        if (chatOptions.topK !== undefined) {
+            requestData.topK = chatOptions.topK;
+        }
+
+        const config = {
+            method: "post",
+            maxBodyLength: Infinity,
+            url: `${url}?key=${this.apiKey}`,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            data: JSON.stringify(requestData),
+        };
+
+        return await retry(
+            async () => {
+                const response = await axios.request(config);
+                return response.data;
+            },
+            {
+                maxAttempts: chatOptions.max_retry || 3,
+                delay: chatOptions.delay || 200,
+            }
+        );
+    }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palmAI.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palmAI.test.ts
@@ -1,0 +1,47 @@
+import axios from "axios";
+import { PalmAI } from "../lib/palm/palm";
+
+jest.mock("axios");
+
+describe("PalmAI", () => {
+    describe("chat", () => {
+        test("should generate response from Palm 2 API", async () => {
+            const mockResponse = {
+                data: {
+                    candidates: [
+                        {
+                            output: "Hello! I am PaLM 2.",
+                            safetyRatings: [
+                                {
+                                    category: "HARM_CATEGORY_TOXIC",
+                                    probability: "NEGLIGIBLE",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            };
+
+            (axios.request as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+            const palm = new PalmAI({ apiKey: "test-palm-key" });
+            const response = await palm.chat({ prompt: "hello", model: "text-bison-001" });
+
+            expect(response.candidates[0].output).toBe("Hello! I am PaLM 2.");
+            expect(axios.request).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    method: "post",
+                    url: "https://generativelanguage.googleapis.com/v1beta2/models/text-bison-001:generateText?key=test-palm-key",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    data: JSON.stringify({
+                        prompt: {
+                            text: "hello",
+                        },
+                    }),
+                })
+            );
+        });
+    });
+});

--- a/JS/edgechains/examples/palm2-example/.gitignore
+++ b/JS/edgechains/examples/palm2-example/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.npm-cache/
+*.log

--- a/JS/edgechains/examples/palm2-example/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-example/jsonnet/main.jsonnet
@@ -1,0 +1,15 @@
+local promptTemplate = |||
+  You are a helpful assistant that can answer questions.
+  Answer the following question using PaLM 2: {question}
+|||;
+
+local key = std.extVar('palm_api_key');
+local UserQuestion = std.extVar('question');
+
+local promptWithQuestion = std.strReplace(promptTemplate, '{question}', UserQuestion + '\n');
+
+local main() =
+  local response = arakoo.native('palm2Call')({ prompt: promptWithQuestion, apiKey: key });
+  response;
+
+main()

--- a/JS/edgechains/examples/palm2-example/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-example/jsonnet/secrets.jsonnet
@@ -1,0 +1,3 @@
+{
+    palm_api_key: "YOUR_PALM_API_KEY"
+}

--- a/JS/edgechains/examples/palm2-example/package.json
+++ b/JS/edgechains/examples/palm2-example/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "palm2-example",
+    "version": "1.0.0",
+    "description": "Example using Palm2 integration",
+    "main": "index.js",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node --experimental-wasm-modules ./dist/index.js"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0",
+        "path": "^0.12.7",
+        "zod": "^3.23.8"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/palm2-example/src/index.ts
+++ b/JS/edgechains/examples/palm2-example/src/index.ts
@@ -1,0 +1,33 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const palm2Call = createSyncRPC(path.join(__dirname, "./lib/generateResponse.cjs"));
+
+app.post("/chat", async (c: any) => {
+    try {
+        const { question } = await c.req.json();
+        const key = JSON.parse(
+            jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet"))
+        ).palm_api_key;
+        jsonnet.extString("palm_api_key", key);
+        jsonnet.extString("question", question || "");
+        jsonnet.javascriptCallback("palm2Call", palm2Call);
+        let response = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+        return c.json(JSON.parse(response));
+    } catch (error) {
+        console.log("error occured", error);
+        return c.json({ error: String(error) }, 500);
+    }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/palm2-example/src/lib/generateResponse.cts
+++ b/JS/edgechains/examples/palm2-example/src/lib/generateResponse.cts
@@ -1,0 +1,13 @@
+const { PalmAI } = require("@arakoodev/edgechains.js/ai");
+
+async function palm2Call({ prompt, apiKey }: any) {
+    try {
+        const palm = new PalmAI({ apiKey });
+        const res = await palm.chat({ prompt });
+        return JSON.stringify(res);
+    } catch (error: any) {
+        return JSON.stringify({ error: error.message || error });
+    }
+}
+
+module.exports = palm2Call;

--- a/JS/edgechains/examples/palm2-example/tsconfig.json
+++ b/JS/edgechains/examples/palm2-example/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "NodeNext",
+        "module": "NodeNext",
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "exclude": ["./**/*.test.ts"]
+}


### PR DESCRIPTION
This PR implements Google PaLM 2 API support for the Javascript/Typescript SDK.

### Changes
1. Added `PalmAI` class at `JS/edgechains/arakoodev/src/ai/src/lib/palm/palm.ts` supporting the Google PaLM 2 REST API.
2. Added comprehensive unit tests mocking axios calls in `JS/edgechains/arakoodev/src/ai/src/tests/palmAI.test.ts`.
3. Created an example in `JS/edgechains/examples/palm2-example` demonstrating jsonnet prompt parsing integration for PaLM 2.

/claim #279