### PR TITLE
feat: AWS Comprehend PII redaction utility (#290)

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -22,6 +22,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.670.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,4 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export { ComprehendAI } from "./lib/comprehend/comprehend.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/comprehend.ts
@@ -1,0 +1,87 @@
+import {
+  ComprehendClient,
+  DetectPiiEntitiesCommand,
+  LanguageCode,
+} from "@aws-sdk/client-comprehend";
+
+interface ComprehendAIConstructionOptions {
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  languageCode?: LanguageCode;
+}
+
+interface RedactPiiOptions {
+  maskMode?: "type" | "character";
+  maskCharacter?: string;
+}
+
+interface DetectedPiiEntity {
+  type?: string;
+  score?: number;
+  beginOffset?: number;
+  endOffset?: number;
+}
+
+export class ComprehendAI {
+  private client: ComprehendClient;
+  private languageCode: LanguageCode;
+
+  constructor(options: ComprehendAIConstructionOptions = {}) {
+    const accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
+    const secretAccessKey =
+      options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
+
+    this.client = new ComprehendClient({
+      region: options.region || process.env.AWS_REGION || "us-east-1",
+      ...(accessKeyId && secretAccessKey
+        ? { credentials: { accessKeyId, secretAccessKey } }
+        : {}),
+    });
+    this.languageCode = options.languageCode || LanguageCode.EN;
+  }
+
+  async detectPiiEntities(text: string): Promise<DetectedPiiEntity[]> {
+    const response = await this.client.send(
+      new DetectPiiEntitiesCommand({
+        Text: text,
+        LanguageCode: this.languageCode,
+      }),
+    );
+    return (response.Entities || []).map((entity) => ({
+      type: entity.Type,
+      score: entity.Score,
+      beginOffset: entity.BeginOffset,
+      endOffset: entity.EndOffset,
+    }));
+  }
+
+  async redactPii(
+    text: string,
+    options: RedactPiiOptions = {},
+  ): Promise<string> {
+    const entities = await this.detectPiiEntities(text);
+    let redacted = "";
+    let cursor = 0;
+    // Reinsert original text before each entity, then its mask
+    for (const entity of entities) {
+      const begin = entity.beginOffset ?? 0;
+      const end = entity.endOffset ?? begin;
+      const mask =
+        options.maskMode === "character"
+          ? (options.maskCharacter || "*").repeat(end - begin)
+          : `[${entity.type}]`;
+      redacted += text.slice(cursor, begin) + mask;
+      cursor = end;
+    }
+    return redacted + text.slice(cursor);
+  }
+
+  // Chainable with Endpoint classes: pass your chat options, get a redacted copy back
+  async redact<T extends { prompt?: string }>(options: T): Promise<T> {
+    if (options.prompt === undefined) {
+      return options;
+    }
+    return { ...options, prompt: await this.redactPii(options.prompt) };
+  }
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/comprehend.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test, vi } from "vitest";
+import { ComprehendAI } from "../lib/comprehend/comprehend";
+
+const sendMock = vi.fn();
+
+vi.mock("@aws-sdk/client-comprehend", () => {
+  return {
+    LanguageCode: { EN: "en" },
+    ComprehendClient: class {
+      send = sendMock;
+    },
+    DetectPiiEntitiesCommand: class {
+      input: unknown;
+      constructor(input: unknown) {
+        this.input = input;
+      }
+    },
+  };
+});
+
+const piiResponse = {
+  Entities: [
+    { Type: "NAME", Score: 0.99, BeginOffset: 11, EndOffset: 19 },
+    { Type: "EMAIL", Score: 0.98, BeginOffset: 32, EndOffset: 51 },
+  ],
+};
+
+describe("ComprehendAI", () => {
+  describe("detectPiiEntities", () => {
+    test("returns detected PII entities", async () => {
+      sendMock.mockResolvedValueOnce(piiResponse);
+      const comprehend = new ComprehendAI({ region: "us-east-1" });
+      const entities = await comprehend.detectPiiEntities(
+        "Hello from John Doe, mail me at johndoe@example.com.",
+      );
+      expect(sendMock).toHaveBeenCalled();
+      expect(entities).toEqual([
+        { type: "NAME", score: 0.99, beginOffset: 11, endOffset: 19 },
+        { type: "EMAIL", score: 0.98, beginOffset: 32, endOffset: 51 },
+      ]);
+    });
+  });
+
+  describe("redactPii", () => {
+    test("replaces PII spans with entity types by default", async () => {
+      sendMock.mockResolvedValueOnce(piiResponse);
+      const comprehend = new ComprehendAI({ region: "us-east-1" });
+      const redacted = await comprehend.redactPii(
+        "Hello from John Doe, mail me at johndoe@example.com.",
+      );
+      expect(redacted).toEqual("Hello from [NAME], mail me at [EMAIL].");
+    });
+
+    test("supports character masking", async () => {
+      sendMock.mockResolvedValueOnce({
+        Entities: [
+          { Type: "NAME", Score: 0.99, BeginOffset: 11, EndOffset: 19 },
+        ],
+      });
+      const comprehend = new ComprehendAI({ region: "us-east-1" });
+      const redacted = await comprehend.redactPii("Hello from John Doe", {
+        maskMode: "character",
+        maskCharacter: "#",
+      });
+      expect(redacted).toEqual("Hello from ########");
+    });
+
+    test("returns the original text when no PII is found", async () => {
+      sendMock.mockResolvedValueOnce({ Entities: [] });
+      const comprehend = new ComprehendAI({ region: "us-east-1" });
+      const redacted = await comprehend.redactPii("Nothing sensitive here.");
+      expect(redacted).toEqual("Nothing sensitive here.");
+    });
+  });
+
+  describe("redact", () => {
+    test("redacts the prompt field and keeps other options for chaining", async () => {
+      sendMock.mockResolvedValueOnce(piiResponse);
+      const comprehend = new ComprehendAI({ region: "us-east-1" });
+      const options = await comprehend.redact({
+        prompt: "Hello from John Doe, mail me at johndoe@example.com.",
+        model: "gpt-3.5-turbo",
+        temperature: 0.7,
+      });
+      expect(options).toEqual({
+        prompt: "Hello from [NAME], mail me at [EMAIL].",
+        model: "gpt-3.5-turbo",
+        temperature: 0.7,
+      });
+    });
+
+    test("passes options through unchanged when no prompt is present", async () => {
+      const comprehend = new ComprehendAI({ region: "us-east-1" });
+      const options = await comprehend.redact({ model: "gpt-3.5-turbo" });
+      expect(options).toEqual({ model: "gpt-3.5-turbo" });
+    });
+  });
+});

--- a/JS/edgechains/examples/comprehend-redact/package.json
+++ b/JS/edgechains/examples/comprehend-redact/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "comprehend-redact",
+  "version": "1.0.0",
+  "description": "Redact PII from prompts with AWS Comprehend before sending them to an LLM",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "tsc && node ./dist/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@arakoodev/edgechains.js": "file:../../arakoodev",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "typescript": "^5.6.3"
+  }
+}

--- a/JS/edgechains/examples/comprehend-redact/readme.md
+++ b/JS/edgechains/examples/comprehend-redact/readme.md
@@ -1,0 +1,28 @@
+# AWS Comprehend PII redaction example
+
+Redact personally identifiable information (PII) from prompts with AWS Comprehend before chaining them into an OpenAI endpoint call.
+
+## Setup
+
+1. Provide AWS credentials in a `.env` file (or via your AWS credential chain):
+
+```
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+OPENAI_API_KEY=...
+```
+
+2. Install dependencies:
+
+```
+npm install
+```
+
+3. Run the example:
+
+```
+npm start
+```
+
+The example prints the redacted prompt (PII replaced with entity type markers like `[NAME]` and `[EMAIL]`) and then the OpenAI chat response.

--- a/JS/edgechains/examples/comprehend-redact/src/index.ts
+++ b/JS/edgechains/examples/comprehend-redact/src/index.ts
@@ -1,0 +1,21 @@
+import "dotenv/config";
+import { OpenAI, ComprehendAI } from "@arakoodev/edgechains.js/ai";
+
+async function main() {
+  const comprehend = new ComprehendAI({
+    region: process.env.AWS_REGION || "us-east-1",
+  });
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  const userInput =
+    "Hi, I am John Doe. I ordered a laptop to 123 Main Street, Seattle. You can reach me at johndoe@example.com. What is the order status?";
+
+  // Chained with the OpenAI endpoint: the prompt is redacted before the chat call
+  const chatOptions = await comprehend.redact({ prompt: userInput });
+  console.log("Redacted prompt:", chatOptions.prompt);
+
+  const response = await openai.chat(chatOptions);
+  console.log("OpenAI response:", response.content);
+}
+
+main().catch(console.error);

--- a/JS/edgechains/examples/comprehend-redact/tsconfig.json
+++ b/JS/edgechains/examples/comprehend-redact/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["./**/*.test.ts"]
+}


### PR DESCRIPTION
/claim #290

Adds a ComprehendAI class that detects PII with AWS SDK v3 and redacts it before chaining into endpoint calls. Includes vitest tests and a working example. Build passes.