### PR TITLE
feat(ai): add Google PaLM 2 API support (#279)

### DIFF
--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -1,5 +1,21 @@
 export { OpenAI } from "./lib/openai/openai.js";
 export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
+export { Palm2AI } from "./lib/palm2/palm2.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export type {
+    Palm2BatchEmbedTextOptions,
+    Palm2BatchEmbedTextResponse,
+    Palm2ChatOptions,
+    Palm2ConstructionOptions,
+    Palm2CountTextTokensOptions,
+    Palm2CountTextTokensResponse,
+    Palm2EmbedTextOptions,
+    Palm2EmbedTextResponse,
+    Palm2GenerateMessageOptions,
+    Palm2GenerateMessageResponse,
+    Palm2GenerateTextOptions,
+    Palm2GenerateTextResponse,
+    Palm2Message,
+} from "./lib/palm2/types.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/palm2.ts
@@ -1,0 +1,214 @@
+import axios from "axios";
+import { retry } from "@lifeomic/attempt";
+import {
+    Palm2BatchEmbedTextOptions,
+    Palm2BatchEmbedTextResponse,
+    Palm2ChatOptions,
+    Palm2ConstructionOptions,
+    Palm2CountTextTokensOptions,
+    Palm2CountTextTokensResponse,
+    Palm2EmbedTextOptions,
+    Palm2EmbedTextResponse,
+    Palm2GenerateMessageResponse,
+    Palm2GenerateTextOptions,
+    Palm2GenerateTextResponse,
+    Palm2Message,
+} from "./types.js";
+
+const DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com";
+const DEFAULT_API_VERSION = "v1beta2";
+const DEFAULT_TEXT_MODEL = "text-bison-001";
+const DEFAULT_CHAT_MODEL = "chat-bison-001";
+const DEFAULT_EMBED_MODEL = "embedding-gecko-001";
+
+export class Palm2AI {
+    apiKey: string;
+    baseUrl: string;
+    apiVersion: string;
+
+    constructor(options: Palm2ConstructionOptions = {}) {
+        this.apiKey =
+            options.apiKey || process.env.PALM2_API_KEY || process.env.GOOGLE_API_KEY || "";
+        this.baseUrl = (options.baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
+        this.apiVersion = options.apiVersion || DEFAULT_API_VERSION;
+        this.checkKeys();
+    }
+
+    private checkKeys(): void {
+        if (!this.apiKey) {
+            console.error(
+                "API key is missing. Please provide a valid Google Generative Language API key. You can add it in .env file as PALM2_API_KEY or GOOGLE_API_KEY"
+            );
+        }
+    }
+
+    async generateText(options: Palm2GenerateTextOptions): Promise<Palm2GenerateTextResponse> {
+        const model = options.model || DEFAULT_TEXT_MODEL;
+        const data = this.omitUndefined({
+            prompt: { text: options.prompt },
+            temperature: options.temperature ?? 0.7,
+            candidateCount: options.candidateCount ?? 1,
+            maxOutputTokens: options.maxOutputTokens ?? 1024,
+            topP: options.topP,
+            topK: options.topK,
+            stopSequences: options.stopSequences,
+            safetySettings: options.safetySettings,
+        });
+
+        return this.request<Palm2GenerateTextResponse>(
+            this.buildUrl(model, "generateText"),
+            data,
+            options.max_retry,
+            options.delay
+        );
+    }
+
+    async generateMessage(options: Palm2ChatOptions): Promise<Palm2GenerateMessageResponse> {
+        const messages = this.resolveMessages(options);
+        const model = options.model || DEFAULT_CHAT_MODEL;
+        const data = this.omitUndefined({
+            prompt: this.omitUndefined({
+                context: options.context,
+                examples: options.examples,
+                messages,
+            }),
+            temperature: options.temperature ?? 0.7,
+            candidateCount: options.candidateCount ?? 1,
+            topP: options.topP,
+            topK: options.topK,
+        });
+
+        return this.request<Palm2GenerateMessageResponse>(
+            this.buildUrl(model, "generateMessage"),
+            data,
+            options.max_retry,
+            options.delay
+        );
+    }
+
+    async chat(options: Palm2ChatOptions): Promise<Palm2GenerateMessageResponse> {
+        return this.generateMessage(options);
+    }
+
+    async embedText(options: Palm2EmbedTextOptions): Promise<Palm2EmbedTextResponse> {
+        const model = options.model || DEFAULT_EMBED_MODEL;
+        return this.request<Palm2EmbedTextResponse>(
+            this.buildUrl(model, "embedText"),
+            { text: options.text },
+            options.max_retry,
+            options.delay
+        );
+    }
+
+    async batchEmbedText(
+        options: Palm2BatchEmbedTextOptions
+    ): Promise<Palm2BatchEmbedTextResponse> {
+        const model = options.model || DEFAULT_EMBED_MODEL;
+        return this.request<Palm2BatchEmbedTextResponse>(
+            this.buildUrl(model, "batchEmbedText"),
+            { texts: options.texts },
+            options.max_retry,
+            options.delay
+        );
+    }
+
+    async countTextTokens(
+        options: Palm2CountTextTokensOptions
+    ): Promise<Palm2CountTextTokensResponse> {
+        const model = options.model || DEFAULT_TEXT_MODEL;
+        return this.request<Palm2CountTextTokensResponse>(
+            this.buildUrl(model, "countTextTokens"),
+            { prompt: { text: options.prompt } },
+            options.max_retry,
+            options.delay
+        );
+    }
+
+    extractText(response: Palm2GenerateTextResponse): string {
+        return response.candidates?.[0]?.output ?? "";
+    }
+
+    extractMessage(response: Palm2GenerateMessageResponse): string {
+        return response.candidates?.[0]?.content ?? "";
+    }
+
+    extractEmbedding(response: Palm2EmbedTextResponse): number[] {
+        return response.embedding?.value || response.embedding?.values || [];
+    }
+
+    private resolveMessages(options: Palm2ChatOptions): Palm2Message[] {
+        if (options.messages && options.messages.length > 0) {
+            return options.messages;
+        }
+        if (options.prompt) {
+            return [{ content: options.prompt }];
+        }
+        throw new Error("Palm2 chat requires either a prompt or a messages array");
+    }
+
+    private buildUrl(model: string, method: string): string {
+        const encodedKey = encodeURIComponent(this.apiKey);
+        return `${this.baseUrl}/${this.apiVersion}/models/${model}:${method}?key=${encodedKey}`;
+    }
+
+    private omitUndefined<T extends Record<string, unknown>>(value: T): T {
+        return Object.fromEntries(
+            Object.entries(value).filter(([, entry]) => entry !== undefined)
+        ) as T;
+    }
+
+    private async request<T>(
+        url: string,
+        data: object,
+        maxRetry?: number,
+        delayMs?: number
+    ): Promise<T> {
+        if (!this.apiKey) {
+            throw new Error(
+                "API key is missing. Please provide a valid Google Generative Language API key. You can add it in .env file as PALM2_API_KEY or GOOGLE_API_KEY"
+            );
+        }
+
+        try {
+            return await retry(
+                async () => {
+                    const response = await axios.post(url, data, {
+                        headers: {
+                            "Content-Type": "application/json",
+                            "x-goog-api-key": this.apiKey,
+                        },
+                        maxBodyLength: Infinity,
+                    });
+                    return response.data;
+                },
+                { maxAttempts: maxRetry || 3, delay: delayMs || 200 }
+            );
+        } catch (error: any) {
+            if (error.response) {
+                console.log("Server responded with status code:", error.response.status);
+                console.log("Response data:", error.response.data);
+            } else if (error.request) {
+                console.log("No response received:", error);
+            } else {
+                console.log("Error creating request:", error.message);
+            }
+            throw error;
+        }
+    }
+}
+
+export type {
+    Palm2BatchEmbedTextOptions,
+    Palm2BatchEmbedTextResponse,
+    Palm2ChatOptions,
+    Palm2ConstructionOptions,
+    Palm2CountTextTokensOptions,
+    Palm2CountTextTokensResponse,
+    Palm2EmbedTextOptions,
+    Palm2EmbedTextResponse,
+    Palm2GenerateMessageOptions,
+    Palm2GenerateMessageResponse,
+    Palm2GenerateTextOptions,
+    Palm2GenerateTextResponse,
+    Palm2Message,
+} from "./types.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/palm2/types.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/palm2/types.ts
@@ -1,0 +1,161 @@
+export type Palm2TextModel = "text-bison-001" | "text-bison" | (string & {});
+export type Palm2ChatModel = "chat-bison-001" | "chat-bison" | (string & {});
+export type Palm2EmbeddingModel = "embedding-gecko-001" | "textembedding-gecko-001" | (string & {});
+
+export type Palm2HarmCategory =
+    | "HARM_CATEGORY_UNSPECIFIED"
+    | "HARM_CATEGORY_DEROGATORY"
+    | "HARM_CATEGORY_TOXICITY"
+    | "HARM_CATEGORY_VIOLENCE"
+    | "HARM_CATEGORY_SEXUAL"
+    | "HARM_CATEGORY_MEDICAL"
+    | "HARM_CATEGORY_DANGEROUS";
+
+export type Palm2HarmBlockThreshold =
+    | "HARM_BLOCK_THRESHOLD_UNSPECIFIED"
+    | "BLOCK_LOW_AND_ABOVE"
+    | "BLOCK_MEDIUM_AND_ABOVE"
+    | "BLOCK_ONLY_HIGH"
+    | "BLOCK_NONE";
+
+export type Palm2HarmProbability =
+    "HARM_PROBABILITY_UNSPECIFIED" | "NEGLIGIBLE" | "LOW" | "MEDIUM" | "HIGH";
+
+export interface Palm2ConstructionOptions {
+    apiKey?: string;
+    baseUrl?: string;
+    apiVersion?: string;
+}
+
+export interface Palm2SafetySetting {
+    category: Palm2HarmCategory;
+    threshold: Palm2HarmBlockThreshold;
+}
+
+export interface Palm2SafetyRating {
+    category: Palm2HarmCategory | string;
+    probability: Palm2HarmProbability | string;
+}
+
+export interface Palm2CitationSource {
+    startIndex?: number;
+    endIndex?: number;
+    uri?: string;
+    license?: string;
+}
+
+export interface Palm2CitationMetadata {
+    citationSources?: Palm2CitationSource[];
+}
+
+export interface Palm2TextPrompt {
+    text: string;
+}
+
+export interface Palm2Message {
+    author?: string;
+    content: string;
+    citationMetadata?: Palm2CitationMetadata;
+}
+
+export interface Palm2Example {
+    input: Palm2Message;
+    output: Palm2Message;
+}
+
+export interface Palm2MessagePrompt {
+    context?: string;
+    examples?: Palm2Example[];
+    messages: Palm2Message[];
+}
+
+export interface Palm2RetryOptions {
+    max_retry?: number;
+    delay?: number;
+}
+
+export interface Palm2GenerateTextOptions extends Palm2RetryOptions {
+    model?: Palm2TextModel;
+    prompt: string;
+    temperature?: number;
+    candidateCount?: number;
+    maxOutputTokens?: number;
+    topP?: number;
+    topK?: number;
+    stopSequences?: string[];
+    safetySettings?: Palm2SafetySetting[];
+}
+
+export interface Palm2ChatOptions extends Palm2RetryOptions {
+    model?: Palm2ChatModel;
+    prompt?: string;
+    context?: string;
+    examples?: Palm2Example[];
+    messages?: Palm2Message[];
+    temperature?: number;
+    candidateCount?: number;
+    topP?: number;
+    topK?: number;
+}
+
+export interface Palm2GenerateMessageOptions extends Palm2ChatOptions {
+    messages: Palm2Message[];
+}
+
+export interface Palm2EmbedTextOptions extends Palm2RetryOptions {
+    model?: Palm2EmbeddingModel;
+    text: string;
+}
+
+export interface Palm2BatchEmbedTextOptions extends Palm2RetryOptions {
+    model?: Palm2EmbeddingModel;
+    texts: string[];
+}
+
+export interface Palm2CountTextTokensOptions extends Palm2RetryOptions {
+    model?: Palm2TextModel;
+    prompt: string;
+}
+
+export interface Palm2ContentFilter {
+    reason?: string;
+    message?: string;
+}
+
+export interface Palm2TextCandidate {
+    output: string;
+    safetyRatings?: Palm2SafetyRating[];
+    citationMetadata?: Palm2CitationMetadata;
+}
+
+export interface Palm2GenerateTextResponse {
+    candidates?: Palm2TextCandidate[];
+    filters?: Palm2ContentFilter[];
+    safetyFeedback?: Array<{
+        rating?: Palm2SafetyRating;
+        setting?: Palm2SafetySetting;
+    }>;
+}
+
+export interface Palm2GenerateMessageResponse {
+    candidates?: Palm2Message[];
+    messages?: Palm2Message[];
+    filters?: Palm2ContentFilter[];
+}
+
+export interface Palm2Embedding {
+    value?: number[];
+    values?: number[];
+}
+
+export interface Palm2EmbedTextResponse {
+    embedding?: Palm2Embedding;
+}
+
+export interface Palm2BatchEmbedTextResponse {
+    embeddings?: Palm2Embedding[];
+}
+
+export interface Palm2CountTextTokensResponse {
+    tokenCount?: number;
+}

--- a/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/palm2/palm2.test.ts
@@ -1,0 +1,384 @@
+import fs from "fs";
+import http from "http";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterEach, describe, expect, it } from "vitest";
+import { Palm2AI } from "../../lib/palm2/palm2.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+type CapturedRequest = {
+    method?: string;
+    url?: string;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+};
+
+type MockServer = {
+    baseUrl: string;
+    requests: CapturedRequest[];
+    close: () => Promise<void>;
+};
+
+const TESTCASES_DIR = path.resolve(__dirname, "../../../../../testcases/palm2");
+const EXAMPLE_DIR = path.resolve(__dirname, "../../../../../../examples/palm2-chat");
+
+function loadJsonnetObject(filePath: string): Record<string, string> {
+    const source = fs.readFileSync(filePath, "utf8");
+    const locals: Record<string, string> = {};
+    const blockRe = /local\s+(\w+)\s*=\s*\|\|\|([\s\S]*?)\|\|\|\s*;/g;
+    let match: RegExpExecArray | null;
+    while ((match = blockRe.exec(source))) {
+        locals[match[1]] = match[2].replace(/^\n/, "").replace(/\n$/, "").trim();
+    }
+
+    const result: Record<string, string> = {};
+    const assignRe = /(\w+)\s*:\s*std\.strReplace\((\w+),/g;
+    while ((match = assignRe.exec(source))) {
+        result[match[1]] = locals[match[2]];
+    }
+    return result;
+}
+
+async function startMockPalm2Server(): Promise<MockServer> {
+    const requests: CapturedRequest[] = [];
+    let failGenerateTextOnce = true;
+
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            const body = raw ? JSON.parse(raw) : {};
+            requests.push({
+                method: req.method,
+                url: req.url,
+                headers: req.headers,
+                body,
+            });
+
+            const url = req.url || "";
+            if (
+                url.includes(":generateText") &&
+                failGenerateTextOnce &&
+                body.prompt?.text === "__retry__"
+            ) {
+                failGenerateTextOnce = false;
+                res.writeHead(500, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ error: { message: "temporary failure" } }));
+                return;
+            }
+
+            if (url.includes(":generateText")) {
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(
+                    JSON.stringify({
+                        candidates: [
+                            {
+                                output: `Bison text: ${body.prompt?.text || ""}`,
+                                safetyRatings: [
+                                    {
+                                        category: "HARM_CATEGORY_TOXICITY",
+                                        probability: "NEGLIGIBLE",
+                                    },
+                                ],
+                            },
+                        ],
+                    })
+                );
+                return;
+            }
+
+            if (url.includes(":generateMessage")) {
+                const lastMessage = body.prompt?.messages?.[body.prompt.messages.length - 1];
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(
+                    JSON.stringify({
+                        candidates: [
+                            { author: "1", content: `Bison chat: ${lastMessage?.content || ""}` },
+                        ],
+                        messages: [
+                            ...(body.prompt?.messages || []),
+                            { author: "1", content: `Bison chat: ${lastMessage?.content || ""}` },
+                        ],
+                    })
+                );
+                return;
+            }
+
+            if (url.includes(":batchEmbedText")) {
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(
+                    JSON.stringify({
+                        embeddings: (body.texts || []).map(() => ({ value: [0.4, 0.5] })),
+                    })
+                );
+                return;
+            }
+
+            if (url.includes(":embedText")) {
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ embedding: { value: [0.1, 0.2, 0.3] } }));
+                return;
+            }
+
+            if (url.includes(":countTextTokens")) {
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(
+                    JSON.stringify({
+                        tokenCount: String(body.prompt?.text || "").split(/\s+/).length,
+                    })
+                );
+                return;
+            }
+
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: { message: `Unknown endpoint ${url}` } }));
+        });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+        throw new Error("Failed to bind mock PaLM 2 server");
+    }
+
+    return {
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        requests,
+        close: () =>
+            new Promise<void>((resolve, reject) => {
+                server.close((error) => (error ? reject(error) : resolve()));
+            }),
+    };
+}
+
+describe("Palm2AI", () => {
+    const prompts = loadJsonnetObject(path.join(TESTCASES_DIR, "prompts.jsonnet"));
+    const chatPrompts = loadJsonnetObject(path.join(TESTCASES_DIR, "chat.jsonnet"));
+    let server: MockServer | undefined;
+
+    afterEach(async () => {
+        if (server) {
+            await server.close();
+            server = undefined;
+        }
+        delete process.env.PALM2_API_KEY;
+        delete process.env.GOOGLE_API_KEY;
+    });
+
+    it("loads generateText, chat, and embedding prompts from jsonnet testcases", () => {
+        expect(prompts.generateTextPrompt).toContain("EdgeChains");
+        expect(prompts.embedText).toContain("JavaScript SDK");
+        expect(chatPrompts.chatPrompt).toContain("EdgeChains");
+        expect(chatPrompts.chatContext).toContain("TypeScript SDK");
+        expect(fs.readFileSync(path.join(TESTCASES_DIR, "prompts.jsonnet"), "utf8")).toContain(
+            "|||"
+        );
+        expect(fs.readFileSync(path.join(TESTCASES_DIR, "chat.jsonnet"), "utf8")).toContain(
+            "local chatPrompt"
+        );
+    });
+
+    it("posts generateText to text-bison-001 with camelCase PaLM 2 fields", async () => {
+        server = await startMockPalm2Server();
+        const palm2 = new Palm2AI({
+            apiKey: "test-key",
+            baseUrl: server.baseUrl,
+        });
+
+        const response = await palm2.generateText({
+            prompt: prompts.generateTextPrompt,
+            temperature: 0.2,
+            maxOutputTokens: 64,
+            topP: 0.8,
+            topK: 20,
+            max_retry: 1,
+        });
+
+        expect(palm2.extractText(response)).toBe(`Bison text: ${prompts.generateTextPrompt}`);
+        expect(server.requests).toHaveLength(1);
+        expect(server.requests[0].method).toBe("POST");
+        expect(server.requests[0].url).toBe(
+            "/v1beta2/models/text-bison-001:generateText?key=test-key"
+        );
+        expect(server.requests[0].headers["x-goog-api-key"]).toBe("test-key");
+        expect(server.requests[0].headers["content-type"]).toContain("application/json");
+        expect(server.requests[0].body).toEqual({
+            prompt: { text: prompts.generateTextPrompt },
+            temperature: 0.2,
+            candidateCount: 1,
+            maxOutputTokens: 64,
+            topP: 0.8,
+            topK: 20,
+        });
+    });
+
+    it("posts generateMessage to chat-bison-001 using jsonnet context, examples, and prompt", async () => {
+        server = await startMockPalm2Server();
+        const palm2 = new Palm2AI({
+            apiKey: "chat-key",
+            baseUrl: server.baseUrl,
+        });
+
+        const response = await palm2.chat({
+            prompt: chatPrompts.chatPrompt,
+            context: chatPrompts.chatContext,
+            examples: [
+                {
+                    input: { content: chatPrompts.exampleInput },
+                    output: { content: chatPrompts.exampleOutput },
+                },
+            ],
+            temperature: 0.1,
+            candidateCount: 2,
+            max_retry: 1,
+        });
+
+        expect(palm2.extractMessage(response)).toBe(`Bison chat: ${chatPrompts.chatPrompt}`);
+        expect(server.requests[0].url).toBe(
+            "/v1beta2/models/chat-bison-001:generateMessage?key=chat-key"
+        );
+        expect(server.requests[0].body).toEqual({
+            prompt: {
+                context: chatPrompts.chatContext,
+                examples: [
+                    {
+                        input: { content: chatPrompts.exampleInput },
+                        output: { content: chatPrompts.exampleOutput },
+                    },
+                ],
+                messages: [{ content: chatPrompts.chatPrompt }],
+            },
+            temperature: 0.1,
+            candidateCount: 2,
+        });
+    });
+
+    it("keeps an explicit messages array for multi-turn chat-bison calls", async () => {
+        server = await startMockPalm2Server();
+        const palm2 = new Palm2AI({
+            apiKey: "chat-key",
+            baseUrl: server.baseUrl,
+        });
+
+        await palm2.generateMessage({
+            messages: [
+                { author: "0", content: "Hello" },
+                { author: "1", content: "Hi there" },
+                { author: "0", content: chatPrompts.chatPrompt },
+            ],
+            max_retry: 1,
+        });
+
+        expect(server.requests[0].body.prompt.messages).toEqual([
+            { author: "0", content: "Hello" },
+            { author: "1", content: "Hi there" },
+            { author: "0", content: chatPrompts.chatPrompt },
+        ]);
+    });
+
+    it("posts embedText, batchEmbedText, and countTextTokens to gecko/bison endpoints", async () => {
+        server = await startMockPalm2Server();
+        const palm2 = new Palm2AI({
+            apiKey: "embed-key",
+            baseUrl: server.baseUrl,
+            apiVersion: "v1beta2",
+        });
+
+        const embedding = await palm2.embedText({ text: prompts.embedText, max_retry: 1 });
+        const batch = await palm2.batchEmbedText({
+            texts: [prompts.embedText, prompts.countTokensPrompt],
+            max_retry: 1,
+        });
+        const tokens = await palm2.countTextTokens({
+            prompt: prompts.countTokensPrompt,
+            max_retry: 1,
+        });
+
+        expect(palm2.extractEmbedding(embedding)).toEqual([0.1, 0.2, 0.3]);
+        expect(batch.embeddings).toHaveLength(2);
+        expect(tokens.tokenCount).toBe(7);
+        expect(server.requests[0].url).toBe(
+            "/v1beta2/models/embedding-gecko-001:embedText?key=embed-key"
+        );
+        expect(server.requests[0].body).toEqual({ text: prompts.embedText });
+        expect(server.requests[1].url).toBe(
+            "/v1beta2/models/embedding-gecko-001:batchEmbedText?key=embed-key"
+        );
+        expect(server.requests[2].url).toBe(
+            "/v1beta2/models/text-bison-001:countTextTokens?key=embed-key"
+        );
+        expect(server.requests[2].body).toEqual({ prompt: { text: prompts.countTokensPrompt } });
+    });
+
+    it("retries generateText after a temporary 500 from the standing API", async () => {
+        server = await startMockPalm2Server();
+        const palm2 = new Palm2AI({
+            apiKey: "retry-key",
+            baseUrl: server.baseUrl,
+        });
+
+        const response = await palm2.generateText({
+            prompt: "__retry__",
+            max_retry: 2,
+            delay: 10,
+        });
+
+        expect(palm2.extractText(response)).toBe("Bison text: __retry__");
+        expect(server.requests).toHaveLength(2);
+        expect(server.requests[0].url).toContain(":generateText");
+        expect(server.requests[1].url).toContain(":generateText");
+    });
+
+    it("reads PALM2_API_KEY from the environment and honors custom model paths", async () => {
+        process.env.PALM2_API_KEY = "env-key";
+        server = await startMockPalm2Server();
+        const palm2 = new Palm2AI({
+            baseUrl: server.baseUrl,
+            apiVersion: "v1beta3",
+        });
+
+        await palm2.generateText({
+            model: "text-bison",
+            prompt: prompts.generateTextPrompt,
+            max_retry: 1,
+        });
+
+        expect(server.requests[0].url).toBe("/v1beta3/models/text-bison:generateText?key=env-key");
+        expect(server.requests[0].headers["x-goog-api-key"]).toBe("env-key");
+    });
+
+    it("throws when no API key is configured before calling the API", async () => {
+        const palm2 = new Palm2AI({ apiKey: "" });
+        await expect(
+            palm2.generateText({ prompt: prompts.generateTextPrompt, max_retry: 1 })
+        ).rejects.toThrow(/API key is missing/);
+    });
+
+    it("throws when chat is called without a prompt or messages", async () => {
+        const palm2 = new Palm2AI({ apiKey: "test-key" });
+        await expect(palm2.chat({ max_retry: 1 })).rejects.toThrow(
+            "Palm2 chat requires either a prompt or a messages array"
+        );
+    });
+
+    it("keeps example prompts in jsonnet instead of hardcoded TypeScript", () => {
+        const exampleIndex = fs.readFileSync(path.join(EXAMPLE_DIR, "src/index.ts"), "utf8");
+        const exampleRpc = fs.readFileSync(
+            path.join(EXAMPLE_DIR, "src/lib/generateResponse.cts"),
+            "utf8"
+        );
+        const examplePrompt = fs.readFileSync(
+            path.join(EXAMPLE_DIR, "jsonnet/main.jsonnet"),
+            "utf8"
+        );
+
+        expect(examplePrompt).toContain("local promptTemplate");
+        expect(examplePrompt).toContain("arakoo.native");
+        expect(examplePrompt).toContain("{question}");
+        expect(exampleIndex).not.toMatch(/You are a helpful assistant/);
+        expect(exampleRpc).not.toMatch(/You are a helpful assistant/);
+        expect(exampleRpc).toContain("Palm2AI");
+    });
+});

--- a/JS/edgechains/arakoodev/testcases/palm2/chat.jsonnet
+++ b/JS/edgechains/arakoodev/testcases/palm2/chat.jsonnet
@@ -1,0 +1,22 @@
+local chatContext = |||
+  You are a concise assistant for the EdgeChains TypeScript SDK.
+|||;
+
+local chatPrompt = |||
+  What is EdgeChains used for?
+|||;
+
+local exampleInput = |||
+  What language is the JavaScript SDK written in?
+|||;
+
+local exampleOutput = |||
+  TypeScript.
+|||;
+
+{
+    chatContext: std.strReplace(chatContext, '\n', ''),
+    chatPrompt: std.strReplace(chatPrompt, '\n', ''),
+    exampleInput: std.strReplace(exampleInput, '\n', ''),
+    exampleOutput: std.strReplace(exampleOutput, '\n', ''),
+}

--- a/JS/edgechains/arakoodev/testcases/palm2/prompts.jsonnet
+++ b/JS/edgechains/arakoodev/testcases/palm2/prompts.jsonnet
@@ -1,0 +1,17 @@
+local generateTextPrompt = |||
+  Write a one-sentence product tagline for EdgeChains.
+|||;
+
+local countTokensPrompt = |||
+  How many tokens are in this sentence?
+|||;
+
+local embedText = |||
+  EdgeChains JavaScript SDK
+|||;
+
+{
+    generateTextPrompt: std.strReplace(generateTextPrompt, '\n', ''),
+    countTokensPrompt: std.strReplace(countTokensPrompt, '\n', ''),
+    embedText: std.strReplace(embedText, '\n', ''),
+}

--- a/JS/edgechains/examples/palm2-chat/.gitignore
+++ b/JS/edgechains/examples/palm2-chat/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/main.jsonnet
@@ -1,0 +1,16 @@
+local promptTemplate = |||
+  You are a helpful assistant that can answer questions based on given question
+  Answer the following question: {question}
+|||;
+
+
+local key = std.extVar('palm2_api_key');
+local UserQuestion = std.extVar('question');
+
+local promptWithQuestion = std.strReplace(promptTemplate, '{question}', UserQuestion + '\n');
+
+local main() =
+  local response = arakoo.native('palm2Call')({ prompt: promptWithQuestion, palm2ApiKey: key });
+  response;
+
+main()

--- a/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/palm2-chat/jsonnet/secrets.jsonnet
@@ -1,0 +1,5 @@
+local PALM2_API_KEY = "your-google-generative-language-api-key";
+
+{
+    "palm2_api_key": PALM2_API_KEY,
+}

--- a/JS/edgechains/examples/palm2-chat/package.json
+++ b/JS/edgechains/examples/palm2-chat/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "palm2-chat",
+    "version": "1.0.0",
+    "description": "Jsonnet-driven Google PaLM 2 (Bison) chat example",
+    "main": "index.js",
+    "type": "module",
+    "keywords": [],
+    "author": "",
+    "scripts": {
+        "start": "tsc && node --experimental-wasm-modules ./dist/index.js"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0",
+        "path": "^0.12.7"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/palm2-chat/readme.md
+++ b/JS/edgechains/examples/palm2-chat/readme.md
@@ -1,0 +1,35 @@
+# PaLM 2 Chat Example
+
+Chat with Google PaLM 2 (chat-bison) using the EdgeChains JavaScript SDK. Prompts live in Jsonnet, not TypeScript.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Configuration
+
+Add a Google Generative Language API key in `jsonnet/secrets.jsonnet`:
+
+```
+local PALM2_API_KEY = "your-google-generative-language-api-key";
+```
+
+## Usage
+
+1. Start the server:
+
+    ```bash
+    npm run start
+    ```
+
+2. Send a `POST` request to `http://localhost:3000/chat`.
+
+    ```bash
+    curl -X POST http://localhost:3000/chat \
+      -H "Content-Type: application/json" \
+      -d '{"question":"What is EdgeChains?"}'
+    ```
+
+The prompt template is in `jsonnet/main.jsonnet`. The TypeScript files only load that template and call `Palm2AI`.

--- a/JS/edgechains/examples/palm2-chat/src/index.ts
+++ b/JS/edgechains/examples/palm2-chat/src/index.ts
@@ -1,0 +1,33 @@
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+
+import { createSyncRPC } from "@arakoodev/edgechains.js/sync-rpc";
+
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+const server = new ArakooServer();
+
+const app = server.createApp();
+
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const palm2Call = createSyncRPC(path.join(__dirname, "./lib/generateResponse.cjs"));
+
+app.post("/chat", async (c: any) => {
+    try {
+        const { question } = await c.req.json();
+        const key = JSON.parse(
+            jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet"))
+        ).palm2_api_key;
+        jsonnet.extString("palm2_api_key", key);
+        jsonnet.extString("question", question || "");
+        jsonnet.javascriptCallback("palm2Call", palm2Call);
+        let response = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+        return c.json(JSON.parse(response));
+    } catch (error) {
+        console.log("error occured", error);
+    }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
+++ b/JS/edgechains/examples/palm2-chat/src/lib/generateResponse.cts
@@ -1,0 +1,13 @@
+const { Palm2AI } = require("@arakoodev/edgechains.js/ai");
+
+async function palm2Call({ prompt, palm2ApiKey }: { prompt: string; palm2ApiKey: string }) {
+    try {
+        const palm2 = new Palm2AI({ apiKey: palm2ApiKey });
+        const response = await palm2.chat({ prompt });
+        return JSON.stringify({ answer: palm2.extractMessage(response) });
+    } catch (error) {
+        return error;
+    }
+}
+
+module.exports = palm2Call;

--- a/JS/edgechains/examples/palm2-chat/tsconfig.json
+++ b/JS/edgechains/examples/palm2-chat/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "NodeNext",
+        "module": "NodeNext",
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "exclude": ["./**/*.test.ts", "vitest.config.ts"]
+}


### PR DESCRIPTION
@algora-pbc /claim #279
Fixes #279

Adds typed Google PaLM 2 (Bison) support in the JS/TS SDK with classes + TypeScript types, unit tests under a `palm2` folder, and a Jsonnet-driven example (prompts in jsonnet only).

I have read the Arakoo CLA Document and I hereby sign the CLA.
