### PR TITLE
feat(js-sdk): add support for Qdrant vector database

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,3 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant, QdrantConfig, QdrantPoint } from "./lib/qdrant/qdrant.js";
+

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,108 @@
+import axios from "axios";
+
+export interface QdrantConfig {
+    url: string;
+    apiKey?: string;
+}
+
+export interface QdrantPoint {
+    id: number | string;
+    vector: number[];
+    payload?: Record<string, any>;
+}
+
+export class Qdrant {
+    url: string;
+    apiKey?: string;
+
+    constructor(config: QdrantConfig) {
+        this.url = config.url.replace(/\/$/, "");
+        this.apiKey = config.apiKey || process.env.QDRANT_API_KEY;
+    }
+
+    private getHeaders() {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (this.apiKey) {
+            headers["api-key"] = this.apiKey;
+        }
+        return headers;
+    }
+
+    async createCollection(
+        collectionName: string,
+        size: number,
+        distance: "Cosine" | "Euclid" | "Dot" = "Cosine"
+    ): Promise<any> {
+        const config = {
+            method: "put",
+            url: `${this.url}/collections/${collectionName}`,
+            headers: this.getHeaders(),
+            data: {
+                vectors: {
+                    size,
+                    distance,
+                },
+            },
+        };
+        const res = await axios.request(config);
+        return res.data;
+    }
+
+    async upsertPoints(collectionName: string, points: QdrantPoint[]): Promise<any> {
+        const config = {
+            method: "put",
+            url: `${this.url}/collections/${collectionName}/points?wait=true`,
+            headers: this.getHeaders(),
+            data: {
+                points,
+            },
+        };
+        const res = await axios.request(config);
+        return res.data;
+    }
+
+    async searchPoints(
+        collectionName: string,
+        vector: number[],
+        limit = 10,
+        filter?: any
+    ): Promise<any> {
+        const config = {
+            method: "post",
+            url: `${this.url}/collections/${collectionName}/points/search`,
+            headers: this.getHeaders(),
+            data: {
+                vector,
+                limit,
+                ...(filter && { filter }),
+            },
+        };
+        const res = await axios.request(config);
+        return res.data;
+    }
+
+    async deletePoints(collectionName: string, ids: (number | string)[]): Promise<any> {
+        const config = {
+            method: "post",
+            url: `${this.url}/collections/${collectionName}/points/delete?wait=true`,
+            headers: this.getHeaders(),
+            data: {
+                ids,
+            },
+        };
+        const res = await axios.request(config);
+        return res.data;
+    }
+
+    async deleteCollection(collectionName: string): Promise<any> {
+        const config = {
+            method: "delete",
+            url: `${this.url}/collections/${collectionName}`,
+            headers: this.getHeaders(),
+        };
+        const res = await axios.request(config);
+        return res.data;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant.test.ts
@@ -1,0 +1,109 @@
+import axios from "axios";
+import { Qdrant } from "../lib/qdrant/qdrant";
+
+jest.mock("axios");
+
+describe("Qdrant", () => {
+    let qdrant: Qdrant;
+
+    beforeEach(() => {
+        qdrant = new Qdrant({ url: "http://localhost:6333", apiKey: "test-key" });
+        jest.clearAllMocks();
+    });
+
+    test("createCollection should send PUT request", async () => {
+        const mockResponse = { data: { result: true, status: "ok" } };
+        (axios.request as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        const res = await qdrant.createCollection("test-collection", 128, "Cosine");
+
+        expect(res).toEqual({ result: true, status: "ok" });
+        expect(axios.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "put",
+                url: "http://localhost:6333/collections/test-collection",
+                headers: {
+                    "Content-Type": "application/json",
+                    "api-key": "test-key",
+                },
+                data: {
+                    vectors: {
+                        size: 128,
+                        distance: "Cosine",
+                    },
+                },
+            })
+        );
+    });
+
+    test("upsertPoints should send PUT request with points", async () => {
+        const mockResponse = { data: { result: { operation_id: 1, status: "completed" }, status: "ok" } };
+        (axios.request as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        const points = [
+            { id: 1, vector: [0.1, 0.2], payload: { text: "hello" } },
+        ];
+        const res = await qdrant.upsertPoints("test-collection", points);
+
+        expect(res).toEqual(mockResponse.data);
+        expect(axios.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "put",
+                url: "http://localhost:6333/collections/test-collection/points?wait=true",
+                data: { points },
+            })
+        );
+    });
+
+    test("searchPoints should send POST request", async () => {
+        const mockResponse = { data: { result: [{ id: 1, score: 0.99, payload: { text: "hello" } }] } };
+        (axios.request as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        const res = await qdrant.searchPoints("test-collection", [0.1, 0.2], 5);
+
+        expect(res).toEqual(mockResponse.data);
+        expect(axios.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "post",
+                url: "http://localhost:6333/collections/test-collection/points/search",
+                data: {
+                    vector: [0.1, 0.2],
+                    limit: 5,
+                },
+            })
+        );
+    });
+
+    test("deletePoints should send POST request", async () => {
+        const mockResponse = { data: { result: { operation_id: 2, status: "completed" } } };
+        (axios.request as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        const res = await qdrant.deletePoints("test-collection", [1]);
+
+        expect(res).toEqual(mockResponse.data);
+        expect(axios.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "post",
+                url: "http://localhost:6333/collections/test-collection/points/delete?wait=true",
+                data: {
+                    ids: [1],
+                },
+            })
+        );
+    });
+
+    test("deleteCollection should send DELETE request", async () => {
+        const mockResponse = { data: { result: true, status: "ok" } };
+        (axios.request as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        const res = await qdrant.deleteCollection("test-collection");
+
+        expect(res).toEqual(mockResponse.data);
+        expect(axios.request).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: "delete",
+                url: "http://localhost:6333/collections/test-collection",
+            })
+        );
+    });
+});

--- a/JS/edgechains/examples/qdrant-example/.gitignore
+++ b/JS/edgechains/examples/qdrant-example/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.npm-cache/
+*.log

--- a/JS/edgechains/examples/qdrant-example/package.json
+++ b/JS/edgechains/examples/qdrant-example/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "qdrant-example",
+    "version": "1.0.0",
+    "description": "Example demonstrating Qdrant support in edgechains.js",
+    "main": "index.js",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node --experimental-wasm-modules ./dist/index.js"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "file-uri-to-path": "^2.0.0",
+        "path": "^0.12.7"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.7.0-dev.20241007"
+    }
+}

--- a/JS/edgechains/examples/qdrant-example/src/index.ts
+++ b/JS/edgechains/examples/qdrant-example/src/index.ts
@@ -1,0 +1,22 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const runQdrant = createSyncRPC(path.join(__dirname, "./lib/qdrantOperations.cjs"));
+
+app.post("/qdrant-demo", async (c: any) => {
+    try {
+        const { url } = await c.req.json();
+        const result = await runQdrant(url || "http://localhost:6333");
+        return c.json(result);
+    } catch (error) {
+        return c.json({ error: String(error) }, 500);
+    }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/qdrant-example/src/lib/qdrantOperations.cts
+++ b/JS/edgechains/examples/qdrant-example/src/lib/qdrantOperations.cts
@@ -1,0 +1,31 @@
+const { Qdrant } = require("@arakoodev/edgechains.js/vector-db");
+
+async function runQdrant(url: string) {
+    try {
+        const qdrant = new Qdrant({ url });
+        const collectionName = "example_collection";
+        
+        console.log("Creating collection...");
+        await qdrant.createCollection(collectionName, 4, "Cosine");
+        
+        console.log("Upserting points...");
+        await qdrant.upsertPoints(collectionName, [
+            { id: 1, vector: [0.1, 0.2, 0.3, 0.4], payload: { city: "London" } },
+            { id: 2, vector: [0.2, 0.3, 0.4, 0.5], payload: { city: "Paris" } },
+        ]);
+        
+        console.log("Searching points...");
+        const searchRes = await qdrant.searchPoints(collectionName, [0.1, 0.2, 0.3, 0.4], 1);
+        console.log("Search result:", JSON.stringify(searchRes));
+        
+        console.log("Deleting collection...");
+        await qdrant.deleteCollection(collectionName);
+        
+        return { success: true, searchResult: searchRes };
+    } catch (error: any) {
+        console.error("Qdrant error:", error);
+        return { success: false, error: error.message };
+    }
+}
+
+module.exports = runQdrant;

--- a/JS/edgechains/examples/qdrant-example/tsconfig.json
+++ b/JS/edgechains/examples/qdrant-example/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "NodeNext",
+        "module": "NodeNext",
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "exclude": ["./**/*.test.ts"]
+}


### PR DESCRIPTION
This PR implements Qdrant vector database support for the Javascript/Typescript SDK.

### Changes
1. Added `Qdrant` class at `JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts` supporting the Qdrant REST API.
2. Added comprehensive unit tests mocking axios calls in `JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant.test.ts`.
3. Created an example in `JS/edgechains/examples/qdrant-example` demonstrating sync RPC integration for Qdrant.

/claim #273