### PR TITLE
feat: add Qdrant vector database support (JS/TS SDK)

### DIFF
--- a/JS/edgechains/arakoodev/src/db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/db/src/index.ts
@@ -1,1 +1,10 @@
 export { PostgresClient } from "./lib/postgres-client/PostgresClient.js";
+export {
+    QdrantClient,
+    QdrantDistanceMetric,
+} from "./lib/qdrant-client/QdrantClient.js";
+export type {
+    QdrantClientOptions,
+    QdrantFetch,
+    QdrantSearchHit,
+} from "./lib/qdrant-client/QdrantClient.js";

--- a/JS/edgechains/arakoodev/src/db/src/lib/qdrant-client/QdrantClient.ts
+++ b/JS/edgechains/arakoodev/src/db/src/lib/qdrant-client/QdrantClient.ts
@@ -1,0 +1,255 @@
+/**
+ * Qdrant vector search client analogous to PostgresClient.
+ * Talks to the Qdrant HTTP API directly (no @qdrant/* packages).
+ * REST reference: https://qdrant.tech/documentation/
+ */
+
+export enum QdrantDistanceMetric {
+    COSINE = "COSINE",
+    IP = "IP",
+    L2 = "L2",
+}
+
+export type QdrantFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface QdrantClientOptions {
+    /** Base URL of the Qdrant instance, e.g. http://localhost:6333 */
+    url?: string;
+    /** Optional Qdrant API key (sent as `api-key` header) */
+    apiKey?: string;
+    /** Injectable fetch for tests / non-Node runtimes */
+    fetch?: QdrantFetch;
+    /** Request timeout in milliseconds */
+    timeoutMs?: number;
+}
+
+export interface QdrantSearchHit {
+    id: string | number;
+    score: number;
+    raw_text?: string;
+    filename?: string;
+    namespace?: string;
+    metadata?: Record<string, unknown>;
+    payload?: Record<string, unknown>;
+    rrf_score?: number;
+    [key: string]: unknown;
+}
+
+interface QdrantPointResult {
+    id: string | number;
+    score?: number;
+    payload?: Record<string, unknown> | null;
+    vector?: number[] | Record<string, number[]>;
+}
+
+/**
+ * Hyde / RAG style vector search against a Qdrant collection.
+ * Mirrors the constructor shape of PostgresClient so callers can swap stores.
+ */
+export class QdrantClient {
+    wordEmbeddings: number[][];
+    metric: QdrantDistanceMetric;
+    topK: number;
+    /** Retained for PostgresClient signature parity (maps to HNSW ef when set). */
+    probes: number;
+    tableName: string;
+    namespace: string;
+    arkRequest: any;
+    upperLimit: number;
+    url: string;
+    apiKey?: string;
+    private readonly fetchImpl: QdrantFetch;
+    private readonly timeoutMs?: number;
+
+    constructor(
+        wordEmbeddings: number[][],
+        metric: QdrantDistanceMetric,
+        topK: number,
+        probes: number,
+        tableName: string,
+        namespace: string,
+        arkRequest: any,
+        upperLimit: number,
+        options: QdrantClientOptions = {}
+    ) {
+        this.wordEmbeddings = wordEmbeddings;
+        this.metric = metric;
+        this.topK = topK;
+        this.probes = probes;
+        this.tableName = tableName;
+        this.namespace = namespace;
+        this.arkRequest = arkRequest;
+        this.upperLimit = upperLimit;
+        this.url = normalizeBaseUrl(
+            options.url || process.env.QDRANT_URL || "http://localhost:6333"
+        );
+        this.apiKey = options.apiKey || process.env.QDRANT_API_KEY;
+        const fetchImpl = options.fetch || globalThis.fetch;
+        if (typeof fetchImpl !== "function") {
+            throw new Error("A fetch implementation is required to use QdrantClient");
+        }
+        this.fetchImpl = fetchImpl.bind(globalThis);
+        this.timeoutMs = options.timeoutMs;
+    }
+
+    /**
+     * Search the Qdrant collection for each embedding and merge results.
+     * When multiple embeddings are provided, Reciprocal Rank Fusion (RRF)
+     * is applied — similar in spirit to PostgresClient's RRF scoring.
+     */
+    async dbQuery(): Promise<QdrantSearchHit[]> {
+        if (!this.wordEmbeddings?.length) {
+            return [];
+        }
+
+        const perEmbeddingHits = await Promise.all(
+            this.wordEmbeddings.map((embedding) => this.searchOne(embedding))
+        );
+
+        if (perEmbeddingHits.length === 1) {
+            return perEmbeddingHits[0].slice(0, this.topK);
+        }
+
+        return fuseRrf(perEmbeddingHits, this.upperLimit || this.topK);
+    }
+
+    private async searchOne(embedding: number[]): Promise<QdrantSearchHit[]> {
+        const filter = {
+            must: [
+                {
+                    key: "namespace",
+                    match: { value: this.namespace },
+                },
+            ],
+        };
+
+        const body: Record<string, unknown> = {
+            vector: embedding,
+            limit: this.topK,
+            with_payload: true,
+            with_vector: false,
+            filter,
+        };
+
+        // Map Postgres-style probes to Qdrant HNSW search ef when provided.
+        if (this.probes && this.probes > 0) {
+            body.params = { hnsw_ef: this.probes };
+        }
+
+        const result = await this.request<QdrantPointResult[]>(
+            "POST",
+            `/collections/${encodeURIComponent(this.tableName)}/points/search`,
+            body
+        );
+
+        return (result || []).map((point) => mapPoint(point));
+    }
+
+    private async request<T>(
+        method: string,
+        path: string,
+        body?: Record<string, unknown>
+    ): Promise<T> {
+        const url = `${this.url}${path}`;
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (this.apiKey) {
+            headers["api-key"] = this.apiKey;
+        }
+
+        const controller = new AbortController();
+        const timer =
+            this.timeoutMs !== undefined
+                ? setTimeout(() => controller.abort(), this.timeoutMs)
+                : undefined;
+
+        let response: Response;
+        try {
+            response = await this.fetchImpl(url, {
+                method,
+                headers,
+                body: body ? JSON.stringify(body) : undefined,
+                signal: controller.signal,
+            });
+        } catch (error: any) {
+            if (error?.name === "AbortError") {
+                throw new Error(`Qdrant request timed out after ${this.timeoutMs}ms`);
+            }
+            throw error;
+        } finally {
+            if (timer) clearTimeout(timer);
+        }
+
+        const text = await response.text();
+        let payload: any = undefined;
+        if (text) {
+            try {
+                payload = JSON.parse(text);
+            } catch {
+                payload = text;
+            }
+        }
+
+        if (!response.ok) {
+            const detail = typeof payload === "string" ? payload : JSON.stringify(payload);
+            throw new Error(`Qdrant request failed with status ${response.status}: ${detail}`);
+        }
+
+        if (payload && typeof payload === "object" && "result" in payload) {
+            return payload.result as T;
+        }
+        return payload as T;
+    }
+}
+
+function mapPoint(point: QdrantPointResult): QdrantSearchHit {
+    const payload = (point.payload || {}) as Record<string, unknown>;
+    return {
+        id: point.id,
+        score: point.score ?? 0,
+        raw_text: (payload.raw_text as string) ?? (payload.content as string) ?? (payload.text as string),
+        filename: payload.filename as string | undefined,
+        namespace: payload.namespace as string | undefined,
+        metadata: (payload.metadata as Record<string, unknown>) ?? undefined,
+        payload,
+        ...payload,
+    };
+}
+
+/**
+ * Reciprocal Rank Fusion across multiple ranked hit lists.
+ * score_i = sum_r 1 / (k + rank_r(i)) with k = 60 (classic RRF constant).
+ */
+function fuseRrf(lists: QdrantSearchHit[][], limit: number): QdrantSearchHit[] {
+    const k = 60;
+    const scores = new Map<string | number, { hit: QdrantSearchHit; rrf: number }>();
+
+    for (const list of lists) {
+        list.forEach((hit, index) => {
+            const existing = scores.get(hit.id);
+            const add = 1 / (k + index + 1);
+            if (existing) {
+                existing.rrf += add;
+                if ((hit.score ?? 0) > (existing.hit.score ?? 0)) {
+                    existing.hit = hit;
+                }
+            } else {
+                scores.set(hit.id, { hit, rrf: add });
+            }
+        });
+    }
+
+    return Array.from(scores.values())
+        .sort((a, b) => b.rrf - a.rrf)
+        .slice(0, limit)
+        .map(({ hit, rrf }) => ({ ...hit, rrf_score: rrf }));
+}
+
+function normalizeBaseUrl(url: string): string {
+    const trimmed = url.trim().replace(/\/+$/, "");
+    if (!/^https?:\/\//i.test(trimmed)) {
+        throw new Error(`Qdrant URL must be an absolute http(s) URL, received: "${url}"`);
+    }
+    return trimmed;
+}

--- a/JS/edgechains/arakoodev/src/db/src/tests/qdrant-client/qdrantClient.test.ts
+++ b/JS/edgechains/arakoodev/src/db/src/tests/qdrant-client/qdrantClient.test.ts
@@ -1,0 +1,167 @@
+import {
+    QdrantClient,
+    QdrantDistanceMetric,
+} from "../../lib/qdrant-client/QdrantClient";
+
+describe("QdrantClient", () => {
+    const arkRequest = {
+        textWeight: { baseWeight: 1, fineTuneWeight: 0.5 },
+        similarityWeight: { baseWeight: 1, fineTuneWeight: 0.5 },
+        dateWeight: { baseWeight: 1, fineTuneWeight: 0.5 },
+        orderRRF: "similarity",
+        metadataTable: "test_metadata",
+        query: "test_query",
+    };
+
+    const embeddingA = [0.1, 0.2, 0.3];
+    const embeddingB = [0.4, 0.5, 0.6];
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("dbQuery sends a search request with namespace filter", async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            text: async () =>
+                JSON.stringify({
+                    result: [
+                        {
+                            id: 1,
+                            score: 0.92,
+                            payload: {
+                                namespace: "test_namespace",
+                                raw_text: "hello world",
+                                filename: "doc.md",
+                            },
+                        },
+                    ],
+                }),
+        });
+
+        const client = new QdrantClient(
+            [embeddingA],
+            QdrantDistanceMetric.COSINE,
+            10,
+            32,
+            "test_collection",
+            "test_namespace",
+            arkRequest,
+            100,
+            { url: "http://localhost:6333", apiKey: "secret", fetch: fetchMock }
+        );
+
+        const results = await client.dbQuery();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe("http://localhost:6333/collections/test_collection/points/search");
+        expect(init.method).toBe("POST");
+        expect(init.headers["api-key"]).toBe("secret");
+
+        const body = JSON.parse(init.body);
+        expect(body.vector).toEqual(embeddingA);
+        expect(body.limit).toBe(10);
+        expect(body.params).toEqual({ hnsw_ef: 32 });
+        expect(body.filter).toEqual({
+            must: [{ key: "namespace", match: { value: "test_namespace" } }],
+        });
+
+        expect(results).toHaveLength(1);
+        expect(results[0]).toMatchObject({
+            id: 1,
+            score: 0.92,
+            raw_text: "hello world",
+            filename: "doc.md",
+            namespace: "test_namespace",
+        });
+    });
+
+    test("dbQuery fuses multiple embeddings with RRF", async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                text: async () =>
+                    JSON.stringify({
+                        result: [
+                            { id: "a", score: 0.9, payload: { raw_text: "A" } },
+                            { id: "b", score: 0.8, payload: { raw_text: "B" } },
+                        ],
+                    }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                text: async () =>
+                    JSON.stringify({
+                        result: [
+                            { id: "b", score: 0.95, payload: { raw_text: "B" } },
+                            { id: "c", score: 0.7, payload: { raw_text: "C" } },
+                        ],
+                    }),
+            });
+
+        const client = new QdrantClient(
+            [embeddingA, embeddingB],
+            QdrantDistanceMetric.IP,
+            5,
+            0,
+            "docs",
+            "ns",
+            arkRequest,
+            2,
+            { url: "http://qdrant.local", fetch: fetchMock }
+        );
+
+        const results = await client.dbQuery();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(results).toHaveLength(2);
+        // "b" appears in both lists so should rank first by RRF
+        expect(results[0].id).toBe("b");
+        expect(results[0].rrf_score).toBeGreaterThan(results[1].rrf_score!);
+    });
+
+    test("dbQuery returns empty array when there are no embeddings", async () => {
+        const fetchMock = jest.fn();
+        const client = new QdrantClient(
+            [],
+            QdrantDistanceMetric.L2,
+            5,
+            0,
+            "docs",
+            "ns",
+            arkRequest,
+            5,
+            { url: "http://localhost:6333", fetch: fetchMock }
+        );
+
+        await expect(client.dbQuery()).resolves.toEqual([]);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test("dbQuery throws on non-OK Qdrant responses", async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: false,
+            status: 404,
+            text: async () => JSON.stringify({ status: { error: "Not found" } }),
+        });
+
+        const client = new QdrantClient(
+            [embeddingA],
+            QdrantDistanceMetric.COSINE,
+            5,
+            0,
+            "missing",
+            "ns",
+            arkRequest,
+            5,
+            { url: "http://localhost:6333", fetch: fetchMock }
+        );
+
+        await expect(client.dbQuery()).rejects.toThrow(/status 404/);
+    });
+});

--- a/JS/edgechains/arakoodev/src/vector-db/src/index.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/index.ts
@@ -1,1 +1,13 @@
 export { Supabase } from "./lib/supabase/supabase.js";
+export {
+    Qdrant,
+    QdrantDistance,
+    QdrantHttpError,
+} from "./lib/qdrant/qdrant.js";
+export type {
+    QdrantFetch,
+    QdrantPointId,
+    QdrantVector,
+    QdrantRestClient,
+    QdrantOptions,
+} from "./lib/qdrant/qdrant.js";

--- a/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/lib/qdrant/qdrant.ts
@@ -1,0 +1,501 @@
+/**
+ * Dependency-free Qdrant REST client for the JavaScript vector-db package.
+ * Uses the HTTP API directly (no @qdrant/* packages) and mirrors the existing
+ * Supabase method names so callers can switch stores with a small mapping.
+ *
+ * REST reference: https://qdrant.tech/documentation/
+ */
+
+export type QdrantFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type QdrantPointId = string | number;
+
+export type QdrantVector = number[] | Record<string, number[]>;
+
+export enum QdrantDistance {
+    Cosine = "Cosine",
+    Euclid = "Euclid",
+    Dot = "Dot",
+    Manhattan = "Manhattan",
+}
+
+export interface QdrantRestClient {
+    url: string;
+    apiKey?: string;
+    fetch: QdrantFetch;
+    timeoutMs?: number;
+}
+
+export interface QdrantOptions {
+    fetch?: QdrantFetch;
+    timeoutMs?: number;
+}
+
+export class QdrantHttpError extends Error {
+    status: number;
+    body: unknown;
+
+    constructor(status: number, body: unknown) {
+        const detail = typeof body === "string" ? body : JSON.stringify(body);
+        super(`Qdrant request failed with status ${status}: ${detail}`);
+        this.name = "QdrantHttpError";
+        this.status = status;
+        this.body = body;
+    }
+}
+
+interface CollectionArgs {
+    client?: QdrantRestClient;
+    collectionName?: string;
+    tableName?: string;
+}
+
+interface CreateCollectionArgs extends CollectionArgs {
+    vectorSize?: number;
+    size?: number;
+    distance?: QdrantDistance | string;
+    vectors?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+interface InsertVectorDataArgs extends CollectionArgs {
+    id?: QdrantPointId;
+    vector?: QdrantVector;
+    embedding?: QdrantVector;
+    payload?: Record<string, unknown>;
+    points?: Array<Record<string, unknown>>;
+    wait?: boolean;
+    [key: string]: unknown;
+}
+
+interface GetDataFromQueryArgs extends CollectionArgs {
+    functionNameToCall?: string;
+    vector?: QdrantVector;
+    query?: QdrantVector;
+    query_embedding?: QdrantVector;
+    embedding?: QdrantVector;
+    limit?: number;
+    match_count?: number;
+    topK?: number;
+    filter?: Record<string, unknown>;
+    with_payload?: boolean | string[] | Record<string, unknown>;
+    with_vector?: boolean | string[] | Record<string, unknown>;
+    score_threshold?: number;
+}
+
+interface GetDataArgs extends CollectionArgs {
+    limit?: number;
+    offset?: QdrantPointId | Record<string, unknown>;
+    filter?: Record<string, unknown>;
+    with_payload?: boolean | string[] | Record<string, unknown>;
+    with_vector?: boolean | string[] | Record<string, unknown>;
+}
+
+interface GetDataByIdArgs extends CollectionArgs {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    with_payload?: boolean | string[] | Record<string, unknown>;
+    with_vector?: boolean | string[] | Record<string, unknown>;
+}
+
+interface UpdateByIdArgs extends CollectionArgs {
+    id: QdrantPointId;
+    updatedContent: Record<string, unknown>;
+    wait?: boolean;
+}
+
+interface DeleteByIdArgs extends CollectionArgs {
+    id?: QdrantPointId;
+    ids?: QdrantPointId[];
+    wait?: boolean;
+}
+
+export class Qdrant {
+    QDRANT_URL: string;
+    QDRANT_API_KEY?: string;
+    private readonly defaultFetch?: QdrantFetch;
+    private readonly defaultTimeoutMs?: number;
+
+    constructor(QDRANT_URL?: string, QDRANT_API_KEY?: string, options: QdrantOptions = {}) {
+        this.QDRANT_URL = QDRANT_URL || process.env.QDRANT_URL || "";
+        this.QDRANT_API_KEY = QDRANT_API_KEY || process.env.QDRANT_API_KEY;
+        this.defaultFetch = options.fetch;
+        this.defaultTimeoutMs = options.timeoutMs;
+    }
+
+    /** Build a reusable REST client, matching Supabase.createClient(). */
+    createClient(options: QdrantOptions = {}): QdrantRestClient {
+        if (!this.QDRANT_URL) {
+            throw new Error(
+                "QDRANT_URL is required. Pass it to the constructor or set the QDRANT_URL environment variable."
+            );
+        }
+
+        const fetchImplementation = options.fetch || this.defaultFetch || globalThis.fetch;
+        if (typeof fetchImplementation !== "function") {
+            throw new Error("A fetch implementation is required to use Qdrant");
+        }
+
+        return {
+            url: normalizeBaseUrl(this.QDRANT_URL),
+            apiKey: this.QDRANT_API_KEY,
+            fetch: fetchImplementation.bind(globalThis),
+            timeoutMs: options.timeoutMs ?? this.defaultTimeoutMs,
+        };
+    }
+
+    async createCollection({
+        client,
+        collectionName,
+        tableName,
+        vectors,
+        vectorSize,
+        size,
+        distance = QdrantDistance.Cosine,
+        ...args
+    }: CreateCollectionArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        if (!vectors && !vectorSize && !size) {
+            throw new Error("vectorSize or vectors is required to create a Qdrant collection");
+        }
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}`,
+            body: {
+                ...args,
+                vectors: vectors || {
+                    size: vectorSize || size,
+                    distance,
+                },
+            },
+        });
+    }
+
+    async getCollection({ client, collectionName, tableName }: CollectionArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "GET",
+            path: `/collections/${encodeURIComponent(collection)}`,
+        });
+    }
+
+    async deleteCollection({
+        client,
+        collectionName,
+        tableName,
+    }: CollectionArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "DELETE",
+            path: `/collections/${encodeURIComponent(collection)}`,
+        });
+    }
+
+    /**
+     * Upsert one or more points. Accepts Supabase-shaped fields
+     * (`tableName`, `embedding`) and native Qdrant fields (`points`).
+     */
+    async insertVectorData({
+        client,
+        collectionName,
+        tableName,
+        id,
+        vector,
+        embedding,
+        payload,
+        points,
+        wait = true,
+        ...args
+    }: InsertVectorDataArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const pointVector = vector || embedding;
+
+        if (!points && !pointVector) {
+            throw new Error("vector, embedding, or points is required to insert Qdrant data");
+        }
+
+        const restPayloadKeys = ["content", "raw_text", "text", "filename", "namespace", "metadata"];
+        const derivedPayload: Record<string, unknown> = { ...(payload || {}) };
+        for (const key of restPayloadKeys) {
+            if (args[key] !== undefined && derivedPayload[key] === undefined) {
+                derivedPayload[key] = args[key];
+            }
+        }
+
+        const resolvedPoints =
+            points ||
+            [
+                {
+                    id: id ?? cryptoRandomId(),
+                    vector: pointVector,
+                    payload: Object.keys(derivedPayload).length ? derivedPayload : undefined,
+                },
+            ];
+
+        return this.request({
+            client,
+            method: "PUT",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            query: { wait },
+            body: { points: resolvedPoints },
+        });
+    }
+
+    /** Vector search → POST /collections/{name}/points/search */
+    async getDataFromQuery({
+        client,
+        collectionName,
+        tableName,
+        vector,
+        query,
+        query_embedding,
+        embedding,
+        limit,
+        match_count,
+        topK,
+        filter,
+        with_payload = true,
+        with_vector = false,
+        score_threshold,
+    }: GetDataFromQueryArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const queryVector = vector || query || query_embedding || embedding;
+        if (!queryVector) {
+            throw new Error("vector, query, or query_embedding is required to search Qdrant data");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/search`,
+            body: compact({
+                vector: queryVector,
+                limit: limit ?? match_count ?? topK ?? 10,
+                filter,
+                with_payload,
+                with_vector,
+                score_threshold,
+            }),
+        });
+    }
+
+    /** Scroll / list points → POST /collections/{name}/points/scroll */
+    async getData({
+        client,
+        collectionName,
+        tableName,
+        limit = 10,
+        offset,
+        filter,
+        with_payload = true,
+        with_vector = false,
+    }: GetDataArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/scroll`,
+            body: compact({
+                limit,
+                offset,
+                filter,
+                with_payload,
+                with_vector,
+            }),
+        });
+    }
+
+    async getDataById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        with_payload = true,
+        with_vector = false,
+    }: GetDataByIdArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to retrieve Qdrant points");
+        }
+
+        const result = await this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points`,
+            body: {
+                ids: resolvedIds,
+                with_payload,
+                with_vector,
+            },
+        });
+
+        if (id !== undefined && !ids) {
+            return Array.isArray(result) ? result[0] ?? null : result;
+        }
+        return result;
+    }
+
+    async updateById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        updatedContent,
+        wait = true,
+    }: UpdateByIdArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        if (!updatedContent || typeof updatedContent !== "object") {
+            throw new Error("updatedContent is required to update a Qdrant point");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/payload`,
+            query: { wait },
+            body: {
+                payload: updatedContent,
+                points: [id],
+            },
+        });
+    }
+
+    async deleteById({
+        client,
+        collectionName,
+        tableName,
+        id,
+        ids,
+        wait = true,
+    }: DeleteByIdArgs): Promise<unknown> {
+        const collection = resolveCollectionName(collectionName, tableName);
+        const resolvedIds = ids || (id !== undefined ? [id] : []);
+        if (!resolvedIds.length) {
+            throw new Error("id or ids is required to delete Qdrant points");
+        }
+
+        return this.request({
+            client,
+            method: "POST",
+            path: `/collections/${encodeURIComponent(collection)}/points/delete`,
+            query: { wait },
+            body: {
+                points: resolvedIds,
+            },
+        });
+    }
+
+    // Native Qdrant aliases
+    upsert = this.insertVectorData.bind(this);
+    search = this.getDataFromQuery.bind(this);
+    scroll = this.getData.bind(this);
+    retrieve = this.getDataById.bind(this);
+    deletePoints = this.deleteById.bind(this);
+
+    private async request({
+        client,
+        method,
+        path,
+        query,
+        body,
+    }: {
+        client?: QdrantRestClient;
+        method: string;
+        path: string;
+        query?: Record<string, string | number | boolean | undefined>;
+        body?: Record<string, unknown>;
+    }): Promise<unknown> {
+        const resolvedClient = client || this.createClient();
+        const url = new URL(`${resolvedClient.url}${path}`);
+
+        for (const [key, value] of Object.entries(query || {})) {
+            if (value !== undefined) {
+                url.searchParams.set(key, String(value));
+            }
+        }
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (resolvedClient.apiKey) {
+            headers["api-key"] = resolvedClient.apiKey;
+        }
+
+        const controller = new AbortController();
+        const timeoutMs = resolvedClient.timeoutMs;
+        const timer =
+            timeoutMs !== undefined ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+
+        let response: Response;
+        try {
+            response = await resolvedClient.fetch(url.toString(), {
+                method,
+                headers,
+                body: body ? JSON.stringify(body) : undefined,
+                signal: controller.signal,
+            });
+        } catch (error: any) {
+            if (error?.name === "AbortError") {
+                throw new Error(`Qdrant request timed out after ${timeoutMs}ms`);
+            }
+            throw error;
+        } finally {
+            if (timer) clearTimeout(timer);
+        }
+
+        const payload = await readResponseBody(response);
+        if (!response.ok) {
+            throw new QdrantHttpError(response.status, payload);
+        }
+
+        if (payload && typeof payload === "object" && "result" in (payload as object)) {
+            return (payload as { result?: unknown }).result;
+        }
+        return payload;
+    }
+}
+
+function normalizeBaseUrl(url: string): string {
+    const trimmed = url.trim().replace(/\/+$/, "");
+    if (!/^https?:\/\//i.test(trimmed)) {
+        throw new Error(`QDRANT_URL must be an absolute http(s) URL, received: "${url}"`);
+    }
+    return trimmed;
+}
+
+function resolveCollectionName(collectionName?: string, tableName?: string): string {
+    const collection = collectionName || tableName;
+    if (!collection) {
+        throw new Error("collectionName or tableName is required");
+    }
+    return collection;
+}
+
+function compact<T extends Record<string, unknown>>(value: T): Partial<T> {
+    return Object.fromEntries(
+        Object.entries(value).filter(([, entry]) => entry !== undefined)
+    ) as Partial<T>;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+    if (!text) return undefined;
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+function cryptoRandomId(): string {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    return `qc-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
+++ b/JS/edgechains/arakoodev/src/vector-db/src/tests/qdrant/qdrant.test.ts
@@ -1,0 +1,165 @@
+import { Qdrant, QdrantDistance, QdrantHttpError } from "../../lib/qdrant/qdrant";
+
+function mockResponse(body: unknown, ok = true, status = 200) {
+    return {
+        ok,
+        status,
+        text: async () => (body === undefined ? "" : JSON.stringify(body)),
+    };
+}
+
+describe("Qdrant vector-db client", () => {
+    const baseUrl = "http://localhost:6333";
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("createClient requires a URL", () => {
+        const qdrant = new Qdrant("");
+        expect(() => qdrant.createClient()).toThrow(/QDRANT_URL is required/);
+    });
+
+    test("createCollection issues PUT /collections/{name}", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ result: true }));
+        const qdrant = new Qdrant(baseUrl, "key", { fetch: fetchMock });
+        const client = qdrant.createClient();
+
+        await qdrant.createCollection({
+            client,
+            collectionName: "docs",
+            vectorSize: 3,
+            distance: QdrantDistance.Cosine,
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe("http://localhost:6333/collections/docs");
+        expect(init.method).toBe("PUT");
+        expect(init.headers["api-key"]).toBe("key");
+        expect(JSON.parse(init.body)).toEqual({
+            vectors: { size: 3, distance: "Cosine" },
+        });
+    });
+
+    test("insertVectorData upserts a point from embedding + content", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ result: { status: "ok" } }));
+        const qdrant = new Qdrant(baseUrl, undefined, { fetch: fetchMock });
+        const client = qdrant.createClient();
+
+        await qdrant.insertVectorData({
+            client,
+            tableName: "docs",
+            id: 42,
+            embedding: [0.1, 0.2, 0.3],
+            content: "hello",
+            namespace: "ns1",
+        });
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toContain("/collections/docs/points?wait=true");
+        const body = JSON.parse(init.body);
+        expect(body.points).toHaveLength(1);
+        expect(body.points[0]).toMatchObject({
+            id: 42,
+            vector: [0.1, 0.2, 0.3],
+            payload: { content: "hello", namespace: "ns1" },
+        });
+    });
+
+    test("getDataFromQuery posts a search request", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(
+            mockResponse({
+                result: [{ id: 1, score: 0.9, payload: { content: "hit" } }],
+            })
+        );
+        const qdrant = new Qdrant(baseUrl, undefined, { fetch: fetchMock });
+        const client = qdrant.createClient();
+
+        const result = await qdrant.getDataFromQuery({
+            client,
+            collectionName: "docs",
+            query_embedding: [0.1, 0.2],
+            match_count: 5,
+        });
+
+        expect(result).toEqual([{ id: 1, score: 0.9, payload: { content: "hit" } }]);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe("http://localhost:6333/collections/docs/points/search");
+        expect(JSON.parse(init.body)).toMatchObject({
+            vector: [0.1, 0.2],
+            limit: 5,
+            with_payload: true,
+            with_vector: false,
+        });
+    });
+
+    test("getDataById retrieves a single point", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(
+            mockResponse({
+                result: [{ id: 7, payload: { content: "seven" } }],
+            })
+        );
+        const qdrant = new Qdrant(baseUrl, undefined, { fetch: fetchMock });
+        const client = qdrant.createClient();
+
+        const point = await qdrant.getDataById({
+            client,
+            tableName: "docs",
+            id: 7,
+        });
+
+        expect(point).toEqual({ id: 7, payload: { content: "seven" } });
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe("http://localhost:6333/collections/docs/points");
+        expect(JSON.parse(init.body).ids).toEqual([7]);
+    });
+
+    test("updateById sets payload", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ result: { status: "ok" } }));
+        const qdrant = new Qdrant(baseUrl, undefined, { fetch: fetchMock });
+        const client = qdrant.createClient();
+
+        await qdrant.updateById({
+            client,
+            collectionName: "docs",
+            id: 1,
+            updatedContent: { content: "updated" },
+        });
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toContain("/points/payload?wait=true");
+        expect(JSON.parse(init.body)).toEqual({
+            payload: { content: "updated" },
+            points: [1],
+        });
+    });
+
+    test("deleteById deletes points", async () => {
+        const fetchMock = jest.fn().mockResolvedValue(mockResponse({ result: { status: "ok" } }));
+        const qdrant = new Qdrant(baseUrl, undefined, { fetch: fetchMock });
+        const client = qdrant.createClient();
+
+        await qdrant.deleteById({
+            client,
+            collectionName: "docs",
+            ids: [1, 2],
+        });
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toContain("/points/delete?wait=true");
+        expect(JSON.parse(init.body)).toEqual({ points: [1, 2] });
+    });
+
+    test("throws QdrantHttpError on failure", async () => {
+        const fetchMock = jest
+            .fn()
+            .mockResolvedValue(mockResponse({ status: { error: "boom" } }, false, 500));
+        const qdrant = new Qdrant(baseUrl, undefined, { fetch: fetchMock });
+        const client = qdrant.createClient();
+
+        await expect(
+            qdrant.getCollection({ client, collectionName: "docs" })
+        ).rejects.toBeInstanceOf(QdrantHttpError);
+    });
+});


### PR DESCRIPTION
@algora-pbc /claim #273
Fixes #273

## Summary
Adds Qdrant vector database support to the JavaScript/TypeScript SDK without using `@qdrant/*` packages (HTTP API only).

### `@arakoodev/edgechains.js/db`
- New `QdrantClient` analogous to `PostgresClient` for Hyde-style multi-embedding search
- Same constructor shape (embeddings, metric, topK, probes→`hnsw_ef`, table/collection, namespace, arkRequest, upperLimit)
- Namespace payload filter + RRF merge across multiple embeddings
- `PostgresClient` left unchanged

### `@arakoodev/edgechains.js/vector-db`
- New `Qdrant` class mirroring the existing `Supabase` method surface:
  `createClient`, `createCollection`, `insertVectorData`, `getDataFromQuery`, `getData`, `getDataById`, `updateById`, `deleteById`
- Native aliases: `upsert` / `search` / `scroll` / `retrieve` / `deletePoints`

### Tests
Mocked unit tests under:
- `src/db/src/tests/qdrant-client/`
- `src/vector-db/src/tests/qdrant/`

I have read the Arakoo CLA Document and I hereby sign the CLA.

## Demo video

Short Algora demo (~68s): new Qdrant files, Jest **12/12**, tsc clean.

- Video: https://github.com/robinthedev-a11y/EdgeChains/releases/download/demo-pr-657-qdrant/edgechains-657-demo.mp4
- Release: https://github.com/robinthedev-a11y/EdgeChains/releases/tag/demo-pr-657-qdrant

