### PR TITLE
feat(vector-db): add dependency-free Qdrant REST client

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/README.md
+++ b/JS/edgechains/arakoodev/src/vector-db/README.md
@@ -1,0 +1,32 @@
+# Qdrant
+
+The vector database package includes a dependency-free Qdrant REST client.
+
+```ts
+import { Qdrant } from "@arakoodev/edgechains.js/vector-db"
+
+const qdrant = new Qdrant(process.env.QDRANT_URL, process.env.QDRANT_API_KEY)
+const client = qdrant.createClient()
+
+await qdrant.createCollection({
+  client,
+  collectionName: "documents",
+  vectorSize: 3,
+})
+
+await qdrant.insertVectorData({
+  client,
+  collectionName: "documents",
+  points: [{ id: 1, vector: [0.1, 0.2, 0.3], payload: { text: "hello" } }],
+})
+
+const matches = await qdrant.getDataFromQuery({
+  client,
+  collectionName: "documents",
+  vector: [0.1, 0.2, 0.3],
+  limit: 5,
+})
+```
+
+The wrapper also supports scrolling, point retrieval, payload updates, and
+point deletion. Tests mock `fetch`, so no Qdrant account or server is needed.

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,3 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";
+export type { QdrantClient, QdrantPoint, QdrantSearchResult } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,122 @@
+export interface QdrantClient {
+    url: string;
+    apiKey?: string;
+}
+
+export interface QdrantPoint {
+    id: string | number;
+    vector: number[] | Record<string, number[]>;
+    payload?: Record<string, unknown>;
+}
+
+export interface QdrantSearchResult {
+    id: string | number;
+    score: number;
+    payload?: Record<string, unknown>;
+    vector?: unknown;
+}
+
+interface RequestOptions {
+    method?: "GET" | "PUT" | "POST" | "DELETE";
+    body?: unknown;
+}
+
+/** Dependency-free wrapper around Qdrant's public REST API. */
+export class Qdrant {
+    constructor(
+        private readonly url: string = process.env.QDRANT_URL || "",
+        private readonly apiKey: string = process.env.QDRANT_API_KEY || ""
+    ) {}
+
+    createClient(): QdrantClient {
+        if (!this.url) throw new Error("Qdrant URL is required");
+        return { url: this.url.replace(/\/$/, ""), apiKey: this.apiKey || undefined };
+    }
+
+    private async request<T>(client: QdrantClient, path: string, options: RequestOptions = {}): Promise<T> {
+        const response = await fetch(`${client.url}${path}`, {
+            method: options.method || "GET",
+            headers: {
+                "content-type": "application/json",
+                ...(client.apiKey ? { "api-key": client.apiKey } : {}),
+            },
+            ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+        });
+        const data = await response.json() as { result?: T; status?: unknown };
+        if (!response.ok) throw new Error(`Qdrant request failed (${response.status})`);
+        return (data.result === undefined ? data : data.result) as T;
+    }
+
+    createCollection({ client, collectionName, vectorSize, distance = "Cosine" }: {
+        client: QdrantClient; collectionName: string; vectorSize: number;
+        distance?: "Cosine" | "Euclid" | "Dot" | "Manhattan";
+    }): Promise<unknown> {
+        return this.request(client, `/collections/${encodeURIComponent(collectionName)}`, {
+            method: "PUT", body: { vectors: { size: vectorSize, distance } },
+        });
+    }
+
+    insertVectorData({ client, collectionName, points, wait = true }: {
+        client: QdrantClient; collectionName: string; points: QdrantPoint[]; wait?: boolean;
+    }): Promise<unknown> {
+        return this.request(client,
+            `/collections/${encodeURIComponent(collectionName)}/points?wait=${wait}`, {
+                method: "PUT", body: { points },
+            });
+    }
+
+    async getDataFromQuery({ client, collectionName, vector, limit = 10, filter,
+        withPayload = true }: {
+        client: QdrantClient; collectionName: string; vector: number[];
+        limit?: number; filter?: Record<string, unknown>; withPayload?: boolean;
+    }): Promise<QdrantSearchResult[]> {
+        return this.request(client,
+            `/collections/${encodeURIComponent(collectionName)}/points/search`, {
+                method: "POST", body: {
+                    vector, limit, with_payload: withPayload, ...(filter ? { filter } : {}),
+                },
+            });
+    }
+
+    async getData({ client, collectionName, limit = 10, offset, filter,
+        withPayload = true, withVector = false }: {
+        client: QdrantClient; collectionName: string; limit?: number;
+        offset?: string | number; filter?: Record<string, unknown>;
+        withPayload?: boolean; withVector?: boolean;
+    }): Promise<unknown> {
+        return this.request(client,
+            `/collections/${encodeURIComponent(collectionName)}/points/scroll`, {
+                method: "POST", body: { limit, with_payload: withPayload,
+                    with_vector: withVector, ...(offset === undefined ? {} : { offset }),
+                    ...(filter ? { filter } : {}) },
+            });
+    }
+
+    getDataById({ client, collectionName, id, withPayload = true, withVector = false }: {
+        client: QdrantClient; collectionName: string; id: string | number;
+        withPayload?: boolean; withVector?: boolean;
+    }): Promise<unknown> {
+        return this.request(client,
+            `/collections/${encodeURIComponent(collectionName)}/points/${encodeURIComponent(id)}` +
+            `?with_payload=${withPayload}&with_vector=${withVector}`);
+    }
+
+    updateById({ client, collectionName, id, payload, wait = true }: {
+        client: QdrantClient; collectionName: string; id: string | number;
+        payload: Record<string, unknown>; wait?: boolean;
+    }): Promise<unknown> {
+        return this.request(client,
+            `/collections/${encodeURIComponent(collectionName)}/points/payload?wait=${wait}`, {
+                method: "POST", body: { payload, points: [id] },
+            });
+    }
+
+    deleteById({ client, collectionName, id, wait = true }: {
+        client: QdrantClient; collectionName: string; id: string | number; wait?: boolean;
+    }): Promise<unknown> {
+        return this.request(client,
+            `/collections/${encodeURIComponent(collectionName)}/points/delete?wait=${wait}`, {
+                method: "POST", body: { points: [id] },
+            });
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Qdrant } from "../../lib/qdrant/qdrant.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+const response = (result: unknown, ok = true) =>
+    ({ ok, status: ok ? 200 : 400, json: async () => ({ result }) }) as Response;
+
+describe("Qdrant REST client", () => {
+    it("upserts points using the API key", async () => {
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response({ status: "ok" }));
+        const qdrant = new Qdrant("https://qdrant.example/", "secret");
+        await qdrant.insertVectorData({
+            client: qdrant.createClient(), collectionName: "docs",
+            points: [{ id: 1, vector: [0.1, 0.2], payload: { text: "hello" } }],
+        });
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://qdrant.example/collections/docs/points?wait=true",
+            expect.objectContaining({ method: "PUT", headers: expect.objectContaining({ "api-key": "secret" }) })
+        );
+    });
+
+    it("searches and returns Qdrant results", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(response([{ id: 1, score: 0.9 }]));
+        const qdrant = new Qdrant("https://qdrant.example");
+        const result = await qdrant.getDataFromQuery({
+            client: qdrant.createClient(), collectionName: "docs", vector: [0.1], limit: 3,
+        });
+        expect(result).toEqual([{ id: 1, score: 0.9 }]);
+    });
+
+    it("supports retrieve, payload update and deletion", async () => {
+        const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response(true));
+        const qdrant = new Qdrant("https://qdrant.example");
+        const client = qdrant.createClient();
+        await qdrant.getDataById({ client, collectionName: "docs", id: "a/b" });
+        await qdrant.updateById({ client, collectionName: "docs", id: 1, payload: { tag: "new" } });
+        await qdrant.deleteById({ client, collectionName: "docs", id: 1 });
+        expect(fetchMock.mock.calls[0][0]).toContain("a%2Fb");
+        expect(fetchMock.mock.calls[1][1]).toEqual(expect.objectContaining({ method: "POST" }));
+        expect(fetchMock.mock.calls[2][1]).toEqual(expect.objectContaining({ method: "POST" }));
+    });
+
+    it("rejects unsuccessful responses without leaking response bodies", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(response({ secret: "hidden" }, false));
+        const qdrant = new Qdrant("https://qdrant.example");
+        await expect(qdrant.getData({ client: qdrant.createClient(), collectionName: "docs" }))
+            .rejects.toThrow("Qdrant request failed (400)");
+    });
+});


### PR DESCRIPTION
## Summary

- add a dependency-free Qdrant REST client to the JavaScript vector-db package
- support collection creation, point upsert, vector search, scrolling, retrieval, payload updates, and deletion
- export `Qdrant` and its public types alongside the existing `Supabase` integration
- document a minimal usage example
- add deterministic tests with mocked `fetch`; no Qdrant account or live server is required

## Validation

- `npx tsc -b --pretty false`
- `npx vitest run src/vector-db/src/tests/qdrant/qdrant.test.ts` — 4 tests passed
- `git diff --check`

## Demo

A short MP4 demonstrates the exported API, covered operations, successful TypeScript build, and passing tests. Attach `edgechains-273-demo.mp4` from the prepared submission package to this PR.

/claim #273

https://github.com/user-attachments/assets/9cbd774d-9dad-46bf-9655-2995b3d940d0

