### PR TITLE
feat(ai): AWS Comprehend PII redaction utility (#290)

### DIFF
--- a/JS/edgechains/arakoodev/package.json
+++ b/JS/edgechains/arakoodev/package.json
@@ -22,6 +22,7 @@
         "test": "vitest"
     },
     "dependencies": {
+        "@aws-sdk/client-comprehend": "^3.686.0",
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@hono/node-server": "^0.6.0",

--- a/JS/edgechains/arakoodev/src/ai/src/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/index.ts
@@ -3,3 +3,31 @@ export { GeminiAI } from "./lib/gemini/gemini.js";
 export { LlamaAI } from "./lib/llama/llama.js";
 export { RetellAI } from "./lib/retell-ai/retell.js";
 export { RetellWebClient } from "./lib/retell-ai/retellWebClient.js";
+export {
+    AWSComprehend,
+    ComprehendPIIRedactor,
+    ComprehendRedactionEndpoint,
+    DETECT_PII_ENTITIES_MAX_UTF8_BYTES,
+    PII_ENTITY_CATEGORIES,
+    PII_ENTITY_TYPES,
+    applyRedactions,
+    codePointOffsetToUtf16Index,
+    pipe,
+    resolveOverlappingEntities,
+    splitTextByUtf8ByteLimit,
+} from "./lib/comprehend/index.js";
+export type {
+    AWSComprehendOptions,
+    ComprehendClientLike,
+    ContainsPiiResult,
+    MaskMode,
+    PiiLabel,
+    RedactableMessage,
+    RedactablePromptOptions,
+    RedactPiiOptions,
+    RedactPiiResult,
+    RedactTranscriptResult,
+    RedactionReplacement,
+    TranscriptTurn,
+    Utf8TextChunk,
+} from "./lib/comprehend/index.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/apply-redaction.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/apply-redaction.ts
@@ -1,0 +1,90 @@
+import type { PiiEntity } from "@aws-sdk/client-comprehend";
+import { codePointOffsetToUtf16Index } from "./text.js";
+import type { MaskMode, RedactPiiOptions, RedactionReplacement } from "./types.js";
+
+export interface LocatedEntity {
+    begin: number;
+    end: number;
+    entity: PiiEntity;
+}
+
+export function locateEntities(text: string, entities: PiiEntity[]): LocatedEntity[] {
+    return entities
+        .map((entity) => {
+            const begin = codePointOffsetToUtf16Index(text, entity.BeginOffset || 0);
+            const end = codePointOffsetToUtf16Index(
+                text,
+                entity.EndOffset === undefined ? entity.BeginOffset || 0 : entity.EndOffset
+            );
+            return { begin, end, entity };
+        })
+        .filter(({ begin, end }) => begin >= 0 && end >= 0 && end <= text.length && begin < end);
+}
+
+/**
+ * Drop overlapping PII spans, keeping the longest (then highest-score) match.
+ * Prevents a NAME inside an ADDRESS (or similar) from corrupting later offsets.
+ */
+export function resolveOverlappingEntities(entities: LocatedEntity[]): LocatedEntity[] {
+    const sorted = [...entities].sort((left, right) => {
+        if (left.begin !== right.begin) {
+            return left.begin - right.begin;
+        }
+        const leftLength = left.end - left.begin;
+        const rightLength = right.end - right.begin;
+        if (leftLength !== rightLength) {
+            return rightLength - leftLength;
+        }
+        return (right.entity.Score || 0) - (left.entity.Score || 0);
+    });
+
+    const accepted: LocatedEntity[] = [];
+    for (const candidate of sorted) {
+        const overlaps = accepted.some(
+            (chosen) => candidate.begin < chosen.end && candidate.end > chosen.begin
+        );
+        if (!overlaps) {
+            accepted.push(candidate);
+        }
+    }
+    return accepted;
+}
+
+export function buildReplacement(
+    entity: PiiEntity,
+    original: string,
+    options: {
+        maskCharacter: string;
+        maskMode: MaskMode;
+        replacement?: RedactionReplacement;
+    }
+): string {
+    const { replacement } = options;
+    if (typeof replacement === "function") {
+        return replacement(entity, original);
+    }
+    if (typeof replacement === "string") {
+        return replacement;
+    }
+    if (options.maskMode === "MASK") {
+        return options.maskCharacter.repeat(original.length);
+    }
+    return `[${entity.Type || "PII"}]`;
+}
+
+export function applyRedactions(
+    text: string,
+    entities: PiiEntity[],
+    options: Pick<RedactPiiOptions, "maskCharacter" | "maskMode" | "replacement"> & {
+        maskCharacter: string;
+        maskMode: MaskMode;
+    }
+): string {
+    return resolveOverlappingEntities(locateEntities(text, entities))
+        .sort((left, right) => right.begin - left.begin)
+        .reduce((redactedText, { begin, end, entity }) => {
+            const original = redactedText.slice(begin, end);
+            const redaction = buildReplacement(entity, original, options);
+            return redactedText.slice(0, begin) + redaction + redactedText.slice(end);
+        }, text);
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/aws-comprehend.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/aws-comprehend.ts
@@ -1,0 +1,427 @@
+import {
+    ComprehendClient,
+    ContainsPiiEntitiesCommand,
+    DetectPiiEntitiesCommand,
+    type LanguageCode,
+    type PiiEntity,
+} from "@aws-sdk/client-comprehend";
+import { applyRedactions } from "./apply-redaction.js";
+import { splitTextByUtf8ByteLimit, uniqueLabels } from "./text.js";
+import {
+    DETECT_PII_ENTITIES_MAX_UTF8_BYTES,
+    type AWSComprehendOptions,
+    type ComprehendClientLike,
+    type ContainsPiiResult,
+    type MaskMode,
+    type PiiLabel,
+    type RedactableMessage,
+    type RedactablePromptOptions,
+    type RedactPiiOptions,
+    type RedactPiiResult,
+    type RedactTranscriptResult,
+    type RedactionReplacement,
+    type TranscriptTurn,
+    type Utf8TextChunk,
+} from "./types.js";
+
+const CHAINABLE_ENDPOINT_METHODS = new Set([
+    "chat",
+    "chatWithFunction",
+    "embeddings",
+    "generateEmbeddings",
+    "gptFn",
+    "gptFnChat",
+    "makeRequest",
+    "streamedChat",
+    "zodSchemaResponse",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function comprehendErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+    return String(error);
+}
+
+/**
+ * Detect and redact PII in prompts using Amazon Comprehend, then chain the
+ * redacted prompt into existing AI endpoint classes (`OpenAI`, `GeminiAI`,
+ * `LlamaAI`) the same way those classes already chain: Promises.
+ *
+ * Real-time analysis follows the two-pass pattern from the Comprehend PII
+ * blogs: `ContainsPiiEntities` for a cheap label scan, then `DetectPiiEntities`
+ * for offsets. Redaction is applied locally from those offsets, matching
+ * `REPLACE_WITH_PII_ENTITY_TYPE` and `MASK`.
+ *
+ * @see https://aws.amazon.com/blogs/machine-learning/detecting-and-redacting-pii-using-amazon-comprehend/
+ * @see https://aws.amazon.com/blogs/machine-learning/how-to-redact-pii-data-in-conversation-transcripts/
+ */
+export class AWSComprehend {
+    private client: ComprehendClientLike;
+    private entityTypes?: string[];
+    private languageCode: LanguageCode | string;
+    private maskCharacter: string;
+    private maskMode: MaskMode;
+    private maxUtf8Bytes: number;
+    private minScore: number;
+    private preflight: boolean;
+    private replacement?: RedactionReplacement;
+
+    constructor(options: AWSComprehendOptions = {}) {
+        this.client =
+            options.client ||
+            (new ComprehendClient({
+                region: options.region || process.env.AWS_REGION || "us-east-1",
+                credentials:
+                    options.accessKeyId && options.secretAccessKey
+                        ? {
+                              accessKeyId: options.accessKeyId,
+                              secretAccessKey: options.secretAccessKey,
+                              sessionToken: options.sessionToken,
+                          }
+                        : undefined,
+            }) as ComprehendClientLike);
+        this.entityTypes = options.entityTypes;
+        this.languageCode = options.languageCode || "en";
+        this.maskCharacter = options.maskCharacter || "*";
+        this.maskMode = options.maskMode || "REPLACE_WITH_PII_ENTITY_TYPE";
+        this.maxUtf8Bytes = options.maxUtf8Bytes || DETECT_PII_ENTITIES_MAX_UTF8_BYTES;
+        this.minScore = options.minScore ?? 0;
+        this.preflight = options.preflight !== false;
+        this.replacement = options.replacement;
+    }
+
+    /**
+     * Cheap first pass: `ContainsPiiEntities` returns labels only (no offsets).
+     */
+    async containsPii(options: RedactPiiOptions | string): Promise<ContainsPiiResult> {
+        const redactOptions = this.normalizeOptions(options);
+        if (!redactOptions.text) {
+            return { containsPii: false, labels: [], text: "" };
+        }
+
+        const labels = uniqueLabels(
+            (
+                await Promise.all(
+                    splitTextByUtf8ByteLimit(redactOptions.text, this.maxUtf8Bytes).map((chunk) =>
+                        this.sendContains(chunk.text, redactOptions)
+                    )
+                )
+            ).flat()
+        ).filter((label) => this.isRelevantLabel(label, redactOptions));
+
+        return {
+            containsPii: labels.length > 0,
+            labels,
+            text: redactOptions.text,
+        };
+    }
+
+    async detectPiiEntities(options: RedactPiiOptions | string): Promise<PiiEntity[]> {
+        const redactOptions = this.normalizeOptions(options);
+        if (!redactOptions.text) {
+            return [];
+        }
+
+        const entities = (
+            await Promise.all(
+                splitTextByUtf8ByteLimit(redactOptions.text, this.maxUtf8Bytes).map((chunk) =>
+                    this.detectChunk(chunk, redactOptions)
+                )
+            )
+        ).flat();
+
+        return entities.filter((entity) => this.isIncluded(entity, redactOptions));
+    }
+
+    async redact(options: RedactPiiOptions | string): Promise<RedactPiiResult> {
+        const redactOptions = this.normalizeOptions(options);
+        if (!redactOptions.text) {
+            return {
+                entities: [],
+                labels: [],
+                redactedText: "",
+                skippedDetection: true,
+                text: "",
+            };
+        }
+
+        const usePreflight = redactOptions.preflight ?? this.preflight;
+        const chunks = splitTextByUtf8ByteLimit(redactOptions.text, this.maxUtf8Bytes);
+
+        const perChunk = await Promise.all(
+            chunks.map(async (chunk) => {
+                const labels = usePreflight
+                    ? await this.sendContains(chunk.text, redactOptions)
+                    : [];
+                if (usePreflight && !this.hasRelevantLabels(labels, redactOptions)) {
+                    return { entities: [] as PiiEntity[], labels };
+                }
+                return {
+                    entities: await this.detectChunk(chunk, redactOptions),
+                    labels,
+                };
+            })
+        );
+
+        const labels = uniqueLabels(perChunk.flatMap((chunk) => chunk.labels)).filter((label) =>
+            this.isRelevantLabel(label, redactOptions)
+        );
+        const entities = perChunk
+            .flatMap((chunk) => chunk.entities)
+            .filter((entity) => this.isIncluded(entity, redactOptions));
+        const skippedDetection = usePreflight && entities.length === 0 && labels.length === 0;
+
+        return {
+            entities,
+            labels,
+            redactedText: applyRedactions(redactOptions.text, entities, {
+                maskCharacter: redactOptions.maskCharacter || this.maskCharacter,
+                maskMode: redactOptions.maskMode || this.maskMode,
+                replacement: redactOptions.replacement ?? this.replacement,
+            }),
+            skippedDetection,
+            text: redactOptions.text,
+        };
+    }
+
+    async redactPrompt(options: RedactPiiOptions | string): Promise<string> {
+        const result = await this.redact(options);
+        return result.redactedText;
+    }
+
+    async redactMessages(messages: RedactableMessage[]): Promise<RedactableMessage[]> {
+        return this.redactMessageArray(messages);
+    }
+
+    async redactPromptOptions<T extends RedactablePromptOptions>(options: T): Promise<T> {
+        const redactedOptions = { ...options };
+
+        if (typeof options.prompt === "string") {
+            redactedOptions.prompt = await this.redactPrompt(options.prompt);
+        }
+
+        if (typeof options.input === "string") {
+            redactedOptions.input = await this.redactPrompt(options.input);
+        } else if (Array.isArray(options.input)) {
+            redactedOptions.input = await Promise.all(
+                options.input.map((item) =>
+                    typeof item === "string" ? this.redactPrompt(item) : item
+                )
+            );
+        }
+
+        if (Array.isArray(options.messages)) {
+            redactedOptions.messages = await this.redactMessageArray(options.messages);
+        }
+
+        return redactedOptions;
+    }
+
+    /**
+     * Redact a contact-center / conversation transcript turn by turn.
+     * @see https://aws.amazon.com/blogs/machine-learning/how-to-redact-pii-data-in-conversation-transcripts/
+     */
+    async redactTranscript(turns: TranscriptTurn[]): Promise<RedactTranscriptResult> {
+        const results = await Promise.all(turns.map((turn) => this.redact(turn.text || "")));
+        return {
+            entities: results.flatMap((result) => result.entities),
+            labels: uniqueLabels(results.flatMap((result) => result.labels)),
+            turns: turns.map((turn, index) => ({
+                ...turn,
+                text: results[index].redactedText,
+            })),
+        };
+    }
+
+    /** Operator for `pipe(prompt, redactor.asOperator(), (safe) => openai.chat({ prompt: safe }))`. */
+    asOperator(overrides: Omit<RedactPiiOptions, "text"> = {}) {
+        return (text: string) => this.redactPrompt({ ...overrides, text });
+    }
+
+    /** Operator that redacts `prompt` / `messages` / `input` on endpoint options. */
+    asPromptOperator() {
+        return <T extends RedactablePromptOptions>(options: T) => this.redactPromptOptions(options);
+    }
+
+    /**
+     * Wrap an existing endpoint class (`OpenAI`, `GeminiAI`, `LlamaAI`, or a
+     * compatible `chat()` implementation) so PII is redacted before the call.
+     *
+     * The current JS SDK is Promise-based rather than RxJS; this is the same
+     * chaining model used by `OpenAI.chat()` and the Jsonnet native callbacks.
+     */
+    chain<T extends object>(endpoint: T): T {
+        return new ComprehendRedactionEndpoint(this, endpoint).asEndpoint();
+    }
+
+    async redactCallArgs(args: unknown[]): Promise<unknown[]> {
+        if (args.length === 0) {
+            return args;
+        }
+
+        const first = args[0];
+        if (typeof first === "string") {
+            return [await this.redactPrompt(first), ...args.slice(1)];
+        }
+        if (Array.isArray(first)) {
+            return [await this.redactArrayArg(first), ...args.slice(1)];
+        }
+        if (isRecord(first)) {
+            return [
+                await this.redactPromptOptions(first as RedactablePromptOptions),
+                ...args.slice(1),
+            ];
+        }
+        return args;
+    }
+
+    private async detectChunk(
+        chunk: Utf8TextChunk,
+        options: RedactPiiOptions
+    ): Promise<PiiEntity[]> {
+        const response = await this.sendDetect(chunk.text, options);
+        return (response.Entities || []).map((entity) => ({
+            ...entity,
+            BeginOffset:
+                entity.BeginOffset === undefined
+                    ? undefined
+                    : entity.BeginOffset + chunk.codePointOffset,
+            EndOffset:
+                entity.EndOffset === undefined
+                    ? undefined
+                    : entity.EndOffset + chunk.codePointOffset,
+        }));
+    }
+
+    private async sendContains(text: string, options: RedactPiiOptions): Promise<PiiLabel[]> {
+        try {
+            const response = (await this.client.send(
+                new ContainsPiiEntitiesCommand({
+                    LanguageCode: (options.languageCode || this.languageCode) as LanguageCode,
+                    Text: text,
+                })
+            )) as { Labels?: PiiLabel[] };
+            return response.Labels || [];
+        } catch (error) {
+            throw new Error(
+                `Amazon Comprehend ContainsPiiEntities failed: ${comprehendErrorMessage(error)}`
+            );
+        }
+    }
+
+    private async sendDetect(
+        text: string,
+        options: RedactPiiOptions
+    ): Promise<{ Entities?: PiiEntity[] }> {
+        try {
+            return (await this.client.send(
+                new DetectPiiEntitiesCommand({
+                    LanguageCode: (options.languageCode || this.languageCode) as LanguageCode,
+                    Text: text,
+                })
+            )) as { Entities?: PiiEntity[] };
+        } catch (error) {
+            throw new Error(
+                `Amazon Comprehend DetectPiiEntities failed: ${comprehendErrorMessage(error)}`
+            );
+        }
+    }
+
+    private async redactArrayArg(items: unknown[]): Promise<unknown[]> {
+        return Promise.all(
+            items.map(async (item) => {
+                if (typeof item === "string") {
+                    return this.redactPrompt(item);
+                }
+                if (isRecord(item) && typeof item.content === "string") {
+                    return {
+                        ...item,
+                        content: await this.redactPrompt(item.content),
+                    };
+                }
+                return item;
+            })
+        );
+    }
+
+    private async redactMessageArray(messages: RedactableMessage[]): Promise<RedactableMessage[]> {
+        return Promise.all(
+            messages.map(async (message) => {
+                if (typeof message.content !== "string") {
+                    return { ...message };
+                }
+                return {
+                    ...message,
+                    content: await this.redactPrompt(message.content),
+                };
+            })
+        );
+    }
+
+    private normalizeOptions(options: RedactPiiOptions | string): RedactPiiOptions {
+        return typeof options === "string" ? { text: options } : options;
+    }
+
+    private isIncluded(entity: PiiEntity, options: RedactPiiOptions): boolean {
+        if (entity.BeginOffset === undefined || entity.EndOffset === undefined) {
+            return false;
+        }
+        if ((entity.Score || 0) < (options.minScore ?? this.minScore)) {
+            return false;
+        }
+        const allowedTypes = options.entityTypes || this.entityTypes;
+        return !allowedTypes || allowedTypes.includes(entity.Type || "");
+    }
+
+    private isRelevantLabel(label: PiiLabel, options: RedactPiiOptions): boolean {
+        if ((label.Score || 0) < (options.minScore ?? this.minScore)) {
+            return false;
+        }
+        const allowedTypes = options.entityTypes || this.entityTypes;
+        return !allowedTypes || allowedTypes.includes(label.Name || "");
+    }
+
+    private hasRelevantLabels(labels: PiiLabel[], options: RedactPiiOptions): boolean {
+        return labels.some((label) => this.isRelevantLabel(label, options));
+    }
+}
+
+/**
+ * Endpoint-style wrapper so Comprehend redaction can sit in front of any
+ * existing AI class that exposes `chat()` (or the other prompt-taking methods).
+ */
+export class ComprehendRedactionEndpoint<T extends object> {
+    constructor(
+        private readonly comprehend: AWSComprehend,
+        private readonly endpoint: T
+    ) {}
+
+    asEndpoint(): T {
+        const comprehend = this.comprehend;
+        const endpoint = this.endpoint;
+
+        return new Proxy(endpoint, {
+            get(target, prop, receiver) {
+                const value = Reflect.get(target, prop, receiver);
+                if (typeof value !== "function") {
+                    return value;
+                }
+                if (!CHAINABLE_ENDPOINT_METHODS.has(String(prop))) {
+                    return (...args: unknown[]) => value.apply(target, args);
+                }
+                return async (...args: unknown[]) => {
+                    const nextArgs = await comprehend.redactCallArgs(args);
+                    return value.apply(target, nextArgs);
+                };
+            },
+        });
+    }
+}
+
+/** Compatibility alias used by some call sites / earlier drafts. */
+export class ComprehendPIIRedactor extends AWSComprehend {}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/index.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/index.ts
@@ -1,0 +1,26 @@
+export { AWSComprehend, ComprehendPIIRedactor, ComprehendRedactionEndpoint } from "./aws-comprehend.js";
+export { applyRedactions, resolveOverlappingEntities } from "./apply-redaction.js";
+export { pipe } from "./pipe.js";
+export { codePointOffsetToUtf16Index, splitTextByUtf8ByteLimit, uniqueLabels } from "./text.js";
+export {
+    DETECT_PII_ENTITIES_MAX_UTF8_BYTES,
+    PII_ENTITY_CATEGORIES,
+    PII_ENTITY_TYPES,
+} from "./types.js";
+export type {
+    AWSComprehendOptions,
+    ComprehendClientLike,
+    ContainsPiiResult,
+    LanguageCode,
+    MaskMode,
+    PiiEntity,
+    PiiLabel,
+    RedactableMessage,
+    RedactablePromptOptions,
+    RedactPiiOptions,
+    RedactPiiResult,
+    RedactTranscriptResult,
+    RedactionReplacement,
+    TranscriptTurn,
+    Utf8TextChunk,
+} from "./types.js";

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/pipe.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/pipe.ts
@@ -1,0 +1,36 @@
+export type Operator<T, R> = (value: T) => R | Promise<R>;
+
+/**
+ * Promise/async equivalent of the old RxJS `pipe` used by EdgeChains endpoints.
+ * Each operator receives the resolved value of the previous step.
+ */
+export async function pipe<A>(value: A | Promise<A>): Promise<A>;
+export async function pipe<A, B>(value: A | Promise<A>, fn1: Operator<A, B>): Promise<B>;
+export async function pipe<A, B, C>(
+    value: A | Promise<A>,
+    fn1: Operator<A, B>,
+    fn2: Operator<B, C>
+): Promise<C>;
+export async function pipe<A, B, C, D>(
+    value: A | Promise<A>,
+    fn1: Operator<A, B>,
+    fn2: Operator<B, C>,
+    fn3: Operator<C, D>
+): Promise<D>;
+export async function pipe<A, B, C, D, E>(
+    value: A | Promise<A>,
+    fn1: Operator<A, B>,
+    fn2: Operator<B, C>,
+    fn3: Operator<C, D>,
+    fn4: Operator<D, E>
+): Promise<E>;
+export async function pipe(
+    value: unknown,
+    ...fns: Array<Operator<unknown, unknown>>
+): Promise<unknown> {
+    let current = await value;
+    for (const fn of fns) {
+        current = await fn(current);
+    }
+    return current;
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/text.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/text.ts
@@ -1,0 +1,129 @@
+import type { Utf8TextChunk } from "./types.js";
+
+function utf8BytesForCodePoint(codePoint: number): number {
+    if (codePoint <= 0x7f) {
+        return 1;
+    }
+    if (codePoint <= 0x7ff) {
+        return 2;
+    }
+    if (codePoint <= 0xffff) {
+        return 3;
+    }
+    return 4;
+}
+
+function utf16WidthForCodePoint(codePoint: number): number {
+    return codePoint > 0xffff ? 2 : 1;
+}
+
+/**
+ * Convert an Amazon Comprehend offset (Unicode code points) into a JavaScript
+ * UTF-16 code-unit index for `String.slice`.
+ *
+ * Astral characters (emoji) are one Comprehend code point but two JS units;
+ * using the raw offset with `slice` shifts later entities and can leave PII.
+ * Returns -1 when the offset is past the end of `text`.
+ */
+export function codePointOffsetToUtf16Index(text: string, codePointOffset: number): number {
+    if (codePointOffset <= 0) {
+        return 0;
+    }
+
+    let utf16Index = 0;
+    let codePoints = 0;
+    while (utf16Index < text.length && codePoints < codePointOffset) {
+        const codePoint = text.codePointAt(utf16Index);
+        if (codePoint === undefined) {
+            break;
+        }
+        utf16Index += utf16WidthForCodePoint(codePoint);
+        codePoints += 1;
+    }
+    return codePoints === codePointOffset ? utf16Index : -1;
+}
+
+/**
+ * Split `text` into chunks whose UTF-8 encoding is at most `maxUtf8Bytes`.
+ * Splits on Unicode code-point boundaries (never through a surrogate pair)
+ * and prefers whitespace so PII spans are less likely to be cut in half.
+ */
+export function splitTextByUtf8ByteLimit(text: string, maxUtf8Bytes: number): Utf8TextChunk[] {
+    if (!text) {
+        return [];
+    }
+    if (maxUtf8Bytes < 1) {
+        throw new Error("maxUtf8Bytes must be at least 1");
+    }
+
+    const chunks: Utf8TextChunk[] = [];
+    let jsIndex = 0;
+    let codePointOffset = 0;
+
+    while (jsIndex < text.length) {
+        let end = jsIndex;
+        let bytes = 0;
+        let codePoints = 0;
+        let breakEnd = -1;
+        let breakBytes = 0;
+        let breakCodePoints = 0;
+
+        while (end < text.length) {
+            const codePoint = text.codePointAt(end);
+            if (codePoint === undefined) {
+                break;
+            }
+            const charBytes = utf8BytesForCodePoint(codePoint);
+            if (bytes + charBytes > maxUtf8Bytes) {
+                break;
+            }
+
+            const width = utf16WidthForCodePoint(codePoint);
+            const char = text.slice(end, end + width);
+            bytes += charBytes;
+            end += width;
+            codePoints += 1;
+
+            if (/\s/u.test(char)) {
+                breakEnd = end;
+                breakBytes = bytes;
+                breakCodePoints = codePoints;
+            }
+        }
+
+        if (end < text.length && breakEnd > jsIndex && breakBytes >= maxUtf8Bytes / 2) {
+            end = breakEnd;
+            codePoints = breakCodePoints;
+        }
+
+        if (end === jsIndex) {
+            const codePoint = text.codePointAt(end);
+            if (codePoint === undefined) {
+                break;
+            }
+            end += utf16WidthForCodePoint(codePoint);
+            codePoints = 1;
+        }
+
+        chunks.push({
+            codePointOffset,
+            text: text.slice(jsIndex, end),
+        });
+        jsIndex = end;
+        codePointOffset += codePoints;
+    }
+
+    return chunks;
+}
+
+export function uniqueLabels<T extends { Name?: string; Score?: number }>(labels: T[]): T[] {
+    const byName = new Map<string, T>();
+    for (const label of labels) {
+        const name = label.Name || "";
+        const existing = byName.get(name);
+        if (!existing || (label.Score || 0) > (existing.Score || 0)) {
+            byName.set(name, label);
+        }
+    }
+    return [...byName.values()];
+}

--- a/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/types.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/lib/comprehend/types.ts
@@ -1,0 +1,137 @@
+import type { LanguageCode, PiiEntity } from "@aws-sdk/client-comprehend";
+
+/**
+ * Amazon Comprehend redaction modes from the PII detection/redaction APIs.
+ * @see https://aws.amazon.com/blogs/machine-learning/detecting-and-redacting-pii-using-amazon-comprehend/
+ */
+export type MaskMode = "REPLACE_WITH_PII_ENTITY_TYPE" | "MASK";
+
+/**
+ * PII entity types documented in the Amazon Comprehend PII blog / API.
+ * @see https://aws.amazon.com/blogs/machine-learning/detecting-and-redacting-pii-using-amazon-comprehend/
+ */
+export const PII_ENTITY_CATEGORIES = {
+    FINANCIAL: [
+        "BANK_ACCOUNT_NUMBER",
+        "BANK_ROUTING",
+        "CREDIT_DEBIT_NUMBER",
+        "CREDIT_DEBIT_CVV",
+        "CREDIT_DEBIT_EXPIRY",
+        "PIN",
+    ],
+    PERSONAL: ["NAME", "ADDRESS", "PHONE", "EMAIL", "AGE"],
+    TECHNICAL_SECURITY: [
+        "USERNAME",
+        "PASSWORD",
+        "URL",
+        "AWS_ACCESS_KEY",
+        "AWS_SECRET_KEY",
+        "IP_ADDRESS",
+        "MAC_ADDRESS",
+    ],
+    NATIONAL: ["SSN", "PASSPORT_NUMBER", "DRIVER_ID"],
+    OTHER: ["DATE_TIME"],
+} as const;
+
+export const PII_ENTITY_TYPES = Object.values(PII_ENTITY_CATEGORIES).flat();
+
+/** Synchronous DetectPiiEntities / ContainsPiiEntities accept at most 100 KB of UTF-8 text. */
+export const DETECT_PII_ENTITIES_MAX_UTF8_BYTES = 100 * 1024;
+
+export type ComprehendClientLike = {
+    send: (command: unknown, ...rest: unknown[]) => Promise<unknown>;
+};
+
+export type RedactionReplacement = string | ((entity: PiiEntity, original: string) => string);
+
+export interface PiiLabel {
+    Name?: string;
+    Score?: number;
+}
+
+export interface Utf8TextChunk {
+    codePointOffset: number;
+    text: string;
+}
+
+export interface AWSComprehendOptions {
+    accessKeyId?: string;
+    client?: ComprehendClientLike;
+    entityTypes?: string[];
+    languageCode?: LanguageCode | string;
+    maskCharacter?: string;
+    maskMode?: MaskMode;
+    /**
+     * Maximum UTF-8 bytes sent in one real-time Comprehend call.
+     * Defaults to the 100 KB synchronous limit; longer prompts are split on
+     * code-point boundaries (preferring whitespace) and offsets are rebased.
+     */
+    maxUtf8Bytes?: number;
+    minScore?: number;
+    /**
+     * When true (default), `redact()` first calls `ContainsPiiEntities` and
+     * only runs `DetectPiiEntities` on chunks that still look like they contain
+     * in-scope PII — the two-pass pattern from the Comprehend PII blogs.
+     */
+    preflight?: boolean;
+    region?: string;
+    replacement?: RedactionReplacement;
+    secretAccessKey?: string;
+    sessionToken?: string;
+}
+
+export interface RedactPiiOptions {
+    entityTypes?: string[];
+    languageCode?: LanguageCode | string;
+    maskCharacter?: string;
+    maskMode?: MaskMode;
+    minScore?: number;
+    preflight?: boolean;
+    replacement?: RedactionReplacement;
+    text: string;
+}
+
+export interface ContainsPiiResult {
+    containsPii: boolean;
+    labels: PiiLabel[];
+    text: string;
+}
+
+export interface RedactPiiResult {
+    entities: PiiEntity[];
+    labels: PiiLabel[];
+    redactedText: string;
+    skippedDetection: boolean;
+    text: string;
+}
+
+export interface RedactableMessage {
+    content?: string;
+    role?: string;
+    [key: string]: unknown;
+}
+
+export interface RedactablePromptOptions {
+    input?: string | string[];
+    messages?: RedactableMessage[];
+    prompt?: string;
+    [key: string]: unknown;
+}
+
+/**
+ * One turn in a contact-center / conversation transcript.
+ * @see https://aws.amazon.com/blogs/machine-learning/how-to-redact-pii-data-in-conversation-transcripts/
+ */
+export interface TranscriptTurn {
+    speaker: string;
+    text: string;
+    [key: string]: unknown;
+}
+
+export interface RedactTranscriptResult {
+    entities: PiiEntity[];
+    labels: PiiLabel[];
+    turns: TranscriptTurn[];
+}
+
+export type { LanguageCode, PiiEntity };

--- a/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehend.test.ts
+++ b/JS/edgechains/arakoodev/src/ai/src/tests/awsComprehend.test.ts
@@ -1,0 +1,570 @@
+import {
+    ContainsPiiEntitiesCommand,
+    DetectPiiEntitiesCommand,
+    type PiiEntity,
+} from "@aws-sdk/client-comprehend";
+import { describe, expect, it, vi } from "vitest";
+import {
+    AWSComprehend,
+    ComprehendPIIRedactor,
+    PII_ENTITY_CATEGORIES,
+    applyRedactions,
+    codePointOffsetToUtf16Index,
+    pipe,
+    resolveOverlappingEntities,
+    splitTextByUtf8ByteLimit,
+} from "../lib/comprehend/index.js";
+import { locateEntities } from "../lib/comprehend/apply-redaction.js";
+
+const SAMPLE = "My name is John Smith, SSN 123-45-6789";
+
+function entitiesForSample(): PiiEntity[] {
+    return [
+        { Score: 0.99, Type: "NAME", BeginOffset: 11, EndOffset: 21 },
+        { Score: 0.99, Type: "SSN", BeginOffset: 27, EndOffset: 38 },
+    ];
+}
+
+function labelsForSample() {
+    return [
+        { Name: "NAME", Score: 0.99 },
+        { Name: "SSN", Score: 0.99 },
+    ];
+}
+
+function createSend(
+    entities: PiiEntity[] = entitiesForSample(),
+    labels = labelsForSample()
+) {
+    return vi.fn().mockImplementation(async (command: unknown) => {
+        if (command instanceof ContainsPiiEntitiesCommand) {
+            return { Labels: labels };
+        }
+        return { Entities: entities };
+    });
+}
+
+function createRedactor(
+    send = createSend(),
+    options: ConstructorParameters<typeof AWSComprehend>[0] = {}
+) {
+    return {
+        send,
+        redactor: new AWSComprehend({ client: { send }, ...options }),
+    };
+}
+
+describe("AWSComprehend", () => {
+    it("skips Amazon Comprehend when the text is empty", async () => {
+        const { send, redactor } = createRedactor();
+        const result = await redactor.redact("");
+
+        expect(send).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            entities: [],
+            labels: [],
+            redactedText: "",
+            skippedDetection: true,
+            text: "",
+        });
+    });
+
+    it("uses ContainsPiiEntities as the cheap first pass", async () => {
+        const { send, redactor } = createRedactor();
+        const result = await redactor.containsPii(SAMPLE);
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0]).toBeInstanceOf(ContainsPiiEntitiesCommand);
+        expect(send.mock.calls[0][0].input).toMatchObject({
+            LanguageCode: "en",
+            Text: SAMPLE,
+        });
+        expect(result.containsPii).toBe(true);
+        expect(result.labels.map((label) => label.Name)).toEqual(["NAME", "SSN"]);
+    });
+
+    it("detects PII entities through DetectPiiEntities", async () => {
+        const { send, redactor } = createRedactor();
+        const entities = await redactor.detectPiiEntities(SAMPLE);
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0]).toBeInstanceOf(DetectPiiEntitiesCommand);
+        expect(send.mock.calls[0][0].input).toMatchObject({
+            LanguageCode: "en",
+            Text: SAMPLE,
+        });
+        expect(entities).toHaveLength(2);
+        expect(entities.map((entity) => entity.Type)).toEqual(["NAME", "SSN"]);
+    });
+
+    it("skips DetectPiiEntities when ContainsPiiEntities finds nothing", async () => {
+        const send = createSend([], []);
+        const redactor = new AWSComprehend({ client: { send } });
+        const result = await redactor.redact("no personal data here");
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0]).toBeInstanceOf(ContainsPiiEntitiesCommand);
+        expect(result.skippedDetection).toBe(true);
+        expect(result.redactedText).toBe("no personal data here");
+        expect(result.entities).toEqual([]);
+    });
+
+    it("runs DetectPiiEntities only after ContainsPiiEntities finds labels", async () => {
+        const { send, redactor } = createRedactor();
+        const result = await redactor.redact(SAMPLE);
+
+        expect(send.mock.calls.map((call) => call[0].constructor.name)).toEqual([
+            "ContainsPiiEntitiesCommand",
+            "DetectPiiEntitiesCommand",
+        ]);
+        expect(result.skippedDetection).toBe(false);
+        expect(result.redactedText).toBe("My name is [NAME], SSN [SSN]");
+        expect(result.labels.map((label) => label.Name)).toEqual(["NAME", "SSN"]);
+    });
+
+    it("can disable the ContainsPiiEntities preflight", async () => {
+        const { send, redactor } = createRedactor(undefined, { preflight: false });
+        await redactor.redact(SAMPLE);
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0]).toBeInstanceOf(DetectPiiEntitiesCommand);
+    });
+
+    it("filters entities below minScore", async () => {
+        const send = createSend([
+            { Score: 0.4, Type: "NAME", BeginOffset: 11, EndOffset: 21 },
+            { Score: 0.99, Type: "SSN", BeginOffset: 27, EndOffset: 38 },
+        ]);
+        const redactor = new AWSComprehend({ client: { send }, minScore: 0.5, preflight: false });
+        const entities = await redactor.detectPiiEntities(SAMPLE);
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].Type).toBe("SSN");
+    });
+
+    it("filters entities by type", async () => {
+        const { redactor } = createRedactor(undefined, { entityTypes: ["SSN"], preflight: false });
+        const entities = await redactor.detectPiiEntities(SAMPLE);
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].Type).toBe("SSN");
+    });
+
+    it("skips detection when preflight labels are outside the requested entity types", async () => {
+        const send = createSend(entitiesForSample(), [{ Name: "EMAIL", Score: 0.99 }]);
+        const redactor = new AWSComprehend({
+            client: { send },
+            entityTypes: ["SSN"],
+        });
+        const result = await redactor.redact(SAMPLE);
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(send.mock.calls[0][0]).toBeInstanceOf(ContainsPiiEntitiesCommand);
+        expect(result.entities).toEqual([]);
+        expect(result.redactedText).toBe(SAMPLE);
+    });
+
+    it("ignores entities that are missing offsets", async () => {
+        const send = createSend([
+            { Score: 0.99, Type: "NAME" },
+            { Score: 0.99, Type: "SSN", BeginOffset: 27, EndOffset: 38 },
+        ]);
+        const redactor = new AWSComprehend({ client: { send }, preflight: false });
+        const entities = await redactor.detectPiiEntities(SAMPLE);
+
+        expect(entities).toHaveLength(1);
+        expect(entities[0].Type).toBe("SSN");
+    });
+
+    it("redacts with PII entity type placeholders by default", async () => {
+        const { redactor } = createRedactor();
+        const result = await redactor.redact(SAMPLE);
+
+        expect(result.redactedText).toBe("My name is [NAME], SSN [SSN]");
+        expect(result.text).toBe(SAMPLE);
+        expect(result.entities).toHaveLength(2);
+    });
+
+    it("masks PII in place while preserving span length", async () => {
+        const { redactor } = createRedactor(undefined, { maskMode: "MASK" });
+        const redacted = await redactor.redactPrompt(SAMPLE);
+
+        expect(redacted).toBe("My name is **********, SSN ***********");
+        expect(redacted.length).toBe(SAMPLE.length);
+    });
+
+    it("uses a custom mask character", async () => {
+        const { redactor } = createRedactor(undefined, {
+            maskMode: "MASK",
+            maskCharacter: "#",
+        });
+        const redacted = await redactor.redactPrompt(SAMPLE);
+
+        expect(redacted).toBe("My name is ##########, SSN ###########");
+    });
+
+    it("applies a custom replacement string", async () => {
+        const { redactor } = createRedactor(undefined, { replacement: "[REDACTED]" });
+        const redacted = await redactor.redactPrompt(SAMPLE);
+
+        expect(redacted).toBe("My name is [REDACTED], SSN [REDACTED]");
+    });
+
+    it("applies a custom replacement function", async () => {
+        const { redactor } = createRedactor(undefined, {
+            replacement: (entity) => `<${entity.Type}>`,
+        });
+        const redacted = await redactor.redactPrompt(SAMPLE);
+
+        expect(redacted).toBe("My name is <NAME>, SSN <SSN>");
+    });
+
+    it("keeps the longer span when two PII entities overlap", async () => {
+        const text = "John Smith lives at 1 Main St";
+        const send = createSend([
+            { Score: 0.9, Type: "NAME", BeginOffset: 0, EndOffset: 10 },
+            { Score: 0.95, Type: "ADDRESS", BeginOffset: 0, EndOffset: 29 },
+        ]);
+        const redactor = new AWSComprehend({ client: { send }, preflight: false });
+        const redacted = await redactor.redactPrompt(text);
+
+        expect(redacted).toBe("[ADDRESS]");
+        expect(redacted).not.toContain("John");
+    });
+
+    it("redacts a conversation transcript turn by turn", async () => {
+        const send = vi.fn().mockImplementation(async (command: unknown) => {
+            const text =
+                command &&
+                typeof command === "object" &&
+                "input" in command &&
+                command.input &&
+                typeof command.input === "object" &&
+                "Text" in command.input
+                    ? String((command.input as { Text?: string }).Text || "")
+                    : "";
+
+            if (command instanceof ContainsPiiEntitiesCommand) {
+                if (text.includes("John Stiles")) {
+                    return { Labels: [{ Name: "NAME", Score: 0.99 }] };
+                }
+                if (text.includes("555-456-7890")) {
+                    return { Labels: [{ Name: "PHONE", Score: 0.99 }] };
+                }
+                return { Labels: [] };
+            }
+
+            if (text.includes("John Stiles")) {
+                const begin = text.indexOf("John Stiles");
+                return {
+                    Entities: [
+                        {
+                            Score: 0.99,
+                            Type: "NAME",
+                            BeginOffset: begin,
+                            EndOffset: begin + "John Stiles".length,
+                        },
+                    ],
+                };
+            }
+            if (text.includes("555-456-7890")) {
+                const begin = text.indexOf("555-456-7890");
+                return {
+                    Entities: [
+                        {
+                            Score: 0.99,
+                            Type: "PHONE",
+                            BeginOffset: begin,
+                            EndOffset: begin + "555-456-7890".length,
+                        },
+                    ],
+                };
+            }
+            return { Entities: [] };
+        });
+        const redactor = new AWSComprehend({ client: { send } });
+        const result = await redactor.redactTranscript([
+            { speaker: "Agent", text: "Whom am I speaking with?" },
+            { speaker: "Caller", text: "Hello, my name is John Stiles." },
+            { speaker: "Agent", text: "The number we have on file is 555-456-7890." },
+        ]);
+
+        expect(result.turns[0].text).toBe("Whom am I speaking with?");
+        expect(result.turns[1].text).toBe("Hello, my name is [NAME].");
+        expect(result.turns[2].text).toBe("The number we have on file is [PHONE].");
+        expect(result.entities.map((entity) => entity.Type)).toEqual(["NAME", "PHONE"]);
+    });
+
+    it("wraps AWS errors with a Comprehend-specific message", async () => {
+        const send = vi.fn().mockRejectedValue(new Error("ExpiredToken"));
+        const redactor = new AWSComprehend({ client: { send }, preflight: false });
+
+        await expect(redactor.redact(SAMPLE)).rejects.toThrow(
+            "Amazon Comprehend DetectPiiEntities failed: ExpiredToken"
+        );
+    });
+
+    it("honors a per-call language override", async () => {
+        const { send, redactor } = createRedactor();
+        await redactor.detectPiiEntities({ text: SAMPLE, languageCode: "es" });
+
+        expect(send.mock.calls[0][0].input.LanguageCode).toBe("es");
+    });
+
+    it("redacts prompt strings and chat messages together", async () => {
+        const { redactor } = createRedactor();
+        const options = await redactor.redactPromptOptions({
+            prompt: SAMPLE,
+            temperature: 0.2,
+            messages: [
+                { role: "user", content: SAMPLE },
+                { role: "system", content: 42 as unknown as string },
+            ],
+        });
+
+        expect(options.temperature).toBe(0.2);
+        expect(options.prompt).toBe("My name is [NAME], SSN [SSN]");
+        expect(options.messages?.[0].content).toBe("My name is [NAME], SSN [SSN]");
+        expect(options.messages?.[1].content).toBe(42);
+    });
+
+    it("redacts embedding input arrays", async () => {
+        const { redactor } = createRedactor();
+        const options = await redactor.redactPromptOptions({
+            model: "text-embedding-ada-002",
+            input: [SAMPLE, "no pii here"],
+        });
+
+        expect(options.input).toEqual(["My name is [NAME], SSN [SSN]", "no pii here"]);
+    });
+
+    it("chains with an existing endpoint chat() method", async () => {
+        const { redactor } = createRedactor();
+        const chat = vi.fn().mockResolvedValue({ content: "ok" });
+        const endpoint = {
+            apiKey: "test",
+            chat,
+            ping() {
+                return this.apiKey;
+            },
+        };
+
+        const chained = redactor.chain(endpoint);
+        const response = await chained.chat({ prompt: SAMPLE, temperature: 0.1 });
+
+        expect(response).toEqual({ content: "ok" });
+        expect(chat).toHaveBeenCalledWith({
+            prompt: "My name is [NAME], SSN [SSN]",
+            temperature: 0.1,
+        });
+        expect(chained.ping()).toBe("test");
+    });
+
+    it("redacts string arguments passed to gptFn-style endpoint methods", async () => {
+        const { redactor } = createRedactor();
+        const gptFn = vi.fn().mockResolvedValue("answer");
+        const chained = redactor.chain({ gptFn });
+
+        await chained.gptFn(SAMPLE);
+
+        expect(gptFn).toHaveBeenCalledWith("My name is [NAME], SSN [SSN]");
+    });
+
+    it("pipes redaction into an endpoint the same way other async chains work", async () => {
+        const { redactor } = createRedactor();
+        const openai = {
+            chat: vi.fn(async ({ prompt }: { prompt: string }) => ({ content: prompt })),
+        };
+
+        const response = await pipe(
+            SAMPLE,
+            redactor.asOperator(),
+            (prompt) => openai.chat({ prompt })
+        );
+
+        expect(response).toEqual({ content: "My name is [NAME], SSN [SSN]" });
+    });
+
+    it("exposes asPromptOperator for endpoint option objects", async () => {
+        const { redactor } = createRedactor();
+        const openai = {
+            chat: vi.fn(async (options: { prompt: string }) => options.prompt),
+        };
+
+        const response = await pipe(
+            { prompt: SAMPLE, max_tokens: 16 },
+            redactor.asPromptOperator(),
+            (options) => openai.chat(options as { prompt: string })
+        );
+
+        expect(response).toBe("My name is [NAME], SSN [SSN]");
+        expect(openai.chat).toHaveBeenCalledWith({
+            prompt: "My name is [NAME], SSN [SSN]",
+            max_tokens: 16,
+        });
+    });
+
+    it("keeps ComprehendPIIRedactor as a compatibility alias", () => {
+        expect(new ComprehendPIIRedactor({ client: { send: vi.fn() } })).toBeInstanceOf(
+            AWSComprehend
+        );
+    });
+
+    it("exports the PII categories from the Comprehend blog", () => {
+        expect(PII_ENTITY_CATEGORIES.NATIONAL).toContain("SSN");
+        expect(PII_ENTITY_CATEGORIES.PERSONAL).toContain("EMAIL");
+    });
+
+    it("redacts gptFnChat-style message arrays passed as the first argument", async () => {
+        const { redactor } = createRedactor();
+        const gptFnChat = vi.fn().mockResolvedValue("answer");
+        const chained = redactor.chain({ gptFnChat });
+
+        await chained.gptFnChat([
+            { role: "system", content: "You are helpful" },
+            { role: "user", content: SAMPLE },
+        ]);
+
+        expect(gptFnChat).toHaveBeenCalledWith([
+            { role: "system", content: "You are helpful" },
+            { role: "user", content: "My name is [NAME], SSN [SSN]" },
+        ]);
+    });
+
+    it("redacts string arrays passed as the first chain argument", async () => {
+        const { redactor } = createRedactor();
+        const embeddings = vi.fn().mockResolvedValue([]);
+        const chained = redactor.chain({ embeddings });
+
+        await chained.embeddings([SAMPLE, "no pii here"]);
+
+        expect(embeddings).toHaveBeenCalledWith(["My name is [NAME], SSN [SSN]", "no pii here"]);
+    });
+
+    it("maps Comprehend code-point offsets past emoji onto UTF-16 slice indices", async () => {
+        const text = "😀 SSN 123-45-6789";
+        const send = createSend(
+            [{ Score: 0.99, Type: "SSN", BeginOffset: 6, EndOffset: 17 }],
+            [{ Name: "SSN", Score: 0.99 }]
+        );
+        const redactor = new AWSComprehend({ client: { send } });
+        const redacted = await redactor.redactPrompt(text);
+
+        expect(redacted).toBe("😀 SSN [SSN]");
+        expect(redacted).not.toContain("123-45-6789");
+        expect(redacted.startsWith("😀")).toBe(true);
+    });
+
+    it("keeps PII intact when several astral characters precede the entity", async () => {
+        const text = "👨‍👩‍👧‍👦 contact Jane at 555-0100";
+        const janeCodePointOffset = [...text].indexOf("J");
+        const jane = "Jane";
+        const send = createSend(
+            [
+                {
+                    Score: 0.99,
+                    Type: "NAME",
+                    BeginOffset: janeCodePointOffset,
+                    EndOffset: janeCodePointOffset + [...jane].length,
+                },
+            ],
+            [{ Name: "NAME", Score: 0.99 }]
+        );
+        const redactor = new AWSComprehend({ client: { send } });
+        const redacted = await redactor.redactPrompt(text);
+
+        expect(redacted).toContain("[NAME]");
+        expect(redacted).not.toContain("Jane");
+        expect(redacted.startsWith("👨‍👩‍👧‍👦")).toBe(true);
+    });
+
+    it("splits prompts over the DetectPiiEntities UTF-8 limit and rebases offsets", async () => {
+        const prefix = "aaaaaaaaaa";
+        const ssn = "123-45-6789";
+        const text = `${prefix} ${ssn}`;
+        const send = vi.fn().mockImplementation(async (command: { input?: { Text?: string } }) => {
+            const chunk = command.input?.Text || "";
+            if (command instanceof ContainsPiiEntitiesCommand) {
+                return {
+                    Labels: chunk.includes(ssn) ? [{ Name: "SSN", Score: 0.99 }] : [],
+                };
+            }
+            if (chunk.includes(ssn)) {
+                const begin = chunk.indexOf(ssn);
+                return {
+                    Entities: [
+                        {
+                            Score: 0.99,
+                            Type: "SSN",
+                            BeginOffset: begin,
+                            EndOffset: begin + ssn.length,
+                        },
+                    ],
+                };
+            }
+            return { Entities: [] };
+        });
+        const redactor = new AWSComprehend({ client: { send }, maxUtf8Bytes: 12 });
+        const result = await redactor.redact(text);
+
+        expect(send.mock.calls.length).toBeGreaterThan(1);
+        expect(
+            send.mock.calls.every(
+                (call) =>
+                    new TextEncoder().encode(call[0].input.Text).byteLength <= 12 ||
+                    [...(call[0].input.Text as string)].length === 1
+            )
+        ).toBe(true);
+        expect(result.redactedText).toBe(`${prefix} [SSN]`);
+        expect(result.entities[0].BeginOffset).toBe(prefix.length + 1);
+        expect(result.entities[0].EndOffset).toBe(prefix.length + 1 + ssn.length);
+    });
+});
+
+describe("codePointOffsetToUtf16Index", () => {
+    it("counts an emoji as one code point and two UTF-16 units", () => {
+        const text = "😀 SSN 123-45-6789";
+        expect(codePointOffsetToUtf16Index(text, 0)).toBe(0);
+        expect(codePointOffsetToUtf16Index(text, 1)).toBe(2);
+        expect(codePointOffsetToUtf16Index(text, 6)).toBe(7);
+        expect(codePointOffsetToUtf16Index(text, 17)).toBe(18);
+        expect(text.slice(7, 18)).toBe("123-45-6789");
+        expect(codePointOffsetToUtf16Index(text, 100)).toBe(-1);
+    });
+});
+
+describe("splitTextByUtf8ByteLimit", () => {
+    it("does not split surrogate pairs and prefers whitespace", () => {
+        const chunks = splitTextByUtf8ByteLimit("😀😀 hello", 9);
+        expect(chunks.map((chunk) => chunk.text)).toEqual(["😀😀 ", "hello"]);
+        expect(chunks[0].text).not.toMatch(/[\uD800-\uDBFF]$/);
+        expect(chunks[1].codePointOffset).toBe(3);
+    });
+});
+
+describe("resolveOverlappingEntities", () => {
+    it("keeps the longer overlapping span", () => {
+        const located = locateEntities("John Smith 1 Main St", [
+            { Score: 0.8, Type: "NAME", BeginOffset: 0, EndOffset: 10 },
+            { Score: 0.9, Type: "ADDRESS", BeginOffset: 0, EndOffset: 20 },
+        ]);
+        const resolved = resolveOverlappingEntities(located);
+        expect(resolved).toHaveLength(1);
+        expect(resolved[0].entity.Type).toBe("ADDRESS");
+    });
+
+    it("keeps non-overlapping spans", () => {
+        const located = locateEntities(SAMPLE, entitiesForSample());
+        expect(resolveOverlappingEntities(located)).toHaveLength(2);
+    });
+});
+
+describe("applyRedactions", () => {
+    it("replaces from the end so earlier offsets stay valid", () => {
+        const redacted = applyRedactions(SAMPLE, entitiesForSample(), {
+            maskCharacter: "*",
+            maskMode: "REPLACE_WITH_PII_ENTITY_TYPE",
+        });
+        expect(redacted).toBe("My name is [NAME], SSN [SSN]");
+    });
+});

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/.gitignore
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/jsonnet/main.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/jsonnet/main.jsonnet
@@ -1,0 +1,11 @@
+local promptTemplate = |||
+  You are a helpful assistant. Answer the question. Do not repeat or store any personal identifiers if they appear in the text.
+  Question: {question}
+|||;
+
+local UserQuestion = std.extVar('question');
+local promptWithQuestion = std.strReplace(promptTemplate, '{question}', UserQuestion + '\n');
+
+{
+  prompt: promptWithQuestion,
+}

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/jsonnet/secrets.jsonnet
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/jsonnet/secrets.jsonnet
@@ -1,0 +1,11 @@
+local OPENAI_API_KEY = "sk-proj-***";
+local AWS_REGION = "us-east-1";
+local AWS_ACCESS_KEY_ID = "";
+local AWS_SECRET_ACCESS_KEY = "";
+
+{
+    "openai_api_key": OPENAI_API_KEY,
+    "aws_region": AWS_REGION,
+    "aws_access_key_id": AWS_ACCESS_KEY_ID,
+    "aws_secret_access_key": AWS_SECRET_ACCESS_KEY,
+}

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/package.json
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "aws-comprehend-pii-redaction",
+    "version": "1.0.0",
+    "description": "Redact PII from prompts and conversation transcripts with Amazon Comprehend, then chain into an EdgeChains LLM endpoint",
+    "main": "index.js",
+    "type": "module",
+    "keywords": [],
+    "author": "",
+    "scripts": {
+        "start": "tsc && node --experimental-wasm-modules ./dist/index.js",
+        "demo": "tsc && COMPREHEND_DEMO=1 node --experimental-wasm-modules ./dist/demo.js"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@arakoodev/edgechains.js": "file:../../arakoodev",
+        "@arakoodev/jsonnet": "^0.24.0",
+        "file-uri-to-path": "^2.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^22.7.4",
+        "typescript": "^5.6.3"
+    }
+}

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/readme.md
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/readme.md
@@ -1,0 +1,97 @@
+# AWS Comprehend PII redaction
+
+Redact personally identifiable information from prompts and conversation transcripts with Amazon Comprehend, then chain the sanitized text into an existing EdgeChains LLM endpoint.
+
+The current JS SDK (`OpenAI`, `GeminiAI`, `LlamaAI`) is Promise-based, not RxJS. This example keeps prompts in Jsonnet (same as `chat-with-llm`) and chains redaction in TypeScript:
+
+```ts
+const chained = comprehend.chain(openai);
+await chained.chat({ prompt });
+```
+
+or
+
+```ts
+await pipe(prompt, comprehend.asOperator(), (safe) => openai.chat({ prompt: safe }));
+```
+
+Implementation follows the two issue links:
+
+- [Detecting and redacting PII using Amazon Comprehend](https://aws.amazon.com/blogs/machine-learning/detecting-and-redacting-pii-using-amazon-comprehend/) — `ContainsPiiEntities` preflight, `DetectPiiEntities` offsets, then local `REPLACE_WITH_PII_ENTITY_TYPE` / `MASK` redaction.
+- [How to redact PII data in conversation transcripts](https://aws.amazon.com/blogs/machine-learning/how-to-redact-pii-data-in-conversation-transcripts/) — `redactTranscript()` for Agent/Caller turns.
+
+## Installation
+
+```bash
+cd ../../arakoodev && npm install && npm run build
+cd ../examples/aws-comprehend-pii-redaction && npm install
+```
+
+## Configuration
+
+Edit `jsonnet/secrets.jsonnet` to use a real Comprehend account and/or OpenAI key:
+
+```
+local OPENAI_API_KEY = "sk-****";
+local AWS_REGION = "us-east-1";
+local AWS_ACCESS_KEY_ID = "AKIA...";
+local AWS_SECRET_ACCESS_KEY = "...";
+```
+
+If AWS keys are left empty, the example uses a local demo detector so you can still run the chain. Set `COMPREHEND_DEMO=1` to force that path even when keys are present.
+
+## Usage
+
+Credential-free demo of the two-pass API, `chain()`, `pipe()`, MASK mode, and the AWS blog conversation transcript:
+
+```bash
+npm run demo
+```
+
+HTTP server (Jsonnet prompt + TypeScript `AWSComprehend.chain(openai)`):
+
+```bash
+COMPREHEND_DEMO=1 npm start
+```
+
+```bash
+curl -X POST http://localhost:3000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"question":"Hi, I am Alice Johnson. Email me at alice@example.com. SSN 078-05-1120."}'
+```
+
+Redaction only (optional `"maskMode": "MASK"`):
+
+```bash
+curl -X POST http://localhost:3000/redact \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Call Jane Smith at 415-555-0199"}'
+```
+
+Conversation transcript:
+
+```bash
+curl -X POST http://localhost:3000/transcript \
+  -H "Content-Type: application/json" \
+  -d '{"turns":[{"speaker":"Caller","text":"Hello, my name is John Stiles."}]}'
+```
+
+## TypeScript chaining
+
+```ts
+import { AWSComprehend, OpenAI, pipe } from "@arakoodev/edgechains.js/ai";
+
+const comprehend = new AWSComprehend({ region: "us-east-1" });
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const chained = comprehend.chain(openai);
+const response = await chained.chat({
+    prompt: "My name is John Smith, SSN 123-45-6789",
+});
+
+const piped = await pipe(
+    "My name is John Smith, SSN 123-45-6789",
+    comprehend.asOperator(),
+    (prompt) => openai.chat({ prompt })
+);
+```

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/src/demo.ts
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/src/demo.ts
@@ -1,0 +1,95 @@
+import { AWSComprehend, pipe } from "@arakoodev/edgechains.js/ai";
+import { createDemoComprehendClient } from "./lib/demoComprehendClient.js";
+
+/**
+ * Conversation sample from the Amazon Comprehend transcript-redaction blog.
+ * @see https://aws.amazon.com/blogs/machine-learning/how-to-redact-pii-data-in-conversation-transcripts/
+ */
+const BLOG_TRANSCRIPT = [
+    {
+        speaker: "Agent",
+        text: "Hi, thank you for calling us today. Whom do I have the pleasure of speaking with today?",
+    },
+    { speaker: "Caller", text: "Hello, my name is John Stiles." },
+    { speaker: "Agent", text: "Hi John, how may I help you?" },
+    {
+        speaker: "Caller",
+        text: "I haven't received my W2 statement yet and wanted to check on its status.",
+    },
+    {
+        speaker: "Agent",
+        text: "Sure, I can help you with that. Can you please confirm the last four digits of your Social Security number?",
+    },
+    { speaker: "Caller", text: "Yes, it's 548-95-6370." },
+    {
+        speaker: "Agent",
+        text: "The number we have on file for you is 555-456-7890. Is that still correct?",
+    },
+    { speaker: "Caller", text: "Yes, it is." },
+    {
+        speaker: "Agent",
+        text: "Great. I have turned on automated notifications. Is there anything else I can assist you with John?",
+    },
+];
+
+class FakeOpenAI {
+    async chat(options: { prompt?: string }) {
+        return {
+            content: `Safe prompt received: ${options.prompt}`,
+        };
+    }
+}
+
+function printSection(title: string) {
+    console.log(`\n=== ${title} ===`);
+}
+
+async function main() {
+    const prompt =
+        "Hi, I am Alice Johnson. Email me at alice@example.com. My SSN is 078-05-1120 and phone is 415-555-0199.";
+
+    const comprehend = new AWSComprehend({
+        client: createDemoComprehendClient(),
+        maskMode: "REPLACE_WITH_PII_ENTITY_TYPE",
+    });
+    const openai = new FakeOpenAI();
+
+    printSection("1. ContainsPiiEntities preflight");
+    const preflight = await comprehend.containsPii(prompt);
+    console.log(JSON.stringify(preflight, null, 2));
+
+    printSection("2. DetectPiiEntities offsets");
+    const detection = await comprehend.detectPiiEntities(prompt);
+    console.log(JSON.stringify(detection, null, 2));
+
+    printSection("3. Two-pass redact() — REPLACE_WITH_PII_ENTITY_TYPE");
+    const redacted = await comprehend.redact(prompt);
+    console.log("original:", redacted.text);
+    console.log("redacted:", redacted.redactedText);
+    console.log("labels:", redacted.labels.map((label) => label.Name).join(", "));
+
+    printSection("4. MASK mode (length-preserving)");
+    const masked = await comprehend.redactPrompt({ text: prompt, maskMode: "MASK" });
+    console.log(masked);
+
+    printSection("5. chain() existing OpenAI-style endpoint");
+    const chainedResponse = await comprehend.chain(openai).chat({ prompt });
+    console.log(chainedResponse);
+
+    printSection("6. pipe() Promise composition");
+    const pipedResponse = await pipe(prompt, comprehend.asOperator(), (safePrompt) =>
+        openai.chat({ prompt: safePrompt })
+    );
+    console.log(pipedResponse);
+
+    printSection("7. Conversation transcript (AWS blog sample)");
+    const transcript = await comprehend.redactTranscript(BLOG_TRANSCRIPT);
+    for (const turn of transcript.turns) {
+        console.log(`${turn.speaker}: ${turn.text}`);
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/src/index.ts
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/src/index.ts
@@ -1,0 +1,105 @@
+import { AWSComprehend, OpenAI } from "@arakoodev/edgechains.js/ai";
+import { ArakooServer } from "@arakoodev/edgechains.js/arakooserver";
+import Jsonnet from "@arakoodev/jsonnet";
+import fileURLToPath from "file-uri-to-path";
+import path from "path";
+import { createDemoComprehendClient } from "./lib/demoComprehendClient.js";
+
+const server = new ArakooServer();
+const app = server.createApp();
+const jsonnet = new Jsonnet();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function isPlaceholder(value?: string) {
+    return !value || /your-|^\*+$|\*\*\*|sk-proj-\*\*\*/i.test(value);
+}
+
+function loadSecrets() {
+    return JSON.parse(jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/secrets.jsonnet")));
+}
+
+function loadPrompt(question: string) {
+    jsonnet.extString("question", question || "");
+    const rendered = jsonnet.evaluateFile(path.join(__dirname, "../jsonnet/main.jsonnet"));
+    return JSON.parse(rendered).prompt as string;
+}
+
+function createRedactor(secrets: {
+    aws_region?: string;
+    aws_access_key_id?: string;
+    aws_secret_access_key?: string;
+}) {
+    const useDemo =
+        process.env.COMPREHEND_DEMO === "1" ||
+        isPlaceholder(secrets.aws_access_key_id) ||
+        isPlaceholder(secrets.aws_secret_access_key);
+
+    return new AWSComprehend({
+        region: secrets.aws_region || "us-east-1",
+        accessKeyId: useDemo ? undefined : secrets.aws_access_key_id,
+        secretAccessKey: useDemo ? undefined : secrets.aws_secret_access_key,
+        client: useDemo ? createDemoComprehendClient() : undefined,
+    });
+}
+
+app.post("/chat", async (c: any) => {
+    try {
+        const { question } = await c.req.json();
+        const secrets = loadSecrets();
+        const prompt = loadPrompt(question);
+        const comprehend = createRedactor(secrets);
+        const redaction = await comprehend.redact(prompt);
+
+        if (isPlaceholder(secrets.openai_api_key)) {
+            return c.json({
+                labels: redaction.labels,
+                redactedPrompt: redaction.redactedText,
+                response: {
+                    content:
+                        "OpenAI API key is not configured. Returning the redacted prompt only.",
+                },
+            });
+        }
+
+        const openai = new OpenAI({ apiKey: secrets.openai_api_key });
+        const response = await comprehend.chain(openai).chat({ prompt, max_tokens: 256 });
+        return c.json({
+            labels: redaction.labels,
+            redactedPrompt: redaction.redactedText,
+            response,
+        });
+    } catch (error) {
+        console.log("error occured", error);
+        return c.json({ error: String(error) }, 500);
+    }
+});
+
+app.post("/redact", async (c: any) => {
+    try {
+        const { maskMode, text } = await c.req.json();
+        const secrets = loadSecrets();
+        const comprehend = createRedactor(secrets);
+        const result = await comprehend.redact({
+            maskMode: maskMode === "MASK" ? "MASK" : "REPLACE_WITH_PII_ENTITY_TYPE",
+            text: text || "",
+        });
+        return c.json(result);
+    } catch (error) {
+        console.log("error occured", error);
+        return c.json({ error: String(error) }, 500);
+    }
+});
+
+app.post("/transcript", async (c: any) => {
+    try {
+        const { turns } = await c.req.json();
+        const secrets = loadSecrets();
+        const comprehend = createRedactor(secrets);
+        return c.json(await comprehend.redactTranscript(turns || []));
+    } catch (error) {
+        console.log("error occured", error);
+        return c.json({ error: String(error) }, 500);
+    }
+});
+
+server.listen(3000);

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/src/lib/demoComprehendClient.ts
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/src/lib/demoComprehendClient.ts
@@ -1,0 +1,77 @@
+import type { ComprehendClientLike } from "@arakoodev/edgechains.js/ai";
+
+type DemoEntity = {
+    Score: number;
+    Type: string;
+    BeginOffset: number;
+    EndOffset: number;
+};
+
+const DEMO_PATTERNS: Array<{ type: string; regex: RegExp }> = [
+    { type: "EMAIL", regex: /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi },
+    { type: "SSN", regex: /\b\d{3}-\d{2}-\d{4}\b/g },
+    { type: "PHONE", regex: /\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g },
+    { type: "CREDIT_DEBIT_NUMBER", regex: /\b\d{13,16}\b/g },
+    {
+        type: "NAME",
+        regex: /\b(?:Alice|Bob|Jane|John|Johnson|Smith|Stiles)(?:\s+(?:Alice|Bob|Jane|John|Johnson|Smith|Stiles))?\b/g,
+    },
+];
+
+export function detectDemoPii(text: string): DemoEntity[] {
+    const entities: DemoEntity[] = [];
+    for (const pattern of DEMO_PATTERNS) {
+        const regex = new RegExp(pattern.regex.source, pattern.regex.flags);
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(text)) !== null) {
+            entities.push({
+                Score: 0.99,
+                Type: pattern.type,
+                BeginOffset: match.index,
+                EndOffset: match.index + match[0].length,
+            });
+        }
+    }
+    return entities.sort((left, right) => left.BeginOffset - right.BeginOffset);
+}
+
+function commandName(command: unknown): string {
+    return command && typeof command === "object" && command.constructor
+        ? command.constructor.name
+        : "";
+}
+
+function commandText(command: unknown): string {
+    if (
+        command &&
+        typeof command === "object" &&
+        "input" in command &&
+        command.input &&
+        typeof command.input === "object" &&
+        "Text" in command.input
+    ) {
+        return String((command.input as { Text?: string }).Text || "");
+    }
+    return "";
+}
+
+/**
+ * Local stand-in for Amazon Comprehend so the example runs without AWS keys.
+ * It answers both `ContainsPiiEntities` (labels) and `DetectPiiEntities` (offsets).
+ */
+export function createDemoComprehendClient(): ComprehendClientLike {
+    return {
+        send: async (command: unknown) => {
+            const text = commandText(command);
+            const entities = detectDemoPii(text);
+            if (commandName(command) === "ContainsPiiEntitiesCommand") {
+                const labels = [...new Set(entities.map((entity) => entity.Type))].map((Name) => ({
+                    Name,
+                    Score: 0.99,
+                }));
+                return { Labels: labels };
+            }
+            return { Entities: entities };
+        },
+    };
+}

--- a/JS/edgechains/examples/aws-comprehend-pii-redaction/tsconfig.json
+++ b/JS/edgechains/examples/aws-comprehend-pii-redaction/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2021",
+        "moduleResolution": "NodeNext",
+        "module": "NodeNext",
+        "rootDir": "./src",
+        "outDir": "./dist",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "exclude": ["./**/*.test.ts", "vitest.config.ts"]
+}


### PR DESCRIPTION
@algora-pbc /claim #290
Fixes #290

Adds an AWS Comprehend PII redaction utility that chains with existing EdgeChains AI endpoint classes (Promise-based chain/pipe), with mocked tests and a working example under `JS/edgechains/examples/`.

I have read the Arakoo CLA Document and I hereby sign the CLA.
