### PR TITLE
feat(vector-db): add dependency-free Qdrant REST client (#273)

### DIFF
--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,3 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export { Qdrant, QdrantDistanceMetric, QdrantHttpError } from "./lib/qdrant/qdrant.js";
+export type { QdrantClient, QdrantOptions, QdrantPointId, QdrantVector } from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,516 @@
+/**
+ * Dependency-free Qdrant REST client for the JavaScript vector-db package.
+ * Uses the HTTP API directly (no @qdrant/* packages) and mirrors the existing
+ * Supabase method names so callers can switch stores with a small mapping.
+ *
+ * REST reference: https://qdrant.github.io/qdrant/redoc/index.html
+ */
+
+type QdrantFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type QdrantPointId = string | number;
+
+export type QdrantVector = number[] | Record<string, number[]>;
+
+export enum QdrantDistanceMetric {
+    Cosine = "Cosine",
+    Euclid = "Euclid",
+    Dot = "Dot",
+    Manhattan = "Manhattan",
+}
+
+export interface QdrantClient {
+    url: string;
+    apiKey?: string;
+    fetch: QdrantFetch;
+    timeoutMs?: number;
+}
+
+export interface QdrantOptions {
+    fetch?: QdrantFetch;
+    timeoutMs?: number;
+}
+
+export class QdrantHttpError extends Error {
+    status: number;
+    body: unknown;
+
+    constructor(status: number, body: unknown) {
+        const detail = typeof body === "string" ? body : JSON.stringify(body);
+        super(`Qdrant request failed with status ${status}: ${detail}`);
+        this.name = "QdrantHttpError";
+        this.status = status;
+        this.body = body;
+    }
+}
+
+interface QdrantEnvelope<T = unknown> {
+    result?: T;
+    status?: unknown;
+    time?: number;
+}
+
+interface CollectionArgs {
+    client?: QdrantClient;
+    collectionName?: string;
+    tableName?: string;
+}
+
+interface CreateCollectionArgs extends CollectionArgs {
+    vectorSize?: number;
+    size?: number;
+    distance?: QdrantDistanceMetric | string;
+    vectors?: Record<string, unknown>;
+}
+
+interface InsertVectorDataArgs extends CollectionArgs {
+    id?: QdrantPointId;
+    vector?: QdrantVector;
+    embedding?: QdrantVector;
+    payload?: Record<string, unknown>;
+    points?: Array<Record<string, unknown>>;
+    wait?: boolean;
+    [key: string]: unknown;
+}
+
+interface GetDataFromQueryArgs extends CollectionArgs {
+    /**
+     * Kept for Supabase-shaped callers. Qdrant has no RPC layer, so this is ignored.
+     */
+    functionNameToCall?: string;
+    vector?: QdrantVector;
+    query?: QdrantVector;
+    query_embedding?: QdrantVector;
+    embedding?: QdrantVector;
+    limit?: number;
+    match_count?: number;
+    topK?: number;
+    filter?: Record<string, unknown>;
+    with_payload?: boolean | string[] | Record<string, unknown>;
+    with_vector?: boolean | string[] | Record<string, unknown>;
+    score_threshold?: number;
+}
+
+interface GetDataArgs extends CollectionArgs {
+    limit?: number;
+    offset?: QdrantPointId | Record<string, unknown>;
+    filter?: Record<string, unknown>;
+    with_payload?: boolean | string[] | Record<string, unknown>;
+    with_vector?: boolean | string[] | Record<string, unknown>;
+}
+
+interface GetDataByIdArgs extends CollectionArgs {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    with_payload?: boolean | string[] | Record<string, unknown>;
+    with_vector?: boolean | string[] | Record<string, unknown>;
+}
+
+interface UpdateByIdArgs extends CollectionArgs {
+    id: QdrantPointId;
+    updatedContent: Record<string, unknown>;
+    wait?: boolean;
+}
+
+interface DeleteByIdArgs extends CollectionArgs {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+    private readonly defaultFetch?: QdrantFetch;
+    private readonly defaultTimeoutMs?: number;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string, options: QdrantOptions = {}) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "";
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+        this.defaultFetch = options.fetch;
+        this.defaultTimeoutMs = options.timeoutMs;
+    }
+
+    /**
+     * Build a reusable REST client, matching Supabase.createClient().
+     */
+    createClient(options: QdrantOptions = {}): QdrantClient {
+        if (!this.QDRANT_URL) {
+            throw new Error(
+                "QDRANT_URL is required. Pass it to the constructor or set the QDRANT_URL environment variable."
+            );
+        }
+
+        const fetchImplementation = options.fetch || this.defaultFetch || globalThis.fetch;
+        if (typeof fetchImplementation !== "function") {
+            throw new Error("A fetch implementation is required to use Qdrant");
+        }
+
+        return {
+            url: normalizeBaseUrl(this.QDRANT_URL),
+            apiKey: this.QDRANT_API_KEY,
+            fetch: fetchImplementation.bind(globalThis),
+            timeoutMs: options.timeoutMs ?? this.defaultTimeoutMs,
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        tableName,
+        vectors,
+        vectorSize,
+        size,
+        distance = QdrantDistanceMetric.Cosine,
+        ...args
+    }: CreateCollectionArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        if (!vectors && !vectorSize && !size) {
+            throw new Error("vectorSize or vectors is required to create a Qdrant collection");
+        }
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}`,
+            body: {
+                ...args,
+                vectors: vectors || {
+                    size: vectorSize || size,
+                    distance,
+                },
+            },
+        });
+    }
+
+    async getCollection({
+        client,
+        collectionName,
+        tableName,
+    }: CollectionArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "GET",
+            path: `/collections/${encodeURIComponent(collection)}`,
+        });
+    }
+
+    async deleteCollection({
+        client,
+        collectionName,
+        tableName,
+    }: CollectionArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "DELETE",
+            path: `/collections/${encodeURIComponent(collection)}`,
+        });
+    }
+
+    /**
+     * Upsert one or more points. Accepts the Supabase insertVectorData shape
+     * (`tableName`, `content`, `embedding`) and native Qdrant fields (`points`).
+     * When `id` is omitted for a single-point insert, a UUID is generated.
+     */
+    async insertVectorData({
+        client,
+        collectionName,
+        tableName,
+        id,
+        vector,
+        embedding,
+        payload,
+        points,
+        wait = true,
+        ...args
+    }: InsertVectorDataArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const pointVector = vector || embedding;
+
+        if (!points && !pointVector) {
+            throw new Error("vector, embedding, or points is required to insert Qdrant data");
+        }
+
+        const resolvedPoints =
+            points ||
+            [
+                {
+                    id: id ?? crypto.randomUUID(),
+                    vector: pointVector,
+                    payload: payload || (Object.keys(args).length ? args : undefined),
+                },
+            ];
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            query: { wait },
+            body: { points: resolvedPoints },
+        });
+    }
+
+    /**
+     * Vector search. Maps to POST /collections/{name}/points/search.
+     * Also accepts Supabase-style `query_embedding` and `match_count`.
+     */
+    async getDataFromQuery({
+        client,
+        collectionName,
+        tableName,
+        vector,
+        query,
+        query_embedding,
+        embedding,
+        limit,
+        match_count,
+        topK,
+        filter,
+        with_payload = true,
+        with_vector = false,
+        score_threshold,
+    }: GetDataFromQueryArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const queryVector = vector || query || query_embedding || embedding;
+        if (!queryVector) {
+            throw new Error("vector, query, or query_embedding is required to search Qdrant data");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/search`,
+            body: compact({
+                vector: queryVector,
+                limit: limit ?? match_count ?? topK ?? 10,
+                filter,
+                with_payload,
+                with_vector,
+                score_threshold,
+            }),
+        });
+    }
+
+    /**
+     * Scroll / list points. Maps to POST /collections/{name}/points/scroll.
+     */
+    async getData({
+        client,
+        collectionName,
+        tableName,
+        limit = 10,
+        offset,
+        filter,
+        with_payload = true,
+        with_vector = false,
+    }: GetDataArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/scroll`,
+            body: compact({
+                limit,
+                offset,
+                filter,
+                with_payload,
+                with_vector,
+            }),
+        });
+    }
+
+    /**
+     * Retrieve points by id. A single `id` returns one point (or null),
+     * matching Supabase.getDataById(). Pass `ids` to retrieve a batch.
+     */
+    async getDataById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        with_payload = true,
+        with_vector = false,
+    }: GetDataByIdArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to retrieve Qdrant points");
+        }
+
+        const result = await this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            body: {
+                ids: resolvedIds,
+                with_payload,
+                with_vector,
+            },
+        });
+
+        if (id !== undefined && !ids) {
+            return Array.isArray(result) ? (result[0] ?? null) : result;
+        }
+        return result;
+    }
+
+    async updateById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        updatedContent,
+        wait = true,
+    }: UpdateByIdArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        if (!updatedContent || typeof updatedContent !== "object") {
+            throw new Error("updatedContent is required to update a Qdrant point");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/payload`,
+            query: { wait },
+            body: {
+                payload: updatedContent,
+                points: [id],
+            },
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        wait = true,
+    }: DeleteByIdArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to delete Qdrant points");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/delete`,
+            query: { wait },
+            body: {
+                points: resolvedIds,
+            },
+        });
+    }
+
+    // Native Qdrant aliases. Same implementations as the Supabase-shaped methods.
+    upsert = this.insertVectorData.bind(this);
+    search = this.getDataFromQuery.bind(this);
+    scroll = this.getData.bind(this);
+    retrieve = this.getDataById.bind(this);
+    deletePoints = this.deleteById.bind(this);
+
+    private async request({
+        client,
+        method,
+        path,
+        query,
+        body,
+    }: {
+        client?: QdrantClient;
+        method: string;
+        path: string;
+        query?: Record<string, string | number | boolean | undefined>;
+        body?: Record<string, unknown>;
+    }): Promise<unknown> {
+        const resolvedClient = client || this.createClient();
+        const url = new URL(`${resolvedClient.url}${path}`);
+
+        for (const [key, value] of Object.entries(query || {})) {
+            if (value !== undefined) {
+                url.searchParams.set(key, String(value));
+            }
+        }
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (resolvedClient.apiKey) {
+            headers["api-key"] = resolvedClient.apiKey;
+        }
+
+        const controller = new AbortController();
+        const timeoutMs = resolvedClient.timeoutMs;
+        const timer =
+            timeoutMs !== undefined
+                ? setTimeout(() => controller.abort(), timeoutMs)
+                : undefined;
+
+        let response: Response;
+        try {
+            response = await resolvedClient.fetch(url.toString(), {
+                method,
+                headers,
+                body: body ? JSON.stringify(body) : undefined,
+                signal: controller.signal,
+            });
+        } catch (error: any) {
+            if (error?.name === "AbortError") {
+                throw new Error(`Qdrant request timed out after ${timeoutMs}ms`);
+            }
+            throw error;
+        } finally {
+            if (timer) {
+                clearTimeout(timer);
+            }
+        }
+
+        const payload = await readResponseBody(response);
+        if (!response.ok) {
+            throw new QdrantHttpError(response.status, payload);
+        }
+
+        if (payload && typeof payload === "object" && "result" in payload) {
+            return (payload as QdrantEnvelope).result;
+        }
+        return payload;
+    }
+}
+
+function normalizeBaseUrl(url: string): string {
+    const trimmed = url.trim().replace(/\/+$/, "");
+    if (!/^https?:\/\//i.test(trimmed)) {
+        throw new Error(`QDRANT_URL must be an absolute http(s) URL, received: "${url}"`);
+    }
+    return trimmed;
+}
+
+function resolveCollectionName(collectionName?: string, tableName?: string): string {
+    const collection = collectionName || tableName;
+    if (!collection) {
+        throw new Error("collectionName or tableName is required");
+    }
+    return collection;
+}
+
+function compact<T extends Record<string, unknown>>(value: T): Partial<T> {
+    return Object.fromEntries(
+        Object.entries(value).filter(([, entry]) => entry !== undefined)
+    ) as Partial<T>;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+    if (!text) {
+        return undefined;
+    }
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,434 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+    Qdrant,
+    QdrantDistanceMetric,
+    QdrantHttpError,
+} from "../../lib/qdrant/qdrant.js";
+
+const MOCK_QDRANT_URL = "https://qdrant.example.com/";
+const MOCK_QDRANT_API_KEY = "mock-api-key";
+
+function createFetchMock(result: unknown = { ok: true }, status = 200) {
+    return vi.fn().mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => JSON.stringify({ result }),
+    });
+}
+
+function lastCall(fetchMock: ReturnType<typeof createFetchMock>) {
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    return {
+        url,
+        method: init.method,
+        headers: init.headers as Record<string, string>,
+        body: init.body ? JSON.parse(init.body as string) : undefined,
+    };
+}
+
+describe("Qdrant", () => {
+    const originalEnv = { ...process.env };
+    let qdrant: Qdrant;
+
+    beforeEach(() => {
+        qdrant = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY);
+    });
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        vi.restoreAllMocks();
+    });
+
+    it("creates a client with a normalized URL and api-key header support", () => {
+        const client = qdrant.createClient();
+
+        expect(client.url).toBe("https://qdrant.example.com");
+        expect(client.apiKey).toBe(MOCK_QDRANT_API_KEY);
+    });
+
+    it("falls back to QDRANT_URL and QDRANT_API_KEY environment variables", () => {
+        process.env.QDRANT_URL = "https://cloud.qdrant.io";
+        process.env.QDRANT_API_KEY = "env-key";
+
+        const fromEnv = new Qdrant();
+        const client = fromEnv.createClient();
+
+        expect(client.url).toBe("https://cloud.qdrant.io");
+        expect(client.apiKey).toBe("env-key");
+    });
+
+    it("throws when createClient is called without a URL", () => {
+        expect(() => new Qdrant().createClient()).toThrow("QDRANT_URL is required");
+    });
+
+    it("rejects a non-http URL", () => {
+        expect(() => new Qdrant("qdrant.local", "key").createClient()).toThrow(
+            "absolute http(s) URL"
+        );
+    });
+
+    it("creates a collection through PUT /collections/{name}", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        const result = await qdrant.createCollection({
+            client,
+            collectionName: "documents",
+            vectorSize: 1536,
+            distance: QdrantDistanceMetric.Cosine,
+        });
+
+        expect(result).toEqual({ acknowledged: true });
+        expect(lastCall(fetchMock)).toEqual({
+            url: "https://qdrant.example.com/collections/documents",
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "api-key": MOCK_QDRANT_API_KEY,
+            },
+            body: {
+                vectors: {
+                    size: 1536,
+                    distance: "Cosine",
+                },
+            },
+        });
+    });
+
+    it("reads and deletes collections by name", async () => {
+        const fetchMock = createFetchMock({ status: "green" });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.getCollection({ client, tableName: "docs / v1" });
+        await qdrant.deleteCollection({ client, collectionName: "docs / v1" });
+
+        expect(fetchMock.mock.calls.map((call) => [call[0], (call[1] as RequestInit).method])).toEqual(
+            [
+                ["https://qdrant.example.com/collections/docs%20%2F%20v1", "GET"],
+                ["https://qdrant.example.com/collections/docs%20%2F%20v1", "DELETE"],
+            ]
+        );
+    });
+
+    it("upserts a Supabase-shaped insertVectorData payload", async () => {
+        const fetchMock = createFetchMock({ operation_id: 11 });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.insertVectorData({
+            client,
+            tableName: "documents",
+            id: 42,
+            content: "Qdrant supports direct REST inserts",
+            embedding: [0.1, 0.2, 0.3],
+        });
+
+        expect(lastCall(fetchMock)).toMatchObject({
+            url: "https://qdrant.example.com/collections/documents/points?wait=true",
+            method: "PUT",
+            body: {
+                points: [
+                    {
+                        id: 42,
+                        vector: [0.1, 0.2, 0.3],
+                        payload: {
+                            content: "Qdrant supports direct REST inserts",
+                        },
+                    },
+                ],
+            },
+        });
+    });
+
+    it("generates a UUID when insertVectorData is called without an id", async () => {
+        const fetchMock = createFetchMock({ operation_id: 12 });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.insertVectorData({
+            client,
+            collectionName: "documents",
+            embedding: [0.4, 0.5],
+            content: "auto id",
+        });
+
+        const pointId = lastCall(fetchMock).body.points[0].id;
+        expect(pointId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+        );
+    });
+
+    it("upserts a batch of points through the native upsert alias", async () => {
+        const fetchMock = createFetchMock({ operation_id: 13 });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.upsert({
+            client,
+            collectionName: "documents",
+            points: [
+                { id: 1, vector: [0.1], payload: { page: 1 } },
+                { id: 2, vector: [0.2], payload: { page: 2 } },
+            ],
+            wait: false,
+        });
+
+        expect(lastCall(fetchMock).url).toBe(
+            "https://qdrant.example.com/collections/documents/points?wait=false"
+        );
+        expect(lastCall(fetchMock).body.points).toHaveLength(2);
+    });
+
+    it("searches by vector and returns the Qdrant result list", async () => {
+        const fetchMock = createFetchMock([{ id: 7, score: 0.98 }]);
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "documents",
+            vector: [0.4, 0.5],
+            limit: 3,
+            filter: { must: [{ key: "source", match: { value: "docs" } }] },
+        });
+
+        expect(result).toEqual([{ id: 7, score: 0.98 }]);
+        expect(lastCall(fetchMock)).toMatchObject({
+            url: "https://qdrant.example.com/collections/documents/points/search",
+            method: "POST",
+            body: {
+                vector: [0.4, 0.5],
+                limit: 3,
+                filter: { must: [{ key: "source", match: { value: "docs" } }] },
+                with_payload: true,
+                with_vector: false,
+            },
+        });
+    });
+
+    it("accepts Supabase-style query_embedding and match_count on search", async () => {
+        const fetchMock = createFetchMock([]);
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.search({
+            client,
+            tableName: "documents",
+            functionNameToCall: "match_documents",
+            query_embedding: [0.9, 0.1],
+            match_count: 5,
+        });
+
+        expect(lastCall(fetchMock).body).toMatchObject({
+            vector: [0.9, 0.1],
+            limit: 5,
+        });
+    });
+
+    it("scrolls collection points with payloads enabled", async () => {
+        const fetchMock = createFetchMock({
+            points: [{ id: 1 }],
+            next_page_offset: null,
+        });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        const result = await qdrant.getData({
+            client,
+            collectionName: "documents",
+            limit: 2,
+            filter: { must_not: [{ key: "archived", match: { value: true } }] },
+        });
+
+        expect(result).toEqual({ points: [{ id: 1 }], next_page_offset: null });
+        expect(lastCall(fetchMock)).toMatchObject({
+            url: "https://qdrant.example.com/collections/documents/points/scroll",
+            method: "POST",
+            body: {
+                limit: 2,
+                filter: { must_not: [{ key: "archived", match: { value: true } }] },
+                with_payload: true,
+                with_vector: false,
+            },
+        });
+    });
+
+    it("returns a single point from getDataById and a batch from retrieve({ ids })", async () => {
+        const fetchMock = createFetchMock([
+            { id: "doc-1", payload: { status: "ok" } },
+        ]);
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        const single = await qdrant.getDataById({
+            client,
+            tableName: "documents",
+            id: "doc-1",
+        });
+        expect(single).toEqual({ id: "doc-1", payload: { status: "ok" } });
+        expect(lastCall(fetchMock).body).toEqual({
+            ids: ["doc-1"],
+            with_payload: true,
+            with_vector: false,
+        });
+
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            text: async () =>
+                JSON.stringify({
+                    result: [
+                        { id: "doc-1" },
+                        { id: "doc-2" },
+                    ],
+                }),
+        });
+
+        const batch = await qdrant.retrieve({
+            client,
+            collectionName: "documents",
+            ids: ["doc-1", "doc-2"],
+        });
+        expect(batch).toEqual([{ id: "doc-1" }, { id: "doc-2" }]);
+    });
+
+    it("updates and deletes points by id", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await qdrant.updateById({
+            client,
+            tableName: "documents",
+            id: "doc-1",
+            updatedContent: { status: "reviewed" },
+        });
+        await qdrant.deleteById({
+            client,
+            tableName: "documents",
+            id: "doc-1",
+        });
+
+        expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+            "https://qdrant.example.com/collections/documents/points/payload?wait=true",
+            "https://qdrant.example.com/collections/documents/points/delete?wait=true",
+        ]);
+        expect(JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+            payload: { status: "reviewed" },
+            points: ["doc-1"],
+        });
+        expect(JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string)).toEqual({
+            points: ["doc-1"],
+        });
+    });
+
+    it("omits the api-key header when no key is configured", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const unauthenticated = new Qdrant("https://localhost:6333");
+        const client = unauthenticated.createClient({ fetch: fetchMock });
+
+        await unauthenticated.createCollection({
+            client,
+            collectionName: "local",
+            vectorSize: 4,
+        });
+
+        expect(lastCall(fetchMock).headers).toEqual({
+            "Content-Type": "application/json",
+        });
+    });
+
+    it("throws QdrantHttpError for a non-2xx response, including non-JSON bodies", async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 401,
+            text: async () => "unauthorized",
+        });
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await expect(
+            qdrant.getDataFromQuery({
+                client,
+                collectionName: "documents",
+                vector: [0.1, 0.2],
+            })
+        ).rejects.toMatchObject({
+            name: "QdrantHttpError",
+            status: 401,
+            message: expect.stringContaining("status 401"),
+        });
+
+        await expect(
+            qdrant.getDataFromQuery({
+                client,
+                collectionName: "documents",
+                vector: [0.1, 0.2],
+            })
+        ).rejects.toBeInstanceOf(QdrantHttpError);
+    });
+
+    it("validates required fields before making REST calls", async () => {
+        const fetchMock = createFetchMock();
+        const client = qdrant.createClient({ fetch: fetchMock });
+
+        await expect(
+            qdrant.createCollection({ client, collectionName: "documents" })
+        ).rejects.toThrow("vectorSize or vectors is required");
+
+        await expect(
+            qdrant.insertVectorData({
+                client,
+                collectionName: "documents",
+                content: "missing vector",
+            })
+        ).rejects.toThrow("vector, embedding, or points is required");
+
+        await expect(
+            qdrant.getDataFromQuery({
+                client,
+                collectionName: "documents",
+            })
+        ).rejects.toThrow("vector, query, or query_embedding is required");
+
+        await expect(qdrant.getData({ client })).rejects.toThrow(
+            "collectionName or tableName is required"
+        );
+
+        await expect(
+            qdrant.getDataById({ client, collectionName: "documents" })
+        ).rejects.toThrow("id or ids is required");
+
+        await expect(
+            qdrant.deleteById({ client, collectionName: "documents" })
+        ).rejects.toThrow("id or ids is required");
+
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("uses constructor-injected fetch when methods omit client", async () => {
+        const fetchMock = createFetchMock({ acknowledged: true });
+        const withInjectedFetch = new Qdrant(MOCK_QDRANT_URL, MOCK_QDRANT_API_KEY, {
+            fetch: fetchMock,
+        });
+
+        await withInjectedFetch.createCollection({
+            collectionName: "documents",
+            vectorSize: 8,
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(lastCall(fetchMock).url).toBe(
+            "https://qdrant.example.com/collections/documents"
+        );
+    });
+
+    it("surfaces timeouts as a readable error", async () => {
+        const fetchMock = vi.fn().mockImplementation((_url, init: RequestInit) => {
+            return new Promise((_resolve, reject) => {
+                init.signal?.addEventListener("abort", () => {
+                    const error = new Error("aborted");
+                    error.name = "AbortError";
+                    reject(error);
+                });
+            });
+        });
+        const client = qdrant.createClient({ fetch: fetchMock, timeoutMs: 5 });
+
+        await expect(
+            qdrant.getCollection({ client, collectionName: "documents" })
+        ).rejects.toThrow("timed out after 5ms");
+    });
+});


### PR DESCRIPTION
@algora-pbc /claim #273
Fixes #273

Adds a dependency-free Qdrant REST client under `@arakoodev/edgechains.js/vector-db` (no `@qdrant/*` packages). Mirrors Supabase method vocabulary with createCollection / insertVectorData / getDataFromQuery / getDataById / updateById / deleteById plus search/scroll helpers. Mocked Vitest coverage under `src/tests/qdrant/`.

I have read the Arakoo CLA Document and I hereby sign the CLA.
