### PR TITLE
feat(ai): add AWS Comprehend PII redaction utility with chaining support

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,12 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+  ComprehendRedactor,
+  withPIIRedaction,
+} from "./lib/comprehend/redactor.js";
+export type {
+  ComprehendRedactorOptions,
+  PIIEntity,
+  RedactionResult,
+} from "./lib/comprehend/redactor.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/redactor.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/redactor.ts
@@ -1,0 +1,212 @@
+import { createHash, createHmac } from "crypto";
+
+export type PIIEntity = {
+  type: string;
+  beginOffset: number;
+  endOffset: number;
+  score: number;
+};
+
+export type RedactionResult = {
+  redactedText: string;
+  entities: PIIEntity[];
+};
+
+export interface ComprehendRedactorOptions {
+  region?: string;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+  };
+  languageCode?: string;
+  /**
+   * "placeholder" replaces each PII span with [TYPE],
+   * "asterisk" replaces it with same-length ****
+   */
+  maskStyle?: "placeholder" | "asterisk";
+  /**
+   * Injectable fetch implementation (used by tests).
+   * Defaults to globalThis.fetch.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+interface DetectPiiEntitiesResponse {
+  Entities: Array<{
+    Score: number;
+    Type: string;
+    BeginOffset: number;
+    EndOffset: number;
+  }>;
+}
+
+const SERVICE = "comprehend";
+const TARGET = "Comprehend_20171127.DetectPiiEntities";
+
+const sha256Hex = (data: string): string =>
+  createHash("sha256").update(data, "utf8").digest("hex");
+
+const hmac = (key: Buffer | string, data: string): Buffer =>
+  createHmac("sha256", key).update(data, "utf8").digest();
+
+/**
+ * Redacts personally identifiable information from prompts using
+ * Amazon Comprehend DetectPiiEntities.
+ *
+ * Can be chained with any AI client exposing `chat()` via {@link withPIIRedaction}.
+ */
+export class ComprehendRedactor {
+  private region: string;
+  private accessKeyId: string;
+  private secretAccessKey: string;
+  private languageCode: string;
+  private maskStyle: "placeholder" | "asterisk";
+  private fetchImpl: typeof fetch;
+
+  constructor(options: ComprehendRedactorOptions = {}) {
+    this.region =
+      options.region ||
+      process.env.AWS_REGION ||
+      process.env.AWS_DEFAULT_REGION ||
+      "";
+    this.accessKeyId =
+      options.credentials?.accessKeyId || process.env.AWS_ACCESS_KEY_ID || "";
+    this.secretAccessKey =
+      options.credentials?.secretAccessKey ||
+      process.env.AWS_SECRET_ACCESS_KEY ||
+      "";
+    this.languageCode = options.languageCode || "en";
+    this.maskStyle = options.maskStyle || "placeholder";
+    this.fetchImpl = options.fetchImpl || globalThis.fetch;
+  }
+
+  private isConfigured(): boolean {
+    return Boolean(this.region && this.accessKeyId && this.secretAccessKey);
+  }
+
+  private signedHeaders(body: string): Record<string, string> {
+    if (!this.isConfigured()) {
+      throw new Error(
+        "AWS credentials are missing. Provide region/accessKeyId/secretAccessKey or set AWS_REGION, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.",
+      );
+    }
+    const amzDate = new Date().toISOString().replace(/[:-]|\.\d{3}/g, "");
+    const dateStamp = amzDate.slice(0, 8);
+    const host = `${SERVICE}.${this.region}.amazonaws.com`;
+    const payloadHash = sha256Hex(body);
+
+    const canonicalHeaders =
+      `content-type:application/x-amz-json-1.1\n` +
+      `host:${host}\n` +
+      `x-amz-date:${amzDate}\n` +
+      `x-amz-target:${TARGET}\n`;
+    const signedHeadersList = "content-type;host;x-amz-date;x-amz-target";
+
+    const canonicalRequest = [
+      "POST",
+      "/",
+      "",
+      canonicalHeaders,
+      signedHeadersList,
+      payloadHash,
+    ].join("\n");
+
+    const scope = `${dateStamp}/${this.region}/${SERVICE}/aws4_request`;
+    const stringToSign = [
+      "AWS4-HMAC-SHA256",
+      amzDate,
+      scope,
+      sha256Hex(canonicalRequest),
+    ].join("\n");
+
+    const kDate = hmac(`AWS4${this.secretAccessKey}`, dateStamp);
+    const kRegion = hmac(kDate, this.region);
+    const kService = hmac(kRegion, SERVICE);
+    const kSigning = hmac(kService, "aws4_request");
+    const signature = createHmac("sha256", kSigning)
+      .update(stringToSign, "utf8")
+      .digest("hex");
+
+    return {
+      "Content-Type": "application/x-amz-json-1.1",
+      Host: host,
+      "X-Amz-Date": amzDate,
+      "X-Amz-Target": TARGET,
+      Authorization: `AWS4-HMAC-SHA256 Credential=${this.accessKeyId}/${scope}, SignedHeaders=${signedHeadersList}, Signature=${signature}`,
+    };
+  }
+
+  /** Calls Comprehend DetectPiiEntities and returns normalized entities. */
+  async detect(text: string): Promise<PIIEntity[]> {
+    const body = JSON.stringify({
+      Text: text,
+      LanguageCode: this.languageCode,
+    });
+    const host = `${SERVICE}.${this.region}.amazonaws.com`;
+    const response = await this.fetchImpl(`https://${host}/`, {
+      method: "POST",
+      headers: this.signedHeaders(body),
+      body,
+    });
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(
+        `Comprehend DetectPiiEntities failed (${response.status}): ${detail}`,
+      );
+    }
+    const parsed = (await response.json()) as DetectPiiEntitiesResponse;
+    return (parsed.Entities || []).map((entity) => ({
+      type: entity.Type,
+      beginOffset: entity.BeginOffset,
+      endOffset: entity.EndOffset,
+      score: entity.Score,
+    }));
+  }
+
+  /** Masks every detected PII span and returns the sanitized text. */
+  async redact(text: string): Promise<RedactionResult> {
+    const entities = await this.detect(text);
+    // Replace from the end so earlier offsets stay valid.
+    const sorted = [...entities].sort((a, b) => b.beginOffset - a.beginOffset);
+    let redactedText = text;
+    for (const entity of sorted) {
+      const replacement =
+        this.maskStyle === "asterisk"
+          ? "*".repeat(Math.max(entity.endOffset - entity.beginOffset, 1))
+          : `[${entity.type}]`;
+      redactedText =
+        redactedText.slice(0, entity.beginOffset) +
+        replacement +
+        redactedText.slice(entity.endOffset);
+    }
+    return { redactedText, entities };
+  }
+}
+
+type ChatCapable = {
+  chat: (options: any) => Promise<any>;
+};
+
+/**
+ * Chains a PII redactor in front of any client exposing `chat()`.
+ * Every prompt is sanitized before reaching the underlying AI endpoint.
+ */
+export function withPIIRedaction<C extends ChatCapable>(
+  client: C,
+  redactor: ComprehendRedactor,
+): C {
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      if (prop !== "chat") {
+        return Reflect.get(target, prop, receiver);
+      }
+      return async (chatOptions: any) => {
+        if (chatOptions && typeof chatOptions.prompt === "string") {
+          const { redactedText } = await redactor.redact(chatOptions.prompt);
+          return target.chat({ ...chatOptions, prompt: redactedText });
+        }
+        return target.chat(chatOptions);
+      };
+    },
+  });
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ComprehendRedactor,
+  withPIIRedaction,
+} from "../lib/comprehend/redactor";
+
+const makeFetch = (
+  entities: any[],
+  capture?: { url?: string; headers?: any; body?: string },
+) => {
+  return vi.fn(async (url: string, init?: any) => {
+    if (capture) {
+      capture.url = url;
+      capture.headers = init?.headers;
+      capture.body = init?.body;
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ Entities: entities }),
+      text: async () => JSON.stringify({ Entities: entities }),
+    } as any;
+  });
+};
+
+const baseOptions = {
+  region: "us-east-1",
+  credentials: { accessKeyId: "AKIDEXAMPLE", secretAccessKey: "secret" },
+};
+
+describe("ComprehendRedactor", () => {
+  it("throws a helpful error when credentials are missing", async () => {
+    const original = { ...process.env };
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+
+    const redactor = new ComprehendRedactor();
+    await expect(redactor.redact("hello")).rejects.toThrow(
+      /credentials are missing/i,
+    );
+
+    process.env.AWS_REGION = original.AWS_REGION;
+    process.env.AWS_DEFAULT_REGION = original.AWS_DEFAULT_REGION;
+    process.env.AWS_ACCESS_KEY_ID = original.AWS_ACCESS_KEY_ID;
+    process.env.AWS_SECRET_ACCESS_KEY = original.AWS_SECRET_ACCESS_KEY;
+  });
+
+  it("sends a signed DetectPiiEntities request and parses entities", async () => {
+    const capture: any = {};
+    const fetchImpl = makeFetch(
+      [{ Score: 0.99, Type: "NAME", BeginOffset: 7, EndOffset: 11 }],
+      capture,
+    );
+    const redactor = new ComprehendRedactor({ ...baseOptions, fetchImpl });
+
+    const entities = await redactor.detect("meet John tomorrow");
+
+    expect(entities).toEqual([
+      { type: "NAME", beginOffset: 7, endOffset: 11, score: 0.99 },
+    ]);
+    expect(capture.url).toBe("https://comprehend.us-east-1.amazonaws.com/");
+    expect(capture.headers["X-Amz-Target"]).toBe(
+      "Comprehend_20171127.DetectPiiEntities",
+    );
+    expect(capture.headers.Authorization).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//,
+    );
+    expect(JSON.parse(capture.body)).toEqual({
+      Text: "meet John tomorrow",
+      LanguageCode: "en",
+    });
+  });
+
+  it("masks PII spans with placeholders by default", async () => {
+    const text = "contact john@example.com now";
+    const fetchImpl = makeFetch([
+      { Score: 1, Type: "EMAIL", BeginOffset: 8, EndOffset: 24 },
+    ]);
+    const redactor = new ComprehendRedactor({ ...baseOptions, fetchImpl });
+
+    const result = await redactor.redact(text);
+
+    expect(result.redactedText).toBe("contact [EMAIL] now");
+    expect(result.entities).toHaveLength(1);
+  });
+
+  it("supports asterisk masking that preserves length", async () => {
+    const text = "card 4111111111111111 please";
+    const spanStart = text.indexOf("4111");
+    const fetchImpl = makeFetch([
+      {
+        Score: 0.98,
+        Type: "CREDIT_DEBIT_NUMBER",
+        BeginOffset: spanStart,
+        EndOffset: spanStart + 16,
+      },
+    ]);
+    const redactor = new ComprehendRedactor({
+      ...baseOptions,
+      maskStyle: "asterisk",
+      fetchImpl,
+    });
+
+    const result = await redactor.redact(text);
+
+    expect(result.redactedText).toBe(`card ${"*".repeat(16)} please`);
+    expect(result.redactedText.length).toBe(text.length);
+  });
+
+  it("handles multiple unsorted entities without corrupting offsets", async () => {
+    const text = "John lives at 10 Downing St";
+    const nameStart = text.indexOf("John");
+    const streetStart = text.indexOf("10 Downing");
+    const fetchImpl = makeFetch([
+      {
+        Score: 0.9,
+        Type: "ADDRESS",
+        BeginOffset: streetStart,
+        EndOffset: streetStart + 10,
+      },
+      {
+        Score: 0.95,
+        Type: "NAME",
+        BeginOffset: nameStart,
+        EndOffset: nameStart + 4,
+      },
+    ]);
+    const redactor = new ComprehendRedactor({ ...baseOptions, fetchImpl });
+
+    const result = await redactor.redact(text);
+
+    expect(result.redactedText).toBe("[NAME] lives at [ADDRESS] St");
+  });
+
+  it("propagates API failures as descriptive errors", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 403,
+          text: async () => "AccessDeniedException",
+          json: async () => ({}),
+        }) as any,
+    );
+    const redactor = new ComprehendRedactor({ ...baseOptions, fetchImpl });
+
+    await expect(redactor.redact("secret")).rejects.toThrow(
+      /403.*AccessDeniedException/s,
+    );
+  });
+});
+
+describe("withPIIRedaction", () => {
+  it("redacts the prompt before it reaches the chained client", async () => {
+    const chatSpy = vi.fn(async (options: any) => ({
+      content: `echo:${options.prompt}`,
+    }));
+    const fakeClient = { chat: chatSpy, someOtherMethod: () => "untouched" };
+
+    const text = "email me at jane@corp.org";
+    const emailStart = text.indexOf("jane@corp.org");
+    const fetchImpl = makeFetch([
+      {
+        Score: 1,
+        Type: "EMAIL",
+        BeginOffset: emailStart,
+        EndOffset: text.length,
+      },
+    ]);
+    const redactor = new ComprehendRedactor({ ...baseOptions, fetchImpl });
+
+    const chained = withPIIRedaction(fakeClient as any, redactor);
+    const response = await chained.chat({
+      prompt: text,
+      model: "gpt-3.5-turbo",
+    });
+
+    expect(chatSpy).toHaveBeenCalledTimes(1);
+    expect(chatSpy.mock.calls[0][0].prompt).toBe("email me at [EMAIL]");
+    // all other options are forwarded untouched
+    expect(chatSpy.mock.calls[0][0].model).toBe("gpt-3.5-turbo");
+    expect(response.content).toBe("echo:email me at [EMAIL]");
+    // non-chat members still work through the proxy
+    expect((chained as any).someOtherMethod()).toBe("untouched");
+  });
+
+  it("passes non-string prompts through without redaction", async () => {
+    const chatSpy = vi.fn(async (options: any) => ({ ok: true }));
+    const fetchImpl = makeFetch([]);
+    const redactor = new ComprehendRedactor({ ...baseOptions, fetchImpl });
+
+    const chained = withPIIRedaction({ chat: chatSpy } as any, redactor);
+    const messages = [{ role: "user", content: "keep raw" }];
+    await chained.chat({ messages });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(chatSpy.mock.calls[0][0].messages).toBe(messages);
+  });
+});

--- a/JS/edgechains/examples/pii-redaction-chat/package.json
+++ b/JS/edgechains/examples/pii-redaction-chat/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "pii-redaction-chat",
+    "version": "1.0.0",
+    "description": "Chains AWS Comprehend PII redaction in front of an LLM chat call with @arakoodev/edgechains.js",
+    "main": "dist/index.js",
+    "type": "module",
+    "scripts": {
+        "start": "tsc && node ./dist/index.js"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "^0.23.6",
+        "@types/node": "^20.14.2",
+        "dotenv": "^16.4.5",
+        "openai": "^4.0.0"
+    }
+}

--- a/JS/edgechains/examples/pii-redaction-chat/readme.md
+++ b/JS/edgechains/examples/pii-redaction-chat/readme.md
@@ -1,0 +1,40 @@
+# PII Redaction Chat (AWS Comprehend + EdgeChains)
+
+Demonstrates chaining **Amazon Comprehend** PII detection in front of an LLM
+endpoint class from `@arakoodev/edgechains.js`. Sensitive data (names, emails,
+phone numbers, addresses, card numbers...) is masked before the prompt ever
+reaches the model.
+
+## Setup
+
+```bash
+npm install
+```
+
+Export credentials:
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=<your-key>
+export AWS_SECRET_ACCESS_KEY=<your-secret>
+export OPENAI_API_KEY=<your-openai-key>
+```
+
+## Run
+
+```bash
+npm start
+```
+
+## Demo video
+
+See Loom walkthrough: <!-- add recorded demo link here -->
+
+## API quick reference
+
+```ts
+const redactor = new ComprehendRedactor({ maskStyle: "asterisk" });
+await redactor.redact(text);          // { redactedText, entities }
+
+const safe = withPIIRedaction(client, redactor); // wraps any .chat() client
+```

--- a/JS/edgechains/examples/pii-redaction-chat/src/index.ts
+++ b/JS/edgechains/examples/pii-redaction-chat/src/index.ts
@@ -1,4 +1,8 @@
-import { ComprehendRedactor, OpenAI, withPIIRedaction } from "@arakoodev/edgechains.js/ai";
+import {
+  ComprehendRedactor,
+  OpenAI,
+  withPIIRedaction,
+} from "@arakoodev/edgechains.js/ai";
 
 /**
  * Example: PII-redacted LLM chat.
@@ -12,44 +16,44 @@ import { ComprehendRedactor, OpenAI, withPIIRedaction } from "@arakoodev/edgecha
  *   OPENAI_API_KEY                                        (LLM)
  */
 async function main() {
-    const redactor = new ComprehendRedactor({
-        region: process.env.AWS_REGION || "us-east-1",
-        languageCode: "en",
-        // switch to "asterisk" to keep the original text length instead of [TYPE] tags
-        maskStyle: "placeholder",
-    });
+  const redactor = new ComprehendRedactor({
+    region: process.env.AWS_REGION || "us-east-1",
+    languageCode: "en",
+    // switch to "asterisk" to keep the original text length instead of [TYPE] tags
+    maskStyle: "placeholder",
+  });
 
-    const rawPrompt =
-        "Hi, my name is Jane Doe, email jane.doe@corp.org. Summarize our refund policy in one sentence.";
+  const rawPrompt =
+    "Hi, my name is Jane Doe, email jane.doe@corp.org. Summarize our refund policy in one sentence.";
 
-    console.log("Original prompt:\n", rawPrompt);
+  console.log("Original prompt:\n", rawPrompt);
 
-    const { redactedText, entities } = await redactor.redact(rawPrompt);
-    console.log("\nDetected entities:", entities);
-    console.log("Prompt sent to the model:\n", redactedText);
+  const { redactedText, entities } = await redactor.redact(rawPrompt);
+  console.log("\nDetected entities:", entities);
+  console.log("Prompt sent to the model:\n", redactedText);
 
-    // Redact-only demo: set DEMO_MODE=redact-only to skip the LLM call.
-    if (process.env.DEMO_MODE === "redact-only") {
-        console.log("\n(redact-only mode: skipping LLM call)");
-        return;
-    }
+  // Redact-only demo: set DEMO_MODE=redact-only to skip the LLM call.
+  if (process.env.DEMO_MODE === "redact-only") {
+    console.log("\n(redact-only mode: skipping LLM call)");
+    return;
+  }
 
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-    // Chain the redactor in front of the endpoint class.
-    // From here on, every chat() prompt is automatically redacted.
-    const safeOpenAI = withPIIRedaction(openai, redactor);
+  // Chain the redactor in front of the endpoint class.
+  // From here on, every chat() prompt is automatically redacted.
+  const safeOpenAI = withPIIRedaction(openai, redactor);
 
-    const response = await safeOpenAI.chat({
-        prompt: rawPrompt,
-        model: "gpt-3.5-turbo",
-        max_tokens: 128,
-    });
+  const response = await safeOpenAI.chat({
+    prompt: rawPrompt,
+    model: "gpt-3.5-turbo",
+    max_tokens: 128,
+  });
 
-    console.log("\nModel reply:\n", response.content);
+  console.log("\nModel reply:\n", response.content);
 }
 
 main().catch((error) => {
-    console.error(error);
-    process.exit(1);
+  console.error(error);
+  process.exit(1);
 });

--- a/JS/edgechains/examples/pii-redaction-chat/src/index.ts
+++ b/JS/edgechains/examples/pii-redaction-chat/src/index.ts
@@ -19,12 +19,6 @@ async function main() {
         maskStyle: "placeholder",
     });
 
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
-    // Chain the redactor in front of the endpoint class.
-    // From here on, every chat() prompt is automatically redacted.
-    const safeOpenAI = withPIIRedaction(openai, redactor);
-
     const rawPrompt =
         "Hi, my name is Jane Doe, email jane.doe@corp.org. Summarize our refund policy in one sentence.";
 
@@ -33,6 +27,18 @@ async function main() {
     const { redactedText, entities } = await redactor.redact(rawPrompt);
     console.log("\nDetected entities:", entities);
     console.log("Prompt sent to the model:\n", redactedText);
+
+    // Redact-only demo: set DEMO_MODE=redact-only to skip the LLM call.
+    if (process.env.DEMO_MODE === "redact-only") {
+        console.log("\n(redact-only mode: skipping LLM call)");
+        return;
+    }
+
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    // Chain the redactor in front of the endpoint class.
+    // From here on, every chat() prompt is automatically redacted.
+    const safeOpenAI = withPIIRedaction(openai, redactor);
 
     const response = await safeOpenAI.chat({
         prompt: rawPrompt,

--- a/JS/edgechains/examples/pii-redaction-chat/src/index.ts
+++ b/JS/edgechains/examples/pii-redaction-chat/src/index.ts
@@ -1,0 +1,49 @@
+import { ComprehendRedactor, OpenAI, withPIIRedaction } from "@arakoodev/edgechains.js/ai";
+
+/**
+ * Example: PII-redacted LLM chat.
+ *
+ * Every prompt is sanitized with Amazon Comprehend BEFORE it reaches the
+ * model, so names, emails, phone numbers, addresses, etc. never leave your
+ * infrastructure.
+ *
+ * Required environment variables:
+ *   AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY  (Comprehend)
+ *   OPENAI_API_KEY                                        (LLM)
+ */
+async function main() {
+    const redactor = new ComprehendRedactor({
+        region: process.env.AWS_REGION || "us-east-1",
+        languageCode: "en",
+        // switch to "asterisk" to keep the original text length instead of [TYPE] tags
+        maskStyle: "placeholder",
+    });
+
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    // Chain the redactor in front of the endpoint class.
+    // From here on, every chat() prompt is automatically redacted.
+    const safeOpenAI = withPIIRedaction(openai, redactor);
+
+    const rawPrompt =
+        "Hi, my name is Jane Doe, email jane.doe@corp.org. Summarize our refund policy in one sentence.";
+
+    console.log("Original prompt:\n", rawPrompt);
+
+    const { redactedText, entities } = await redactor.redact(rawPrompt);
+    console.log("\nDetected entities:", entities);
+    console.log("Prompt sent to the model:\n", redactedText);
+
+    const response = await safeOpenAI.chat({
+        prompt: rawPrompt,
+        model: "gpt-3.5-turbo",
+        max_tokens: 128,
+    });
+
+    console.log("\nModel reply:\n", response.content);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/JS/edgechains/examples/pii-redaction-chat/tsconfig.json
+++ b/JS/edgechains/examples/pii-redaction-chat/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "outDir": "./dist"
+    },
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #290

## What this adds
- `ComprehendRedactor` — calls **Amazon Comprehend `DetectPiiEntities`** via hand-rolled AWS SigV4 signing (node:crypto only — **zero new dependencies** added to package.json)
  - credential resolution: explicit options or `AWS_REGION`/`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
  - masking strategies: `[TYPE]` placeholders (default) or length-preserving asterisks
- `withPIIRedaction(client, redactor)` — chains the redactor in front of any endpoint class exposing `.chat()` (OpenAI / GeminiAI / LlamaAI), so prompts are sanitized before reaching the model
- Both exported from `@arakoodev/edgechains.js/ai`

## Tests
8 new vitest cases (`src/ai/src/tests/comprehend.test.ts`) covering: signed request shape & entity parsing, placeholder/asterisk masking, multi-entity offset handling (unsorted input), API error propagation, chained prompt redaction with option forwarding, and pass-through of non-string prompts. All runnable offline via injectable fetch.

## Example
New `examples/pii-redaction-chat/` — redacts a sample prompt, prints detected entities + sanitized text, then sends the safe prompt through a chained OpenAI call.

## Note on demo video
The Loom walkthrough is pending — I'll attach it shortly (recording setup instructions are in the example readme). Everything else in the acceptance list is implemented.