### PR TITLE
Add Qdrant HTTP vector database client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,3 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type { QdrantPoint, QdrantVectorConfig } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,184 @@
+import axios, { AxiosInstance } from "axios";
+import retry from "retry";
+import { config } from "dotenv";
+config();
+
+type Payload = Record<string, unknown>;
+type QdrantPointId = string | number;
+type Vector = number[] | Record<string, number[]>;
+
+export interface QdrantPoint {
+    id: QdrantPointId;
+    vector: Vector;
+    payload?: Payload;
+}
+
+export interface QdrantVectorConfig {
+    size: number;
+    distance: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL!;
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+    }
+
+    createClient(): AxiosInstance {
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+
+        if (this.QDRANT_API_KEY) {
+            headers["api-key"] = this.QDRANT_API_KEY;
+        }
+
+        return axios.create({
+            baseURL: this.QDRANT_URL.replace(/\/$/, ""),
+            headers,
+        });
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        vectors,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        vectors: QdrantVectorConfig | Record<string, QdrantVectorConfig>;
+    }): Promise<any> {
+        return this.requestWithRetry(() =>
+            client.put(`/collections/${collectionName}`, {
+                vectors,
+            })
+        );
+    }
+
+    async deleteCollection({
+        client,
+        collectionName,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+    }): Promise<any> {
+        return this.requestWithRetry(() => client.delete(`/collections/${collectionName}`));
+    }
+
+    async upsertPoints({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        points: QdrantPoint[];
+        wait?: boolean;
+    }): Promise<any> {
+        return this.requestWithRetry(() =>
+            client.put(`/collections/${collectionName}/points`, {
+                points,
+                wait,
+            })
+        );
+    }
+
+    async searchPoints({
+        client,
+        collectionName,
+        vector,
+        limit = 10,
+        filter,
+        withPayload = true,
+        withVector = false,
+        scoreThreshold,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        vector: Vector;
+        limit?: number;
+        filter?: Payload;
+        withPayload?: boolean | string[];
+        withVector?: boolean | string[];
+        scoreThreshold?: number;
+    }): Promise<any> {
+        return this.requestWithRetry(() =>
+            client.post(`/collections/${collectionName}/points/search`, {
+                vector,
+                limit,
+                filter,
+                with_payload: withPayload,
+                with_vector: withVector,
+                score_threshold: scoreThreshold,
+            })
+        );
+    }
+
+    async getPoint({
+        client,
+        collectionName,
+        id,
+        withPayload = true,
+        withVector = false,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        id: QdrantPointId;
+        withPayload?: boolean | string[];
+        withVector?: boolean | string[];
+    }): Promise<any> {
+        return this.requestWithRetry(() =>
+            client.get(`/collections/${collectionName}/points/${id}`, {
+                params: {
+                    with_payload: withPayload,
+                    with_vector: withVector,
+                },
+            })
+        );
+    }
+
+    async deletePoints({
+        client,
+        collectionName,
+        points,
+        wait = true,
+    }: {
+        client: AxiosInstance;
+        collectionName: string;
+        points: QdrantPointId[];
+        wait?: boolean;
+    }): Promise<any> {
+        return this.requestWithRetry(() =>
+            client.post(`/collections/${collectionName}/points/delete`, {
+                points,
+                wait,
+            })
+        );
+    }
+
+    private async requestWithRetry(operationToRun: () => Promise<any>): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({
+                retries: 5,
+                factor: 3,
+                minTimeout: 1 * 1000,
+                maxTimeout: 60 * 1000,
+                randomize: true,
+            });
+
+            operation.attempt(async () => {
+                try {
+                    const response = await operationToRun();
+                    resolve(response.data);
+                } catch (error: any) {
+                    if (operation.retry(error)) return;
+                    reject(error);
+                }
+            });
+        });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,134 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+vi.mock("axios");
+
+const MOCK_QDRANT_URL = "https://mock-qdrant.cloud";
+const MOCK_QDRANT_API_KEY = "mock-api-key";
+
+describe("Qdrant", () => {
+    const put = vi.fn();
+    const post = vi.fn();
+    const get = vi.fn();
+    const deleteFn = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(axios.create).mockReturnValue({
+            put,
+            post,
+            get,
+            delete: deleteFn,
+        });
+    });
+
+    it("should create an axios client with Qdrant headers", () => {
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+
+        qdrant.createClient();
+
+        expect(axios.create).toHaveBeenCalledWith({
+            baseURL: MOCK_QDRANT_URL,
+            headers: {
+                "Content-Type": "application/json",
+                "api-key": MOCK_QDRANT_API_KEY,
+            },
+        });
+    });
+
+    it("should create a collection", async () => {
+        put.mockResolvedValue({ data: { result: true } });
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        const result = await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
+
+        expect(put).toHaveBeenCalledWith("/collections/documents", {
+            vectors: {
+                size: 1536,
+                distance: "Cosine",
+            },
+        });
+        expect(result).toEqual({ result: true });
+    });
+
+    it("should upsert points", async () => {
+        put.mockResolvedValue({ data: { status: "ok" } });
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        const result = await qdrant.upsertPoints({
+            client,
+            collectionName: "documents",
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+        });
+
+        expect(put).toHaveBeenCalledWith("/collections/documents/points", {
+            points: [
+                {
+                    id: 1,
+                    vector: [0.1, 0.2, 0.3],
+                    payload: { content: "hello" },
+                },
+            ],
+            wait: true,
+        });
+        expect(result).toEqual({ status: "ok" });
+    });
+
+    it("should search points", async () => {
+        post.mockResolvedValue({ data: { result: [{ id: 1, score: 0.99 }] } });
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        const result = await qdrant.searchPoints({
+            client,
+            collectionName: "documents",
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            withPayload: true,
+        });
+
+        expect(post).toHaveBeenCalledWith("/collections/documents/points/search", {
+            vector: [0.1, 0.2, 0.3],
+            limit: 3,
+            filter: undefined,
+            with_payload: true,
+            with_vector: false,
+            score_threshold: undefined,
+        });
+        expect(result).toEqual({ result: [{ id: 1, score: 0.99 }] });
+    });
+
+    it("should delete points", async () => {
+        post.mockResolvedValue({ data: { result: true } });
+        const qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+        const client = qdrant.createClient();
+
+        const result = await qdrant.deletePoints({
+            client,
+            collectionName: "documents",
+            points: [1, 2],
+        });
+
+        expect(post).toHaveBeenCalledWith("/collections/documents/points/delete", {
+            points: [1, 2],
+            wait: true,
+        });
+        expect(result).toEqual({ result: true });
+    });
+});


### PR DESCRIPTION
## Summary
- Adds a Qdrant vector database client using Qdrant's HTTP API through axios, without adding the official Qdrant SDK.
- Supports collection creation/deletion, point upsert, point search, point retrieval, and point deletion.
- Exports the Qdrant client and related TypeScript types from the vector-db package.
- Adds Vitest coverage for client creation and core Qdrant operations.

## Verification
- npx tsc -b
- npm test -- --run src/vector-db/src/tests/qdrant/qdrant.test.ts

Closes #273