### PR TITLE
Add Qdrant REST client to the vector database package

### DIFF
--- a/JS/edgechains/arakoodev/examples/qdrant.cjs
+++ b/JS/edgechains/arakoodev/examples/qdrant.cjs
@@ -1,0 +1,34 @@
+// Run after building the SDK: node examples/qdrant.cjs
+const { QdrantClient } = require('../dist/vector-db/src/index.js');
+
+async function main() {
+    const client = new QdrantClient({
+        url: process.env.QDRANT_URL || 'http://localhost:6333',
+        apiKey: process.env.QDRANT_API_KEY,
+    });
+    const collection = `edgechains_demo_${Date.now()}`;
+    console.log('Create a temporary collection with 3-dimensional Cosine vectors');
+    console.log(await client.createCollection(collection, { size: 3, distance: 'Cosine' }));
+    try {
+        console.log('Insert two documents and one document in a different namespace');
+        console.log(await client.upsert(collection, [
+            { id: 1, vector: [1, 0, 0], payload: { namespace: 'docs', text: 'First document' } },
+            { id: 2, vector: [0, 1, 0], payload: { namespace: 'docs', text: 'Second document' } },
+            { id: 3, vector: [1, 0, 0], payload: { namespace: 'other', text: 'Excluded document' } },
+        ]));
+        const query = {
+            query: [1, 0, 0], limit: 2,
+            filter: { must: [{ key: 'namespace', match: { value: 'docs' } }] },
+        };
+        console.log('Search for [1,0,0], restricted to namespace=docs');
+        console.log(JSON.stringify(await client.query(collection, query), null, 2));
+        console.log('Delete point 1 and query again');
+        await client.deletePoints(collection, [1]);
+        console.log(JSON.stringify(await client.query(collection, query), null, 2));
+    } finally {
+        await client.deleteCollection(collection);
+        console.log('Temporary collection removed');
+    }
+}
+
+main().catch(error => { console.error(error); process.exitCode = 1; });

--- a/JS/edgechains/arakoodev/examples/qdrant.md
+++ b/JS/edgechains/arakoodev/examples/qdrant.md
@@ -1,0 +1,26 @@
+# Qdrant vector storage
+
+`QdrantClient` is exported from `@arakoodev/edgechains.js/vector-db`. It calls Qdrant's REST API directly, without a Qdrant SDK. Use Node.js 18+ and Qdrant 1.10+ (the universal query API).
+
+```ts
+import { QdrantClient } from '@arakoodev/edgechains.js/vector-db'
+
+const qdrant = new QdrantClient({
+  url: process.env.QDRANT_URL!,
+  apiKey: process.env.QDRANT_API_KEY,
+  timeoutMs: 30_000,
+})
+const matches = await qdrant.query('documents', {
+  query: embedding,
+  limit: 5,
+  filter: { must: [{ key: 'namespace', match: { value: 'my-docs' } }] },
+})
+```
+
+The returned points contain `id`, `score`, and `payload`. Query options also support a named vector via `using`, `with_payload`, and `score_threshold`. Collection creation sets the vector size and distance metric; upserts accept numeric/UUID IDs, vectors, and document payloads. Upserts and point deletions use `wait=true` so a subsequent query sees the completed operation. Requests have a configurable deadline and report HTTP/API failures. Authentication uses the `api-key` header; redirects are rejected.
+
+For a complete create/insert/search/delete example, build this package with `npx tsc -b`, set `QDRANT_URL` (and `QDRANT_API_KEY` if needed), and run `node examples/qdrant.cjs`. It creates a uniquely named temporary collection and removes it afterward. Its fixed vectors demonstrate storage and retrieval without an embedding provider or paid model API.
+
+Run transport tests with `npx vitest run src/vector-db/src/tests/qdrant`. Setting `QDRANT_URL` also enables the live integration test. Without that variable, the live test is skipped. The live test was verified with Qdrant 1.19.1 on Windows.
+
+API references: [collections](https://api.qdrant.tech/api-reference/collections/create-collection), [upserts](https://api.qdrant.tech/api-reference/points/upsert-points), [queries](https://api.qdrant.tech/api-reference/search/query-points).

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,11 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { QdrantClient } from "./lib/qdrant/QdrantClient.js";
+export type {
+  QdrantClientOptions,
+  QdrantDistance,
+  QdrantOperation,
+  QdrantPoint,
+  QdrantPointId,
+  QdrantQuery,
+  QdrantScoredPoint,
+} from "./lib/qdrant/QdrantClient.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/QdrantClient.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/QdrantClient.ts
@@ -1,0 +1,153 @@
+export type QdrantPointId = number | string;
+export type QdrantDistance = "Cosine" | "Euclid" | "Dot" | "Manhattan";
+
+export interface QdrantPoint {
+  id: QdrantPointId;
+  vector: number[] | Record<string, number[]>;
+  payload?: Record<string, unknown>;
+}
+
+export interface QdrantScoredPoint {
+  id: QdrantPointId;
+  score: number;
+  payload?: Record<string, unknown> | null;
+}
+
+export interface QdrantQuery {
+  query: number[];
+  limit?: number;
+  filter?: Record<string, unknown>;
+  using?: string;
+  with_payload?: boolean;
+  score_threshold?: number;
+}
+
+export interface QdrantClientOptions {
+  url: string;
+  apiKey?: string;
+  timeoutMs?: number;
+}
+
+export interface QdrantOperation {
+  operation_id?: number;
+  status: "acknowledged" | "completed";
+}
+
+/** Qdrant REST client. Requires Node.js 18+; no Qdrant SDK dependency. */
+export class QdrantClient {
+  private readonly url: string;
+  private readonly apiKey?: string;
+  private readonly timeoutMs: number;
+
+  constructor({ url, apiKey, timeoutMs = 30_000 }: QdrantClientOptions) {
+    const endpoint = new URL(url);
+    if (
+      !["http:", "https:"].includes(endpoint.protocol) ||
+      endpoint.search ||
+      endpoint.hash ||
+      endpoint.username ||
+      endpoint.password
+    ) {
+      throw new Error(
+        "Qdrant URL must be an HTTP(S) endpoint without credentials, query, or fragment",
+      );
+    }
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new Error("Qdrant timeoutMs must be positive and finite");
+    }
+    this.url = endpoint.toString().replace(/\/$/, "");
+    this.apiKey = apiKey;
+    this.timeoutMs = timeoutMs;
+  }
+
+  private collectionPath(collection: string): string {
+    if (!collection || collection === "." || collection === "..") {
+      throw new Error(
+        "Qdrant collection name must not be empty or a dot segment",
+      );
+    }
+    return `/collections/${encodeURIComponent(collection)}`;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(this.url + path, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(this.apiKey ? { "api-key": this.apiKey } : {}),
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+        // Do not forward an API key to a redirect target.
+        redirect: "error",
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Qdrant ${method} ${path} failed (HTTP ${response.status}): ${await response.text()}`,
+        );
+      }
+      const envelope = (await response.json()) as {
+        status: unknown;
+        result: T;
+      };
+      if (envelope.status !== "ok" || !("result" in envelope)) {
+        throw new Error(
+          `Qdrant ${method} ${path} returned an unsuccessful response`,
+        );
+      }
+      return envelope.result;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  createCollection(
+    collection: string,
+    vectors: { size: number; distance: QdrantDistance },
+  ): Promise<boolean> {
+    return this.request("PUT", this.collectionPath(collection), { vectors });
+  }
+
+  upsert(collection: string, points: QdrantPoint[]): Promise<QdrantOperation> {
+    return this.request(
+      "PUT",
+      `${this.collectionPath(collection)}/points?wait=true`,
+      { points },
+    );
+  }
+
+  /** Dense vector search via Qdrant's universal query API (Qdrant 1.10+). */
+  async query(
+    collection: string,
+    query: QdrantQuery,
+  ): Promise<QdrantScoredPoint[]> {
+    const result = await this.request<{ points: QdrantScoredPoint[] }>(
+      "POST",
+      `${this.collectionPath(collection)}/points/query`,
+      { limit: 10, with_payload: true, ...query },
+    );
+    return result.points;
+  }
+
+  deletePoints(
+    collection: string,
+    points: QdrantPointId[],
+  ): Promise<QdrantOperation> {
+    return this.request(
+      "POST",
+      `${this.collectionPath(collection)}/points/delete?wait=true`,
+      { points },
+    );
+  }
+
+  deleteCollection(collection: string): Promise<boolean> {
+    return this.request("DELETE", this.collectionPath(collection));
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/QdrantClient.integration.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/QdrantClient.integration.test.ts
@@ -1,0 +1,49 @@
+import { expect, it } from "vitest";
+import { QdrantClient } from "../../lib/qdrant/QdrantClient.js";
+
+it.skipIf(!process.env.QDRANT_URL)(
+  "creates, inserts, queries, and deletes with a live Qdrant server",
+  async () => {
+    const client = new QdrantClient({
+      url: process.env.QDRANT_URL!,
+      apiKey: process.env.QDRANT_API_KEY,
+    });
+    const collection = `edgechains_test_${Date.now()}`;
+    await client.createCollection(collection, { size: 3, distance: "Cosine" });
+    try {
+      await client.upsert(collection, [
+        {
+          id: 1,
+          vector: [1, 0, 0],
+          payload: { namespace: "docs", text: "first" },
+        },
+        {
+          id: 2,
+          vector: [0, 1, 0],
+          payload: { namespace: "docs", text: "second" },
+        },
+        {
+          id: 3,
+          vector: [1, 0, 0],
+          payload: { namespace: "other", text: "excluded" },
+        },
+      ]);
+      const query = {
+        query: [1, 0, 0],
+        limit: 2,
+        filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+      };
+      const results = await client.query(collection, query);
+      expect(results.map((point) => point.id)).toEqual([1, 2]);
+      expect(results[0].payload?.text).toBe("first");
+      expect(results[0].score).toBeCloseTo(1);
+      await client.deletePoints(collection, [1]);
+      expect(
+        (await client.query(collection, query)).map((point) => point.id),
+      ).toEqual([2]);
+    } finally {
+      await client.deleteCollection(collection);
+    }
+  },
+  30_000,
+);

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/QdrantClient.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/QdrantClient.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import type { AddressInfo } from "node:net";
+import { QdrantClient } from "../../lib/qdrant/QdrantClient.js";
+
+describe("QdrantClient REST transport", () => {
+  let endpoint: string;
+  let requests: {
+    method: string | undefined;
+    url: string | undefined;
+    headers: IncomingHttpHeaders;
+    body: unknown;
+  }[] = [];
+  let status = 200;
+  let response: unknown = { status: "ok", result: true };
+  let delay = 0;
+  const server = createServer(async (request, res) => {
+    let raw = "";
+    for await (const chunk of request) raw += chunk;
+    requests.push({
+      method: request.method,
+      url: request.url,
+      headers: request.headers,
+      body: raw ? JSON.parse(raw) : undefined,
+    });
+    if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+    res.writeHead(status, {
+      "content-type": "application/json",
+      location: "/redirected",
+    });
+    res.end(JSON.stringify(response));
+  });
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    endpoint = `http://127.0.0.1:${(server.address() as AddressInfo).port}/qdrant/`;
+  });
+  afterEach(() => {
+    requests = [];
+    status = 200;
+    response = { status: "ok", result: true };
+    delay = 0;
+  });
+  afterAll(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("creates a collection, preserves the deployment prefix, and sends the API key", async () => {
+    const client = new QdrantClient({ url: endpoint, apiKey: "test-key" });
+    expect(
+      await client.createCollection("notes / team", {
+        size: 3,
+        distance: "Cosine",
+      }),
+    ).toBe(true);
+    expect(requests[0]).toMatchObject({
+      method: "PUT",
+      url: "/qdrant/collections/notes%20%2F%20team",
+      body: { vectors: { size: 3, distance: "Cosine" } },
+    });
+    expect(requests[0].headers["api-key"]).toBe("test-key");
+  });
+
+  it("upserts vectors and payloads and waits for completion", async () => {
+    response = {
+      status: "ok",
+      result: { operation_id: 1, status: "completed" },
+    };
+    const points = [
+      { id: 1, vector: [0.1, 0.2, 0.3], payload: { text: "example" } },
+    ];
+    expect(
+      await new QdrantClient({ url: endpoint }).upsert("notes", points),
+    ).toEqual({ operation_id: 1, status: "completed" });
+    expect(requests[0]).toMatchObject({
+      method: "PUT",
+      url: "/qdrant/collections/notes/points?wait=true",
+      body: { points },
+    });
+    expect(requests[0].headers["api-key"]).toBeUndefined();
+  });
+
+  it("queries with a namespace filter and returns scored payloads", async () => {
+    const points = [{ id: 1, score: 0.9, payload: { text: "match" } }];
+    response = { status: "ok", result: { points } };
+    const query = {
+      query: [1, 0, 0],
+      limit: 2,
+      filter: { must: [{ key: "namespace", match: { value: "docs" } }] },
+    };
+    expect(
+      await new QdrantClient({ url: endpoint }).query("notes", query),
+    ).toEqual(points);
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      url: "/qdrant/collections/notes/points/query",
+      body: { ...query, with_payload: true },
+    });
+    expect(query).not.toHaveProperty("with_payload");
+  });
+
+  it("deletes selected points and a collection", async () => {
+    const client = new QdrantClient({ url: endpoint });
+    response = { status: "ok", result: { status: "completed" } };
+    await client.deletePoints("notes", [
+      1,
+      "00000000-0000-0000-0000-000000000002",
+    ]);
+    expect(requests[0]).toMatchObject({
+      method: "POST",
+      url: "/qdrant/collections/notes/points/delete?wait=true",
+      body: { points: [1, "00000000-0000-0000-0000-000000000002"] },
+    });
+    response = { status: "ok", result: true };
+    expect(await client.deleteCollection("notes")).toBe(true);
+    expect(requests[1]).toMatchObject({
+      method: "DELETE",
+      url: "/qdrant/collections/notes",
+      body: undefined,
+    });
+  });
+
+  it("propagates API errors instead of returning an empty successful result", async () => {
+    status = 400;
+    response = { status: { error: "Wrong vector dimension" } };
+    await expect(
+      new QdrantClient({ url: endpoint }).query("notes", { query: [1] }),
+    ).rejects.toThrow("HTTP 400");
+  });
+
+  it("rejects unsuccessful envelopes", async () => {
+    response = { status: { error: "failure" }, result: null };
+    await expect(
+      new QdrantClient({ url: endpoint }).deleteCollection("notes"),
+    ).rejects.toThrow("unsuccessful response");
+  });
+
+  it("aborts requests at the configured deadline", async () => {
+    delay = 100;
+    await expect(
+      new QdrantClient({ url: endpoint, timeoutMs: 20 }).query("notes", {
+        query: [1],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("does not forward API keys on redirects", async () => {
+    status = 307;
+    await expect(
+      new QdrantClient({ url: endpoint, apiKey: "test-key" }).deleteCollection(
+        "notes",
+      ),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  it.each(["", ".", ".."])(
+    'rejects invalid collection name "%s" before a request',
+    (name) => {
+      expect(() =>
+        new QdrantClient({ url: endpoint }).deleteCollection(name),
+      ).toThrow();
+      expect(requests).toHaveLength(0);
+    },
+  );
+});


### PR DESCRIPTION
Add a Qdrant REST client to the current `@arakoodev/edgechains.js/vector-db` export. It supports collection creation, vector/payload upserts, filtered similarity queries, point deletion, and collection deletion without a Qdrant SDK dependency. Requests support API-key authentication, configurable deadlines, and HTTP/API error reporting.

The issue's original `lib/src/lib/clients` path has moved; this change uses the current `JS/edgechains/arakoodev/src/vector-db` package. The runnable example inserts fixed embeddings, searches within a namespace, and removes its temporary collection.

Closes #273.

/claim #273

[Short demonstration](https://github.com/JoaquinBatser/EdgeChains/blob/bounty-evidence/bounty-evidence/qdrant.mp4): rendered transcript of the example's actual output against Qdrant 1.19.1, not a screen recording or mocked database.

Validation on Windows/Node 24:
- 11 REST transport tests passed using a local HTTP test endpoint, covering wire requests, filters, errors, deadline cancellation, and redirects.
- The live Qdrant 1.19.1 integration test passed: create, insert, filtered ranking, delete, re-query, cleanup.
- The documented example ran successfully against the same live server.
- Full package TypeScript check and build passed (`tsc --noEmit`, `tsc -b`). Changed TypeScript files were formatted with the repository's Prettier configuration.

Run `QDRANT_URL=http://localhost:6333 npx vitest run src/vector-db/src/tests/qdrant` from `JS/edgechains/arakoodev`. Without `QDRANT_URL`, only the live test is skipped. No embedding-provider credentials are needed. The query API requires Qdrant 1.10+.

This contribution was developed with AI assistance.
