### PR TITLE
Add Qdrant vector database support

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,2 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,136 @@
+import axios, { AxiosInstance } from "axios";
+
+interface VectorParams {
+  size: number;
+  distance: string;
+  [key: string]: any;
+}
+
+interface Point {
+  id: string | number;
+  vector: number[] | { [name: string]: number[] };
+  payload?: { [key: string]: any };
+  [key: string]: any;
+}
+
+export class Qdrant {
+  QDRANT_URL: string;
+  QDRANT_API_KEY: string;
+
+  constructor(QDRANT_URL: string, QDRANT_API_KEY: string) {
+    this.QDRANT_URL = (QDRANT_URL || process.env.QDRANT_URL || "").replace(
+      /\/$/,
+      "",
+    );
+    this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY || "";
+  }
+
+  // Function to create a Qdrant REST API client
+  createClient(): AxiosInstance {
+    return axios.create({
+      baseURL: this.QDRANT_URL,
+      headers: {
+        "Content-Type": "application/json",
+        ...(this.QDRANT_API_KEY ? { "api-key": this.QDRANT_API_KEY } : {}),
+      },
+    });
+  }
+
+  /**
+   * Create a collection in Qdrant.
+   * @param client The Qdrant client instance.
+   * @param collectionName The name of the collection to create.
+   * @param vectors The vector configuration, for example { size: 1536, distance: "Cosine" }.
+   * @returns The Qdrant API response.
+   */
+  async createCollection({
+    client,
+    collectionName,
+    vectors,
+  }: {
+    client: AxiosInstance;
+    collectionName: string;
+    vectors: VectorParams;
+  }): Promise<any> {
+    const res = await client.put(`/collections/${collectionName}`, { vectors });
+    return res.data;
+  }
+
+  /**
+   * Upsert points into a Qdrant collection.
+   * @param client The Qdrant client instance.
+   * @param collectionName The name of the collection.
+   * @param points The points to upsert, each with id, vector and optional payload.
+   * @returns The Qdrant API response.
+   */
+  async upsertPoints({
+    client,
+    collectionName,
+    points,
+  }: {
+    client: AxiosInstance;
+    collectionName: string;
+    points: Point[];
+  }): Promise<any> {
+    const res = await client.put(`/collections/${collectionName}/points`, {
+      points,
+    });
+    return res.data;
+  }
+
+  /**
+   * Search a Qdrant collection with a query vector.
+   * @param client The Qdrant client instance.
+   * @param collectionName The name of the collection.
+   * @param vector The query vector.
+   * @param limit The maximum number of results to return.
+   * @param withPayload Whether to include point payloads in the results.
+   * @returns The list of matched points.
+   */
+  async search({
+    client,
+    collectionName,
+    vector,
+    limit,
+    withPayload = true,
+  }: {
+    client: AxiosInstance;
+    collectionName: string;
+    vector: number[];
+    limit: number;
+    withPayload?: boolean;
+  }): Promise<any> {
+    const res = await client.post(
+      `/collections/${collectionName}/points/search`,
+      {
+        vector,
+        limit,
+        with_payload: withPayload,
+      },
+    );
+    return res.data.result;
+  }
+
+  /**
+   * Delete points from a Qdrant collection by id.
+   * @param client The Qdrant client instance.
+   * @param collectionName The name of the collection.
+   * @param ids The point ids to delete.
+   * @returns The Qdrant API response.
+   */
+  async deleteByIds({
+    client,
+    collectionName,
+    ids,
+  }: {
+    client: AxiosInstance;
+    collectionName: string;
+    ids: (string | number)[];
+  }): Promise<any> {
+    const res = await client.post(
+      `/collections/${collectionName}/points/delete`,
+      { points: ids },
+    );
+    return res.data;
+  }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,87 @@
+import { Qdrant } from "../../../../../dist/vector-db/src/lib/qdrant/qdrant.js";
+
+// Mock the Qdrant class
+jest.mock("../../../../../dist/vector-db/src/lib/qdrant/qdrant.js", () => {
+  return {
+    Qdrant: jest.fn().mockImplementation((QDRANT_URL, QDRANT_API_KEY) => ({
+      QDRANT_URL,
+      QDRANT_API_KEY,
+      createClient: jest.fn(),
+      createCollection: jest
+        .fn()
+        .mockImplementation(async ({ collectionName }) => ({
+          result: { name: collectionName },
+        })),
+      upsertPoints: jest.fn().mockImplementation(async () => ({
+        result: { status: "completed" },
+      })),
+      search: jest
+        .fn()
+        .mockImplementation(
+          async ({ collectionName, vector, limit, withPayload = true }) => ({
+            collectionName,
+            vector,
+            limit,
+            withPayload,
+            hits: [{ id: 1, score: 0.99 }],
+          }),
+        ),
+      deleteByIds: jest.fn().mockImplementation(async () => ({
+        result: { status: "completed" },
+      })),
+    })),
+  };
+});
+
+describe("Qdrant", () => {
+  const qdrant = new Qdrant("https://mock-qdrant.io", "mock-api-key");
+  const client = qdrant.createClient();
+
+  test("constructor should store url and api key", () => {
+    expect(qdrant.QDRANT_URL).toBe("https://mock-qdrant.io");
+    expect(qdrant.QDRANT_API_KEY).toBe("mock-api-key");
+  });
+
+  test("createCollection should create a collection", async () => {
+    const res = await qdrant.createCollection({
+      client,
+      collectionName: "documents",
+      vectors: { size: 1536, distance: "Cosine" },
+    });
+    expect(res.result.name).toBe("documents");
+    expect(qdrant.createCollection).toHaveBeenCalledWith({
+      client,
+      collectionName: "documents",
+      vectors: { size: 1536, distance: "Cosine" },
+    });
+  });
+
+  test("upsertPoints should upsert points", async () => {
+    const res = await qdrant.upsertPoints({
+      client,
+      collectionName: "documents",
+      points: [{ id: 1, vector: [0.1, 0.2], payload: { text: "hello" } }],
+    });
+    expect(res.result.status).toBe("completed");
+  });
+
+  test("search should return matched points", async () => {
+    const res = await qdrant.search({
+      client,
+      collectionName: "documents",
+      vector: [0.1, 0.2],
+      limit: 5,
+    });
+    expect(res.collectionName).toBe("documents");
+    expect(res.hits[0].id).toBe(1);
+  });
+
+  test("deleteByIds should delete points by id", async () => {
+    const res = await qdrant.deleteByIds({
+      client,
+      collectionName: "documents",
+      ids: [1],
+    });
+    expect(res.result.status).toBe("completed");
+  });
+});


### PR DESCRIPTION
/claim #273

Adds a Qdrant client to the vector-db package following the existing Supabase pattern. Wraps the Qdrant REST API directly via axios with createCollection, upsertPoints, search, and deleteByIds methods. Includes mock-based Jest tests. Build passes, 5 new tests pass, no existing regressions.