### PR TITLE
feat(vector-db): add Qdrant client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,8 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type {
+    QdrantOptions,
+    QdrantPoint,
+    QdrantPointId,
+    QdrantScoredPoint,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,345 @@
+export type QdrantPointId = string | number;
+
+export interface QdrantPoint {
+    id: QdrantPointId;
+    vector?: number[];
+    payload?: Record<string, unknown>;
+}
+
+export interface QdrantScoredPoint extends QdrantPoint {
+    score: number;
+}
+
+export interface QdrantOptions {
+    fetch?: typeof fetch;
+    apiMode?: "query" | "search";
+}
+
+interface CollectionArgs {
+    collectionName?: string;
+    tableName?: string;
+    name?: string;
+    vectorSize?: number;
+    size?: number;
+    distance?: string;
+}
+
+interface PointArgs {
+    collectionName?: string;
+    tableName?: string;
+    id?: QdrantPointId;
+}
+
+interface QueryArgs extends PointArgs {
+    embedding?: number[];
+    query?: number[];
+    limit?: number;
+    filter?: Record<string, unknown>;
+    score_threshold?: number;
+    scoreThreshold?: number;
+    with_payload?: boolean;
+    withPayload?: boolean;
+}
+
+interface ScrollArgs extends PointArgs {
+    offset?: QdrantPointId;
+    limit?: number;
+    filter?: Record<string, unknown>;
+    with_payload?: boolean;
+    withPayload?: boolean;
+    with_vector?: boolean;
+    withVector?: boolean;
+}
+
+interface InsertVectorDataArgs extends PointArgs {
+    embedding: number[];
+    content?: unknown;
+    metadata?: Record<string, unknown>;
+    payload?: Record<string, unknown>;
+}
+
+interface UpdateArgs extends PointArgs {
+    updatedContent?: Record<string, unknown>;
+    payload?: Record<string, unknown>;
+}
+
+interface QdrantResponse<T> {
+    result: T;
+    status?: string;
+    time?: number;
+}
+
+type FetchLike = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+) => Promise<Response>;
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY: string;
+    private readonly requestFetch: FetchLike;
+    private readonly apiMode: "query" | "search";
+
+    constructor(
+        QDRANT_URL: string,
+        QDRANT_API_KEY?: string,
+        options: QdrantOptions = {},
+    ) {
+        this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(/\/$/, "");
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY || "";
+        this.requestFetch = options.fetch || fetch;
+        this.apiMode = options.apiMode || "query";
+
+        if (!this.QDRANT_URL) {
+            throw new Error("QDRANT_URL is required");
+        }
+    }
+
+    private collectionName(args: { collectionName?: string; tableName?: string; name?: string }) {
+        const name = args.collectionName || args.tableName || args.name;
+        if (!name) throw new Error("collectionName is required");
+        return name;
+    }
+
+    private pointId(id: QdrantPointId | undefined): QdrantPointId {
+        if (id === undefined || id === null || id === "") {
+            throw new Error("id is required");
+        }
+        return id;
+    }
+
+    private collectionPath(name: string, suffix = "") {
+        return `/collections/${encodeURIComponent(name)}${suffix}`;
+    }
+
+    private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+        const headers = new Headers(init.headers);
+        headers.set("content-type", "application/json");
+        if (this.QDRANT_API_KEY) headers.set("api-key", this.QDRANT_API_KEY);
+
+        const response = await this.requestFetch(`${this.QDRANT_URL}${path}`, {
+            ...init,
+            headers,
+        });
+        const text = await response.text();
+        let body: unknown;
+        try {
+            body = text ? JSON.parse(text) : undefined;
+        } catch {
+            body = text;
+        }
+
+        if (!response.ok) {
+            const message =
+                typeof body === "object" && body !== null && "status" in body
+                    ? JSON.stringify(body)
+                    : String(body || response.statusText || "Unknown error");
+            throw new Error(`Qdrant request failed (${response.status}): ${message}`);
+        }
+        return body as T;
+    }
+
+    async createCollection({
+        collectionName,
+        tableName,
+        name,
+        vectorSize,
+        size,
+        distance = "Cosine",
+    }: CollectionArgs): Promise<QdrantResponse<unknown>> {
+        const collection = this.collectionName({ collectionName, tableName, name });
+        const dimensions = vectorSize || size;
+        if (!dimensions || dimensions <= 0) throw new Error("vectorSize is required");
+
+        return this.request<QdrantResponse<unknown>>(
+            this.collectionPath(collection),
+            {
+                method: "PUT",
+                body: JSON.stringify({ vectors: { size: dimensions, distance } }),
+            },
+        );
+    }
+
+    async insertVectorData({
+        collectionName,
+        tableName,
+        id,
+        embedding,
+        content,
+        metadata,
+        payload,
+    }: InsertVectorDataArgs): Promise<QdrantResponse<unknown>> {
+        const collection = this.collectionName({ collectionName, tableName });
+        const pointId = this.pointId(id);
+        const pointPayload =
+            payload || {
+                ...(content === undefined ? {} : { content }),
+                ...(metadata || {}),
+            };
+
+        return this.request<QdrantResponse<unknown>>(
+            `${this.collectionPath(collection, "/points")}?wait=true`,
+            {
+                method: "PUT",
+                body: JSON.stringify({
+                    points: [{ id: pointId, vector: embedding, payload: pointPayload }],
+                }),
+            },
+        );
+    }
+
+    async getDataFromQuery({
+        collectionName,
+        tableName,
+        embedding,
+        query,
+        limit = 10,
+        filter,
+        score_threshold,
+        scoreThreshold,
+        with_payload,
+        withPayload,
+    }: QueryArgs): Promise<QdrantScoredPoint[]> {
+        const collection = this.collectionName({ collectionName, tableName });
+        const vector = embedding || query;
+        if (!vector) throw new Error("embedding is required");
+        const includePayload = with_payload ?? withPayload ?? true;
+        const body = {
+            limit,
+            filter,
+            score_threshold: score_threshold ?? scoreThreshold,
+            with_payload: includePayload,
+        };
+
+        const path =
+            this.apiMode === "search"
+                ? this.collectionPath(collection, "/points/search")
+                : this.collectionPath(collection, "/points/query");
+        const requestBody =
+            this.apiMode === "search" ? { vector, ...body } : { query: vector, ...body };
+        const requestInit: RequestInit = {
+            method: "POST",
+            body: JSON.stringify(requestBody),
+        };
+
+        if (this.apiMode === "search") {
+            const response = await this.request<QdrantResponse<QdrantScoredPoint[]>>(
+                path,
+                requestInit,
+            );
+            return response.result;
+        }
+
+        const response = await this.request<
+            QdrantResponse<{ points: QdrantScoredPoint[] }>
+        >(path, requestInit);
+        return response.result.points;
+    }
+
+    async scroll({
+        collectionName,
+        tableName,
+        offset,
+        limit = 100,
+        filter,
+        with_payload,
+        withPayload,
+        with_vector,
+        withVector,
+    }: ScrollArgs): Promise<{ points: QdrantPoint[]; next_page_offset?: QdrantPointId }> {
+        const collection = this.collectionName({ collectionName, tableName });
+        const response = await this.request<
+            QdrantResponse<{ points: QdrantPoint[]; next_page_offset?: QdrantPointId }>
+        >(this.collectionPath(collection, "/points/scroll"), {
+            method: "POST",
+            body: JSON.stringify({
+                offset,
+                limit,
+                filter,
+                with_payload: with_payload ?? withPayload ?? true,
+                with_vector: with_vector ?? withVector ?? false,
+            }),
+        });
+        return response.result;
+    }
+
+    async getData({
+        collectionName,
+        tableName,
+        limit = 100,
+        filter,
+        with_payload,
+        withPayload,
+        with_vector,
+        withVector,
+    }: ScrollArgs): Promise<QdrantPoint[]> {
+        const points: QdrantPoint[] = [];
+        let offset: QdrantPointId | undefined;
+        do {
+            const page = await this.scroll({
+                collectionName,
+                tableName,
+                offset,
+                limit,
+                filter,
+                with_payload,
+                withPayload,
+                with_vector,
+                withVector,
+            });
+            points.push(...page.points);
+            offset = page.next_page_offset;
+        } while (offset !== undefined && offset !== null);
+        return points;
+    }
+
+    async getDataById({
+        collectionName,
+        tableName,
+        id,
+    }: PointArgs): Promise<QdrantPoint> {
+        const collection = this.collectionName({ collectionName, tableName });
+        const pointId = this.pointId(id);
+        const response = await this.request<QdrantResponse<QdrantPoint>>(
+            this.collectionPath(collection, `/points/${encodeURIComponent(String(pointId))}`),
+        );
+        return response.result;
+    }
+
+    async updateById({
+        collectionName,
+        tableName,
+        id,
+        updatedContent,
+        payload,
+    }: UpdateArgs): Promise<QdrantResponse<unknown>> {
+        const collection = this.collectionName({ collectionName, tableName });
+        const pointId = this.pointId(id);
+        const nextPayload = payload || updatedContent;
+        if (!nextPayload) throw new Error("updatedContent or payload is required");
+
+        return this.request<QdrantResponse<unknown>>(
+            `${this.collectionPath(collection, "/points/payload")}?wait=true`,
+            {
+                method: "POST",
+                body: JSON.stringify({ points: [pointId], payload: nextPayload }),
+            },
+        );
+    }
+
+    async deleteById({
+        collectionName,
+        tableName,
+        id,
+    }: PointArgs): Promise<QdrantResponse<unknown>> {
+        const collection = this.collectionName({ collectionName, tableName });
+        const pointId = this.pointId(id);
+        return this.request<QdrantResponse<unknown>>(
+            `${this.collectionPath(collection, "/points/delete")}?wait=true`,
+            {
+                method: "POST",
+                body: JSON.stringify({ points: [pointId] }),
+            },
+        );
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+function response(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+    });
+}
+
+describe("Qdrant", () => {
+    const fetchMock = vi.fn();
+    let client: Qdrant;
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        client = new Qdrant("https://qdrant.example/", "test-key", {
+            fetch: fetchMock,
+        });
+    });
+
+    it("creates collections with the API key and vector settings", async () => {
+        fetchMock.mockResolvedValue(response({ result: true }));
+
+        await client.createCollection({ collectionName: "documents", vectorSize: 3 });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/documents",
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({ vectors: { size: 3, distance: "Cosine" } }),
+            }),
+        );
+        const init = fetchMock.mock.calls[0][1];
+        expect(init.headers.get("api-key")).toBe("test-key");
+    });
+
+    it("upserts a point with content and metadata as payload", async () => {
+        fetchMock.mockResolvedValue(response({ result: { status: "completed" } }));
+
+        await client.insertVectorData({
+            collectionName: "documents",
+            id: "doc/1",
+            embedding: [0.1, 0.2],
+            content: "hello",
+            metadata: { source: "test" },
+        });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example/collections/documents/points?wait=true",
+        );
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+            points: [
+                {
+                    id: "doc/1",
+                    vector: [0.1, 0.2],
+                    payload: { content: "hello", source: "test" },
+                },
+            ],
+        });
+    });
+
+    it("uses the modern query endpoint and returns scored points", async () => {
+        fetchMock.mockResolvedValue(
+            response({ result: { points: [{ id: 1, score: 0.9 }] } }),
+        );
+
+        const points = await client.getDataFromQuery({
+            collectionName: "documents",
+            embedding: [1, 2],
+            limit: 5,
+        });
+
+        expect(points).toEqual([{ id: 1, score: 0.9 }]);
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example/collections/documents/points/query",
+        );
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+            query: [1, 2],
+            limit: 5,
+        });
+    });
+
+    it("supports the legacy search endpoint response shape", async () => {
+        fetchMock.mockResolvedValue(response({ result: [{ id: 2, score: 0.8 }] }));
+        const legacyClient = new Qdrant("https://qdrant.example/", "test-key", {
+            fetch: fetchMock,
+            apiMode: "search",
+        });
+
+        await expect(
+            legacyClient.getDataFromQuery({
+                collectionName: "documents",
+                embedding: [3, 4],
+            }),
+        ).resolves.toEqual([{ id: 2, score: 0.8 }]);
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://qdrant.example/collections/documents/points/search",
+        );
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+            vector: [3, 4],
+        });
+    });
+
+    it("scrolls through pages when reading all data", async () => {
+        fetchMock
+            .mockResolvedValueOnce(response({ result: { points: [{ id: 1 }], next_page_offset: 2 } }))
+            .mockResolvedValueOnce(response({ result: { points: [{ id: 2 }] } }));
+
+        await expect(client.getData({ collectionName: "documents" })).resolves.toEqual([
+            { id: 1 },
+            { id: 2 },
+        ]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("URL-encodes point ids and surfaces HTTP errors", async () => {
+        fetchMock.mockResolvedValue(response({ result: { id: "a/b" } }));
+        await client.getDataById({ collectionName: "documents", id: "a/b" });
+        expect(fetchMock.mock.calls[0][0]).toContain("/points/a%2Fb");
+
+        fetchMock.mockResolvedValue(response({ status: { error: "bad request" } }, 400));
+        await expect(
+            client.deleteById({ collectionName: "documents", id: 1 }),
+        ).rejects.toThrow("Qdrant request failed (400)");
+    });
+});


### PR DESCRIPTION
# PR draft — Add Qdrant REST vector database client

## Summary

Adds a Qdrant vector database client to the JavaScript SDK using the HTTP API directly, without adding a Qdrant package dependency.

Supported operations:

- collection creation
- point upsert with embeddings and payloads
- similarity query (`/points/query`, with legacy `/points/search` mode)
- paginated scroll and full collection reads
- point retrieval, payload update, and deletion

The client supports API-key authentication, URL-encoded collection/point IDs, injected fetch implementations for tests, and clear HTTP error messages.

## Tests

- `qdrant.test.ts`
- TypeScript compilation passed for the new client.
- Runtime checks passed for the modern `/points/query` response (`result.points`) and the legacy `/points/search` response, plus collection creation, upsert, pagination, and error handling.

## Review note

The issue does not state a dollar amount in its GitHub body, so no payment is counted until the maintainer confirms the bounty and merges the PR. No external PR, issue comment, or message has been sent.

The modern response handling follows [Qdrant's query-points API](https://api.qdrant.tech/api-reference/search/query-points/), which returns scored points under `result.points`.

Closes #273
